### PR TITLE
Temporarily set dockerTag 0.3.0 to latest commit on release-v0.3 branch

### DIFF
--- a/versioned_docs/version-v0.3.x/_constants.mdx
+++ b/versioned_docs/version-v0.3.x/_constants.mdx
@@ -1,7 +1,7 @@
 [//]  # (This file stores the constants used across the documentation.)
 
 export const versions = {
-    dockerTag: 'v0.3.0',
+    dockerTag: '4be7287',
     // TODO: Update this to the latest release version after v0.3.1 is released.
     githubRef: 'release-v0.3', // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
     helmChart: '0.3.0',


### PR DESCRIPTION
## Purpose
Pointing the 0.3.0 dockerTag to the latest commit of the same release branch

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
