### PR TITLE
Change tool name from choreoctl to kubectl in quick start guide

### DIFF
--- a/docs/getting-started/quick-start-guide.mdx
+++ b/docs/getting-started/quick-start-guide.mdx
@@ -169,7 +169,7 @@ The installation process, by default, sets up several essential abstractions. Th
 - Deployment Pipeline for the environments
 - Project
 
-To access the artifacts created in OpenChoreo you can use choreoctl as shown in the following commands:
+To access the artifacts created in OpenChoreo you can use kubectl as shown in the following commands:
 
 You can check each resource type
 

--- a/versioned_docs/version-v0.3.x/getting-started/quick-start-guide.mdx
+++ b/versioned_docs/version-v0.3.x/getting-started/quick-start-guide.mdx
@@ -158,7 +158,7 @@ The installation process, by default, sets up several essential abstractions. Th
 - Deployment Pipeline for the environments
 - Project
 
-To access the artifacts created in OpenChoreo you can use choreoctl as shown in the following commands:
+To access the artifacts created in OpenChoreo you can use kubectl as shown in the following commands:
 
 You can check each resource type
 


### PR DESCRIPTION
## Purpose
The quick start guide said to use choreoctl to view resources. But it should be kubectl.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
