### PR TITLE
Update OpenSearch pod name in installation guide

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -280,7 +280,7 @@ kubectl get pods -n openchoreo-observability-plane --context kind-openchoreo-op
 ```
 
 You should see pods for:
-- `opensearch-0` (Running) - Log storage backend
+- `opensearch-master-0` (Running) - Log storage backend
 - `opensearch-dashboard-*` (Running) - Visualization dashboard
 - `observer-*` (Running) - Log processing service
 
@@ -341,10 +341,10 @@ Verify FluentBit is sending logs to OpenSearch:
 
 ```bash
 # Check if kubernetes indices are being created
-kubectl exec -n openchoreo-observability-plane opensearch-0 --context kind-openchoreo-op -- curl -s "http://localhost:9200/_cat/indices?v" | grep kubernetes
+kubectl exec -n openchoreo-observability-plane opensearch-master-0 --context kind-openchoreo-op -- curl -s "http://localhost:9200/_cat/indices?v" | grep kubernetes
 
 # Check recent log count
-kubectl exec -n openchoreo-observability-plane opensearch-0 --context kind-openchoreo-op -- curl -s "http://localhost:9200/kubernetes-*/_count" | jq '.count'
+kubectl exec -n openchoreo-observability-plane opensearch-master-0 --context kind-openchoreo-op -- curl -s "http://localhost:9200/kubernetes-*/_count" | jq '.count'
 ```
 
 If the indices exist and the count is greater than 0, FluentBit is successfully collecting and storing logs.

--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -219,7 +219,7 @@ kubectl get pods -n openchoreo-observability-plane
 ```
 
 You should see pods for:
-- `opensearch-0` (Running) - Log storage backend
+- `opensearch-master-0` (Running) - Log storage backend
 - `opensearch-dashboard-*` (Running) - Visualization dashboard
 - `observer-*` (Running) - Log processing service
 
@@ -237,10 +237,10 @@ Verify FluentBit is sending logs to OpenSearch:
 
 ```bash
 # Check if kubernetes indices are being created
-kubectl exec -n openchoreo-observability-plane opensearch-0 -- curl -s "http://localhost:9200/_cat/indices?v" | grep kubernetes
+kubectl exec -n openchoreo-observability-plane opensearch-master-0 -- curl -s "http://localhost:9200/_cat/indices?v" | grep kubernetes
 
 # Check recent log count
-kubectl exec -n openchoreo-observability-plane opensearch-0 -- curl -s "http://localhost:9200/kubernetes-*/_count" | jq '.count'
+kubectl exec -n openchoreo-observability-plane opensearch-master-0 -- curl -s "http://localhost:9200/kubernetes-*/_count" | jq '.count'
 ```
 
 If the indices exist and the count is greater than 0, FluentBit is successfully collecting and storing logs.


### PR DESCRIPTION
## Purpose
The pod name of OpenSearch has changed after we started using the OpenSearch Helm chart to deploy. Hence update the 
name in the installation guide accordingly

## Related Issues
https://github.com/openchoreo/openchoreo/issues/793

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
