### PR TITLE
Add observability  integration instruction to getting-started docs

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -274,6 +274,51 @@ Verify that all pods are ready:
 kubectl wait --for=condition=Ready pod --all -n openchoreo-observability-plane --timeout=600s --context k3d-openchoreo-op
 ```
 
+#### Configure Cross-Cluster Observability
+
+Configure the build plane and data plane to send logs to the observability plane. The host and port should be accessible from the data/build plane clusters:
+
+<CodeBlock language="bash">
+    {`# Configure Build Plane FluentBit
+helm upgrade build-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-build-plane \\
+  --version ${versions.helmChart} \\
+  --namespace openchoreo-build-plane \\
+  --set fluentBit.config.opensearch.host="openchoreo-op-control-plane" \\
+  --set fluentBit.config.opensearch.port=30920 \\
+  --kube-context kind-openchoreo-bp \\
+  --set fluentBit.enabled=true \\
+  --set global.defaultResources.registry.local.pushEndpoint="openchoreo-dp-control-plane:30003" \\
+  --set global.defaultResources.registry.local.pullEndpoint="localhost:30003"`}
+</CodeBlock>
+
+<CodeBlock language="bash">
+    {`# Configure Data Plane FluentBit
+helm upgrade data-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-plane \\
+  --version ${versions.helmChart} \\
+  --namespace openchoreo-data-plane \\
+  --set fluentBit.config.opensearch.host="openchoreo-op-control-plane" \\
+  --set fluentBit.config.opensearch.port=30920 \\
+  --set cert-manager.enabled=false \\
+  --set cert-manager.crds.enabled=false \\
+  --kube-context kind-openchoreo-dp`}
+</CodeBlock>
+
+**Important Security Note**: The observability plane collects data from outside clusters without encryption in this setup. For production environments, we recommend implementing proper TLS encryption and network security measures.
+
+After updating the FluentBit configuration, restart the FluentBit pods to apply the new settings:
+
+```bash
+# Restart FluentBit pods in Build Plane
+kubectl rollout restart daemonset/fluent-bit -n openchoreo-build-plane --context kind-openchoreo-bp
+
+# Restart FluentBit pods in Data Plane
+kubectl rollout restart daemonset/fluent-bit -n openchoreo-data-plane --context kind-openchoreo-dp
+
+# Verify FluentBit pods are running
+kubectl get pods -n openchoreo-build-plane --context kind-openchoreo-bp | grep fluent
+kubectl get pods -n openchoreo-data-plane --context kind-openchoreo-dp | grep fluent
+```
+
 Verify FluentBit is sending logs to OpenSearch:
 
 ```bash
@@ -285,6 +330,49 @@ kubectl exec -n openchoreo-observability-plane opensearch-master-0 --context k3d
 ```
 
 If the indices exist and the count is greater than 0, FluentBit is successfully collecting and storing logs.
+
+#### Configure Observer Integration
+
+Configure the DataPlane and BuildPlane to use the observer service. For multi-cluster setup, we need to expose the observer service via NodePort for cross-cluster communication.
+
+First, expose the observer service with a NodePort:
+
+```bash
+# Patch the observer service to use NodePort
+kubectl patch svc observer -n openchoreo-observability-plane --type='json' \
+  -p='[{"op": "replace", "path": "/spec/type", "value": "NodePort"}, {"op": "add", "path": "/spec/ports/0/nodePort", "value": 30880}]' \
+  --context kind-openchoreo-op
+```
+
+Then configure the DataPlane and BuildPlane to use the observer service via NodePort:
+
+```bash
+# Configure DataPlane to use observer service via NodePort
+kubectl patch dataplane default -n default --type merge \
+  -p '{"spec":{"observer":{"url":"http://openchoreo-op-control-plane:30880","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}' \
+  --context kind-openchoreo-cp
+
+# Configure BuildPlane to use observer service via NodePort
+kubectl patch buildplane default -n default --type merge \
+  -p '{"spec":{"observer":{"url":"http://openchoreo-op-control-plane:30880","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}' \
+  --context kind-openchoreo-cp
+```
+
+This configuration enables:
+- Application logs to appear in Backstage portal
+- Enhanced logging and monitoring across build and data planes
+- Integration with the observability plane for comprehensive platform monitoring
+- Centralized log publishing and access through the observer service
+
+Verify the observer configuration:
+
+```bash
+# Check DataPlane observer config
+kubectl get dataplane default -n default -o jsonpath='{.spec.observer}' --context kind-openchoreo-cp | jq '.'
+
+# Check BuildPlane observer config
+kubectl get buildplane default -n default -o jsonpath='{.spec.observer}' --context kind-openchoreo-cp | jq '.'
+```
 
 ## Verification
 

--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -50,7 +50,7 @@ If you're using **Colima**, set the `K3D_FIX_DNS=0` environment variable when cr
 
 ## Quick Setup
 
-This setup uses pre-built images and Helm charts from the OpenChoreo registry. 
+This setup uses pre-built images and Helm charts from the OpenChoreo registry.
 
 
 ### 1. Create OpenChoreo k3d Cluster
@@ -236,6 +236,34 @@ kubectl exec -n openchoreo-observability-plane opensearch-master-0 -- curl -s "h
 
 If the indices exist and the count is greater than 0, FluentBit is successfully collecting and storing logs.
 
+#### Configure Observer Integration
+Configure the DataPlane and BuildPlane to use the observer service.
+
+```bash
+# Configure DataPlane to use observer service
+kubectl patch dataplane default -n default --type merge -p '{"spec":{"observer":{"url":"http://observer.openchoreo-observability-plane:8080","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}'
+
+# Configure BuildPlane to use observer service
+kubectl patch buildplane default -n default --type merge -p '{"spec":{"observer":{"url":"http://observer.openchoreo-observability-plane:8080","authentication":{"basicAuth":{"username":"dummy","password":"dummy"}}}}}'
+```
+
+**Important**: Without this configuration, build logs will not be pushed to the observability plane and application logs will not be visible in the Backstage portal, significantly impacting the developer experience.
+
+This configuration enables:
+- Application logs to appear in Backstage portal
+- Enhanced logging and monitoring across build and data planes
+- Integration with the observability plane for comprehensive platform monitoring
+- Centralized log publishing and access through the observer service
+
+Verify the observer configuration:
+
+```bash
+# Check DataPlane observer config
+kubectl get dataplane default -n default -o jsonpath='{.spec.observer}' | jq '.'
+
+# Check BuildPlane observer config
+kubectl get buildplane default -n default -o jsonpath='{.spec.observer}' | jq '.'
+```
 ### 7. Verify OpenChoreo Installation
 
 #### Check that default OpenChoreo resources were created:


### PR DESCRIPTION
## Purpose
Add instruction to single-cluster and multi-cluster getting started docs explaining how to integrate the observability plane with dataplane and buildplane to view logs in backstage portal.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
