### PR TITLE
Update docs related to Kgateway for dataplane

### DIFF
--- a/docs/concepts/runtime-model.md
+++ b/docs/concepts/runtime-model.md
@@ -81,8 +81,8 @@ OpenChoreo manages network security through the cell architecture and gateway pa
 allowed between components of the same project, while all cross-cell communication must flow through the defined 
 gateways. This provides security boundaries between different application domains.
 
-The platform uses Cilium for network policy enforcement and Envoy Gateway for ingress traffic management. Developers 
-declare their components' endpoints and connections in the workload specification, and the platform handles the 
+The platform uses Cilium for network policy enforcement and Kgateway for ingress traffic management. Developers
+declare their components' endpoints and connections in the workload specification, and the platform handles the
 underlying network configuration.
 
 ## Workload Execution

--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -135,10 +135,11 @@ kubectl get pods -n openchoreo-data-plane --context=k3d-openchoreo-dp
 ```
 
 You should see pods for:
-- `envoy-gateway-*` (Running)
+
+- `openchoreo-data-plane-gateway-*` (Running)
 - `external-secrets-*` (3 pods, all Running)
 - `fluent-bit-*` (Running on each node)
-- `gateway-external-*` (Running)
+- `gateway-default-*` (Running)
 
 #### Configure DataPlane
 

--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -127,11 +127,11 @@ kubectl get pods -n openchoreo-data-plane
 ```
 
 You should see pods for:
-- `envoy-gateway-*` (Running)
 - `cluster-agent-*` (Running) - Agent for secure control plane communication
+- `openchoreo-data-plane-gateway-*` (Running)
 - `external-secrets-*` (3 pods, all Running)
 - `fluent-bit-*` (Running on each node)
-- `gateway-external-*` (Running)
+- `gateway-default-*` (Running)
 
 #### Configure DataPlane
 

--- a/docs/overview/what-is-openchoreo.mdx
+++ b/docs/overview/what-is-openchoreo.mdx
@@ -34,7 +34,7 @@ OpenChoreo is made up of several key components that work together to deliver a 
 - **Control Plane** - The orchestration layer that watches developer and platform APIs, validates configurations and translates them into Kubernetes-native and cloud-native infrastructure.
 - **Developer API** - Simplified, self-service interfaces for developers to model, deploy and manage the full SDLC of cloud-native applications, without needing to understand platform internals. 
 - **Platform API** - Declarative interfaces used by platform engineers to configure and manage the OpenChoreo installation.  
-- **Data Plane** - The execution environment for applications that is built on Kubernetes and extended with Cilium, Envoy Gateway, and other CNCF tools. The Data Plane is where runtime semantics are enforced.
+- **Data Plane** - The execution environment for applications that is built on Kubernetes and extended with Cilium, Kgateway, and other CNCF tools. The Data Plane is where runtime semantics are enforced.
 - **CI Plane** - A built-in CI engine powered by Argo Workflows. It builds the container images, runs tests and publishes artifacts. It is an optional plane. 
 - **Observability Plane** - Out-of-the-box visibility with logs, metrics and traces, using tools like Prometheus, Fluent Bit and OpenSearch. 
 


### PR DESCRIPTION
## Purpose
> This PR updates the docs related to the replacement of the Envoy Gateway with Kgateway for dataplane ingress.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/640

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
