### PR TITLE
Add instructions to install OpenSearch K8s operator and enable tracing in multi cluster setup

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -242,14 +242,26 @@ This will:
 
 #### Install OpenChoreo Observability Plane
 
-Install the OpenChoreo observability plane using Helm. This will create the `openchoreo-observability-plane` namespace automatically:
+#### Prerequisites
+Install the [OpenSearch Kubernetes operator](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/) as follows. This will create the `openchoreo-observability-plane` namespace automatically:
+
+<CodeBlock language="bash">
+{`helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
+helm repo update
+helm install opensearch-operator opensearch-operator/opensearch-operator \\ 
+  --create-namespace \\
+  --namespace openchoreo-observability-plane \\
+  --version 2.8.0`}
+</CodeBlock>
+
+
+Install the OpenChoreo observability plane using Helm. 
 
 <CodeBlock language="bash">
     {`helm install openchoreo-observability-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \\
   --version ${versions.helmChart} \\
   --kube-context k3d-openchoreo-op \\
   --namespace openchoreo-observability-plane \\
-  --create-namespace \\
   --values https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/multi-cluster/values-op.yaml`}
 </CodeBlock>
 
@@ -301,6 +313,8 @@ helm upgrade data-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-pla
   --set fluentBit.config.opensearch.port=30920 \\
   --set cert-manager.enabled=false \\
   --set cert-manager.crds.enabled=false \\
+  --set observability.observabilityPlaneUrl="openchoreo-op-control-plane" \\
+  --set opentelemetry-collector.enabled=true \\
   --kube-context kind-openchoreo-dp`}
 </CodeBlock>
 

--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -192,14 +192,25 @@ kubectl get buildplane -n default
 
 ### 5. Install OpenChoreo Observability Plane (Optional)
 
-Install the OpenChoreo observability plane using the following helm install command for monitoring and logging capabilities. This will create the `openchoreo-observability-plane` namespace automatically:
+#### Prerequisites
+Install the [OpenSearch Kubernetes operator](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/) as follows. This will create the `openchoreo-observability-plane` namespace automatically:
+
+<CodeBlock language="bash">
+{`helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
+helm repo update
+helm install opensearch-operator opensearch-operator/opensearch-operator \\ 
+  --create-namespace \\
+  --namespace openchoreo-observability-plane \\
+  --version 2.8.0`}
+</CodeBlock>
+
+Install the OpenChoreo observability plane using the following helm install command for monitoring and logging capabilities. 
 
 <CodeBlock language="bash">
 {`helm install openchoreo-observability-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \\
   --version ${versions.helmChart} \\
   --kube-context k3d-openchoreo \\
   --namespace openchoreo-observability-plane \\
-  --create-namespace \\
   --values https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/single-cluster/values-op.yaml`}
 </CodeBlock>
 


### PR DESCRIPTION
## Purpose
The OpenSearch Kubernetes operator is required for single cluster and multi cluster setups. This adds it as a prerequisite. Also updates the command in multi cluster deployment to enable tracing

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1050

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
