### PR TITLE
Update dataplane cr definition to support cluster agent access

### DIFF
--- a/docs/reference/api/platform/dataplane.md
+++ b/docs/reference/api/platform/dataplane.md
@@ -4,8 +4,11 @@ title: DataPlane API Reference
 
 # DataPlane
 
-A DataPlane represents a Kubernetes cluster where application workloads are deployed. It defines the connection to a
-target Kubernetes cluster, container registry configuration, and gateway settings for routing traffic to applications.
+A DataPlane represents a Kubernetes cluster where application workloads are deployed. It defines the connection to a target Kubernetes cluster and gateway settings for routing traffic to applications.
+
+OpenChoreo supports two modes of communication with the DataPlane:
+- **Agent-based** (Recommended): The control plane communicates with the downstream cluster through a WebSocket agent running in the DataPlane cluster
+- **Direct Kubernetes API access**: The control plane connects directly to the Kubernetes API server using client certificates or bearer tokens
 
 ## API Version
 
@@ -27,31 +30,90 @@ metadata:
 
 ### Spec Fields
 
-| Field               | Type                                            | Required | Default | Description                                         |
-|---------------------|-------------------------------------------------|----------|---------|-----------------------------------------------------|
-| `kubernetesCluster` | [KubernetesClusterSpec](#kubernetesclusterspec) | Yes      | -       | Target Kubernetes cluster configuration             |
-| `registry`          | [Registry](#registry)                           | Yes      | -       | Container registry configuration for pulling images |
-| `gateway`           | [GatewaySpec](#gatewayspec)                     | Yes      | -       | API gateway configuration for this DataPlane        |
-| `observer`          | [ObserverAPI](#observerapi)                     | No       | -       | Observer API integration for monitoring and logging |
+| Field                 | Type                                            | Required | Default | Description                                                                    |
+|-----------------------|-------------------------------------------------|----------|---------|--------------------------------------------------------------------------------|
+| `gateway`             | [GatewaySpec](#gatewayspec)                     | Yes      | -       | API gateway configuration for this DataPlane                                   |
+| `agent`               | [AgentConfig](#agentconfig)                     | No       | -       | Agent-based communication configuration (recommended)                          |
+| `kubernetesCluster`   | [KubernetesClusterSpec](#kubernetesclusterspec) | No       | -       | Target Kubernetes cluster configuration (optional when agent is enabled) |
+| `imagePullSecretRefs` | []string                                        | No       | -       | References to SecretReference resources for image pull secrets                 |
+| `secretStoreRef`      | [SecretStoreRef](#secretstoreref)               | No       | -       | Reference to External Secrets Operator ClusterSecretStore in the DataPlane    |
+| `observer`            | [ObserverAPI](#observerapi)                     | No       | -       | Observer API integration for monitoring and logging                            |
+
+### AgentConfig
+
+Configuration for agent-based communication with the downstream cluster.
+
+| Field      | Type                      | Required | Default | Description                                                                  |
+|------------|---------------------------|----------|---------|------------------------------------------------------------------------------|
+| `enabled`  | boolean                   | No       | false   | Whether agent-based communication is enabled                                 |
+| `clientCA` | [ValueFrom](#valuefrom)   | No       | -       | CA certificate to verify the agent's client certificate (base64-encoded PEM) |
 
 ### KubernetesClusterSpec
 
-| Field                      | Type   | Required | Default | Description                       |
-|----------------------------|--------|----------|---------|-----------------------------------|
-| `name`                     | string | Yes      | -       | Name of the Kubernetes cluster    |
-| `credentials.apiServerURL` | string | Yes      | -       | URL of the Kubernetes API server  |
-| `credentials.caCert`       | string | Yes      | -       | Base64-encoded CA certificate     |
-| `credentials.clientCert`   | string | Yes      | -       | Base64-encoded client certificate |
-| `credentials.clientKey`    | string | Yes      | -       | Base64-encoded client private key |
+Configuration for the target Kubernetes cluster. Optional when `agent.enabled` is true.
 
-### Registry
+| Field    | Type                              | Required | Default | Description                                    |
+|----------|-----------------------------------|----------|---------|------------------------------------------------|
+| `server` | string                            | Yes      | -       | URL of the Kubernetes API server               |
+| `tls`    | [KubernetesTLS](#kubernetestls)   | Yes      | -       | TLS configuration for the connection           |
+| `auth`   | [KubernetesAuth](#kubernetesauth) | Yes      | -       | Authentication configuration                   |
 
-| Field       | Type   | Required | Default | Description                                               |
-|-------------|--------|----------|---------|-----------------------------------------------------------|
-| `prefix`    | string | Yes      | -       | Registry domain and namespace (e.g., docker.io/namespace) |
-| `secretRef` | string | No       | ""      | Name of Kubernetes Secret with registry credentials       |
+### KubernetesTLS
+
+TLS configuration for the Kubernetes connection.
+
+| Field | Type                    | Required | Default | Description                |
+|-------|-------------------------|----------|---------|----------------------------|
+| `ca`  | [ValueFrom](#valuefrom) | Yes      | -       | CA certificate             |
+
+### KubernetesAuth
+
+Authentication configuration for the Kubernetes cluster. Either `mtls` or `bearerToken` must be specified.
+
+| Field         | Type                      | Required | Default | Description                                   |
+|---------------|---------------------------|----------|---------|-----------------------------------------------|
+| `mtls`        | [MTLSAuth](#mtlsauth)     | No       | -       | Certificate-based authentication (mTLS)       |
+| `bearerToken` | [ValueFrom](#valuefrom)   | No       | -       | Bearer token authentication                   |
+
+### MTLSAuth
+
+Certificate-based authentication (mTLS) configuration.
+
+| Field        | Type                    | Required | Default | Description            |
+|--------------|-------------------------|----------|---------|------------------------|
+| `clientCert` | [ValueFrom](#valuefrom) | Yes      | -       | Client certificate     |
+| `clientKey`  | [ValueFrom](#valuefrom) | Yes      | -       | Client private key     |
+
+### ValueFrom
+
+Common pattern for referencing secrets or providing inline values. Either `secretRef` or `value` should be specified.
+
+| Field       | Type                                        | Required | Default | Description                       |
+|-------------|---------------------------------------------|----------|---------|-----------------------------------|
+| `secretRef` | [SecretKeyReference](#secretkeyreference)   | No       | -       | Reference to a secret key         |
+| `value`     | string                                      | No       | -       | Inline value (not recommended for sensitive data) |
+
+### SecretKeyReference
+
+Reference to a specific key in a Kubernetes secret.
+
+| Field       | Type   | Required | Default                   | Description                                                  |
+|-------------|--------|----------|---------------------------|--------------------------------------------------------------|
+| `name`      | string | Yes      | -                         | Name of the secret                                           |
+| `namespace` | string | No       | Same as parent resource   | Namespace of the secret                                      |
+| `key`       | string | Yes      | -                         | Key within the secret                                        |
+
+### SecretStoreRef
+
+Reference to an External Secrets Operator ClusterSecretStore.
+
+| Field  | Type   | Required | Default | Description                                       |
+|--------|--------|----------|---------|---------------------------------------------------|
+| `name` | string | Yes      | -       | Name of the ClusterSecretStore in the DataPlane   |
 
 ### GatewaySpec
+
+Gateway configuration for the DataPlane.
 
 | Field                     | Type   | Required | Default | Description                                             |
 |---------------------------|--------|----------|---------|---------------------------------------------------------|
@@ -59,6 +121,8 @@ metadata:
 | `organizationVirtualHost` | string | Yes      | -       | Organization-specific virtual host for internal traffic |
 
 ### ObserverAPI
+
+Configuration for Observer API integration.
 
 | Field                               | Type   | Required | Default | Description                       |
 |-------------------------------------|--------|----------|---------|-----------------------------------|
@@ -83,34 +147,154 @@ Common condition types for DataPlane resources:
 
 ## Examples
 
-### Basic DataPlane
+### Agent-based DataPlane
+
+This example shows a DataPlane using agent-based communication. The control plane communicates with the downstream cluster through a WebSocket agent.
 
 ```yaml
 apiVersion: openchoreo.dev/v1alpha1
 kind: DataPlane
 metadata:
-  name: production-dataplane
-  namespace: default
+  name: agent-dataplane
+  namespace: my-org
 spec:
-  kubernetesCluster:
-    name: production-cluster
-    credentials:
-      apiServerURL: https://k8s-api.example.com:6443
-      caCert: LS0tLS1CRUdJTi... # Base64-encoded CA cert
-      clientCert: LS0tLS1CRUdJTi... # Base64-encoded client cert
-      clientKey: LS0tLS1CRUdJTi... # Base64-encoded client key
-  registry:
-    prefix: docker.io/myorg
-    secretRef: registry-credentials
+  # Agent configuration
+  agent:
+    enabled: true
+    clientCA:
+      secretRef:
+        name: cluster-agent-ca
+        key: ca.crt
+
+  # Gateway configuration
   gateway:
     publicVirtualHost: api.example.com
     organizationVirtualHost: internal.example.com
+
+  # External Secrets Operator integration
+  secretStoreRef:
+    name: vault-backend
+
+  # Image pull secret references
+  imagePullSecretRefs:
+    - docker-registry-credentials
+
+  # Observer API (optional)
   observer:
     url: https://observer.example.com
     authentication:
       basicAuth:
         username: admin
         password: secretpassword
+```
+
+### Direct Kubernetes API Access DataPlane
+
+This example shows a DataPlane using direct Kubernetes API access with mTLS authentication.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: DataPlane
+metadata:
+  name: production-dataplane
+  namespace: my-org
+spec:
+  # Direct Kubernetes cluster access
+  kubernetesCluster:
+    server: https://k8s-api.example.com:6443
+    tls:
+      ca:
+        secretRef:
+          name: k8s-ca-cert
+          key: ca.crt
+    auth:
+      mtls:
+        clientCert:
+          secretRef:
+            name: k8s-client-cert
+            key: tls.crt
+        clientKey:
+          secretRef:
+            name: k8s-client-cert
+            key: tls.key
+
+  # Gateway configuration
+  gateway:
+    publicVirtualHost: api.example.com
+    organizationVirtualHost: internal.example.com
+
+  # Observer API (optional)
+  observer:
+    url: https://observer.example.com
+    authentication:
+      basicAuth:
+        username: admin
+        password: secretpassword
+```
+
+### DataPlane with Bearer Token Authentication
+
+This example shows a DataPlane using bearer token authentication instead of mTLS.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: DataPlane
+metadata:
+  name: dev-dataplane
+  namespace: my-org
+spec:
+  kubernetesCluster:
+    server: https://k8s-dev.example.com:6443
+    tls:
+      ca:
+        secretRef:
+          name: k8s-ca-cert
+          key: ca.crt
+    auth:
+      bearerToken:
+        secretRef:
+          name: k8s-token
+          key: token
+
+  gateway:
+    publicVirtualHost: dev-api.example.com
+    organizationVirtualHost: dev-internal.example.com
+```
+
+### DataPlane with External Secrets Integration
+
+This example demonstrates using External Secrets Operator for managing secrets and image pull credentials.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: DataPlane
+metadata:
+  name: secure-dataplane
+  namespace: my-org
+spec:
+  # Agent-based communication
+  agent:
+    enabled: true
+    clientCA:
+      secretRef:
+        name: agent-ca-cert
+        namespace: openchoreo-system
+        key: ca.crt
+
+  # External Secrets Operator ClusterSecretStore reference
+  secretStoreRef:
+    name: vault-backend
+
+  # References to SecretReference resources
+  # These will be converted to ExternalSecrets and added as imagePullSecrets
+  imagePullSecretRefs:
+    - docker-hub-credentials
+    - gcr-credentials
+    - private-registry-credentials
+
+  gateway:
+    publicVirtualHost: secure-api.example.com
+    organizationVirtualHost: secure-internal.example.com
 ```
 
 ## Annotations


### PR DESCRIPTION
## Purpose
This pull request updates the DataPlane API documentation to clarify communication modes, deprecate direct Kubernetes API access, and improve configuration examples. The changes emphasize agent-based communication as the recommended approach and introduce new configuration fields for secrets and external integrations. Deprecated fields and modes are clearly marked, and examples have been expanded for better guidance.

**Communication Modes and Deprecation Notices**
* Added detailed explanation of agent-based (recommended) and direct Kubernetes API access (deprecated) communication modes in the DataPlane overview, including a prominent deprecation warning for direct API access.

**Spec Field Updates and New Configurations**
* Updated the DataPlane spec fields: removed the `registry` field, added `agent`, `imagePullSecretRefs`, and `secretStoreRef` fields, and marked `kubernetesCluster` as deprecated and optional when agent-based communication is enabled. Provided new configuration sections for agent-based communication and secret management.

**Examples and Usage Patterns**
* Replaced and expanded examples to show agent-based DataPlane configuration, deprecated direct Kubernetes API access (with both mTLS and bearer token authentication), and integration with External Secrets Operator for secret management and image pull credentials. [[1]](diffhunk://#diff-573d24f59f283625e18138a6a6eede3b9521414a1fdad6f776ba39cec18bb6b2L86-R250) [[2]](diffhunk://#diff-573d24f59f283625e18138a6a6eede3b9521414a1fdad6f776ba39cec18bb6b2R259-R327)

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
