### PR TITLE
Update single cluster setup with agent support

### DIFF
--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -104,6 +104,7 @@ kubectl get pods -n openchoreo-control-plane
 
 You should see pods for:
 - `controller-manager` (Running)
+- `cluster-gateway-*` (Running) - Gateway for agent-based data plane communication
 - `cert-manager-*` (3 pods, all Running)
 
 ### 3. Install OpenChoreo Data Plane
@@ -127,6 +128,7 @@ kubectl get pods -n openchoreo-data-plane
 
 You should see pods for:
 - `envoy-gateway-*` (Running)
+- `cluster-agent-*` (Running) - Agent for secure control plane communication
 - `external-secrets-*` (3 pods, all Running)
 - `fluent-bit-*` (Running on each node)
 - `gateway-external-*` (Running)
@@ -136,16 +138,25 @@ You should see pods for:
 Register the data plane with the control plane by running:
 
 <CodeBlock language="bash">
-{`curl -s https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/add-data-plane.sh | bash -s -- --control-plane-context k3d-openchoreo`}
+{`curl -s https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/add-data-plane.sh | bash -s -- --control-plane-context k3d-openchoreo --enable-agent --agent-ca-namespace openchoreo-control-plane`}
 </CodeBlock>
 
-This script creates a DataPlane resource in the default namespace.
+This script creates a DataPlane resource in the default namespace with agent-based communication enabled. The agent provides secure WebSocket-based connectivity between the control plane and data plane without requiring direct Kubernetes API access.
 
-Verify the DataPlane was created:
+Verify the DataPlane was created and check its status:
 
 ```bash
+# Check DataPlane resource
 kubectl get dataplane -n default
+
+# Verify agent mode is enabled
+kubectl get dataplane default -n default -o jsonpath='{.spec.agent.enabled}'
+
+# Check DataPlane status
+kubectl get dataplane default -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq '.'
 ```
+
+The agent.enabled field should show `true`, and the Ready condition should have status `True` once the agent successfully connects to the control plane.
 
 ### 4. Install OpenChoreo Build Plane (Optional)
 


### PR DESCRIPTION
## Purpose
This pull request updates the single-cluster getting started guide to clarify the roles of agent-based communication between the control plane and data plane, and provides improved instructions for enabling, verifying, and understanding agent mode. The changes make it easier for users to set up secure connectivity and confirm the correct operation of the data plane agent.

**Documentation improvements for agent-based communication:**

* Added descriptions for `cluster-gateway-*` and `cluster-agent-*` pods to clarify their roles in agent-based communication between the control and data planes. [[1]](diffhunk://#diff-c999a900436d904341a97590648e7ffd3f86549aad71e84215b36f590fedb104R106) [[2]](diffhunk://#diff-c999a900436d904341a97590648e7ffd3f86549aad71e84215b36f590fedb104R130)
* Updated the data plane registration command to include `--enable-agent` and `--agent-ca-namespace`, enabling agent-based communication and specifying the CA namespace.
* Enhanced the explanation of the DataPlane resource to describe agent-based communication and its benefits for secure WebSocket connectivity.
* Added detailed verification steps for checking agent mode status and DataPlane readiness, including commands to inspect the `agent.enabled` field and `Ready` condition.


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
