### PR TITLE
Update the command used to install the Observability plane without HA

### DIFF
--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -213,7 +213,6 @@ By default, the OpenChoreo Observability Plane deploys OpenSearch in a highly av
   --kube-context k3d-openchoreo \\
   --namespace openchoreo-observability-plane \\
   --values https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/single-cluster/values-op.yaml \\
-  --set global.installationMode=singleClusterNoHa \\
   --set openSearch.enabled=true \\ 
   --set openSearchCluster.enabled=false`}
 </CodeBlock>

--- a/versioned_docs/version-v0.6.x/getting-started/single-cluster.mdx
+++ b/versioned_docs/version-v0.6.x/getting-started/single-cluster.mdx
@@ -213,7 +213,6 @@ By default, the OpenChoreo Observability Plane deploys OpenSearch in a highly av
   --kube-context k3d-openchoreo \\
   --namespace openchoreo-observability-plane \\
   --values https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/single-cluster/values-op.yaml \\
-  --set global.installationMode=singleClusterNoHa \\
   --set openSearch.enabled=true \\ 
   --set openSearchCluster.enabled=false`}
 </CodeBlock>


### PR DESCRIPTION
## Purpose
`installationMode=singleClusterNoHa` is no longer required to deploy OpenSearch without High Availability in the Observability plane

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1127

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
