### PR TITLE
Remove dataplane and buildplane status check which is no valid

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -245,9 +245,6 @@ kubectl get dataplane -n default --context k3d-openchoreo-cp
 
 # Verify agent mode is enabled
 kubectl get dataplane default -n default --context k3d-openchoreo-cp -o jsonpath='{.spec.agent.enabled}'
-
-# Check agent connection status
-kubectl get dataplane default -n default --context k3d-openchoreo-cp -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
 ```
 
 The `agent.enabled` field should show `true`, and the Ready condition should have status `True` once the agent successfully connects to the control plane.
@@ -358,9 +355,6 @@ kubectl get buildplane -n default --context k3d-openchoreo-cp
 
 # Verify agent mode is enabled
 kubectl get buildplane default -n default --context k3d-openchoreo-cp -o jsonpath='{.spec.agent.enabled}'
-
-# Check agent connection status
-kubectl get buildplane default -n default --context k3d-openchoreo-cp -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
 ```
 
 The `agent.enabled` field should show `true`, and the Ready condition should have status `True` once the agent successfully connects to the control plane.

--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -509,9 +509,6 @@ kubectl get dataplane -n default
 
 # Verify agent mode is enabled
 kubectl get dataplane default -n default -o jsonpath='{.spec.agent.enabled}'
-
-# Check DataPlane status
-kubectl get dataplane default -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq '.'
 ```
 
 The `agent.enabled` field should show `true`, and the Ready condition should have status `True` once the agent successfully connects to the control plane.
@@ -685,7 +682,7 @@ kubectl get pods -n openchoreo-data-plane
 # Expected: cluster-agent-*, kgateway-*, external-secrets-*, fluent-bit-* pods
 
 kubectl get dataplane -A
-# Expected: default dataplane in Ready state
+# Expected: default dataplane exists
 ```
 
 ---
@@ -721,9 +718,6 @@ kubectl get buildplane -n default
 
 # Verify agent mode is enabled
 kubectl get buildplane default -n default -o jsonpath='{.spec.agent.enabled}'
-
-# Check BuildPlane status
-kubectl get buildplane default -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq '.'
 ```
 
 The `agent.enabled` field should show `true`, and the Ready condition should have status `True` once the agent successfully connects to the control plane.


### PR DESCRIPTION
## Purpose

This pull request updates the documentation for both single-cluster and multi-cluster setup guides, simplifying the verification steps for agent mode and dataplane/buildplane status. The main change is the removal of commands that check the Ready status condition directly, leaving only the agent mode verification and updating expected output descriptions.

**Documentation simplification:**

* Removed the command to check the Ready status condition for `dataplane` in both multi-cluster (`docs/getting-started/multi-cluster.mdx`) and single-cluster (`docs/getting-started/single-cluster.mdx`) guides, focusing only on verifying if agent mode is enabled. [[1]](diffhunk://#diff-5c5917518c25fd51ce3eea9e6402cb27d8cfa96237170f84fd0c3c95479beec6L248-L250) [[2]](diffhunk://#diff-c999a900436d904341a97590648e7ffd3f86549aad71e84215b36f590fedb104L512-L514)
* Removed the command to check the Ready status condition for `buildplane` in both multi-cluster and single-cluster guides, again focusing on agent mode verification. [[1]](diffhunk://#diff-5c5917518c25fd51ce3eea9e6402cb27d8cfa96237170f84fd0c3c95479beec6L361-L363) [[2]](diffhunk://#diff-c999a900436d904341a97590648e7ffd3f86549aad71e84215b36f590fedb104L724-L726)

**Clarity improvements:**

* Updated the expected output description for the `kubectl get dataplane -A` command in the single-cluster guide to clarify that the existence of the default dataplane is expected, not specifically its Ready state.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
