### PR TITLE
Use formal grammar in multi-cluster setup comments

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -252,7 +252,7 @@ The `agent.enabled` field should show `true`, and the Ready condition should hav
 **Optional: View the Data Plane's CA certificate** (used for agent authentication):
 
 ```bash
-# Note: Use --context to specify the data plane cluster since it's in a different cluster
+# Note: Use --context to specify the data plane cluster since it is in a different cluster
 kubectl --context k3d-openchoreo-dp get secret cluster-agent-tls \
   -n openchoreo-data-plane \
   -o jsonpath='{.data.ca\.crt}' | base64 -d
@@ -362,7 +362,7 @@ The `agent.enabled` field should show `true`, and the Ready condition should hav
 **Optional: View the Build Plane's CA certificate** (used for agent authentication):
 
 ```bash
-# Note: Use --context to specify the build plane cluster since it's in a different cluster
+# Note: Use --context to specify the build plane cluster since it is in a different cluster
 kubectl --context k3d-openchoreo-bp get secret cluster-agent-tls \
   -n openchoreo-build-plane \
   -o jsonpath='{.data.ca\.crt}' | base64 -d


### PR DESCRIPTION
## Purpose

This pull request makes minor documentation improvements to clarify instructions in the multi-cluster setup guide. The changes update comments to use more precise language when referring to different clusters.

This has created some issues when running the command

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
