### PR TITLE
Fix Helm install line continuation typo

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -397,7 +397,7 @@ Install the [OpenSearch Kubernetes operator](https://docs.opensearch.org/latest/
 <CodeBlock language="bash">
 {`helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 helm repo update
-helm install opensearch-operator opensearch-operator/opensearch-operator \\ 
+helm install opensearch-operator opensearch-operator/opensearch-operator \\
   --create-namespace \\
   --namespace openchoreo-observability-plane \\
   --version 2.8.0`}


### PR DESCRIPTION
## Purpose
Fixes error when running the helm install

```
chathuranga@chathurangada ocrelease % helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
helm repo update
helm install opensearch-operator opensearch-operator/opensearch-operator \
--create-namespace \
--namespace openchoreo-observability-plane \
--version 2.8.0
"opensearch-operator" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "opensearch-operator" chart repository
...Successfully got an update from the "cilium" chart repository
...Successfully got an update from the "opentelemetry" chart repository
...Successfully got an update from the "external-secrets" chart repository
Update Complete. ⎈Happy Helming!⎈
Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments:  
zsh: command not found: --create-namespace
chathuranga@chathurangada ocrelease %
```

> The backslash had a trailing space (\ ), so the newline wasn’t escaped. Helm saw an extra blank argument and stopped with “expected at most two arguments,” and zsh tried to run --create-namespace as a separate command.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
