### PR TITLE
Replace the github stars button with star the repo button.

### DIFF
--- a/src/components/common/GitHubStarButton/index.tsx
+++ b/src/components/common/GitHubStarButton/index.tsx
@@ -4,6 +4,40 @@ import styles from './styles.module.css';
 const GITHUB_API_URL = 'https://api.github.com/repos/openchoreo/openchoreo';
 const GITHUB_REPO_URL = 'https://github.com/openchoreo/openchoreo';
 
+/**
+ * GitHubStarButton Component
+ * Simple "Star us on GitHub" button with OpenChoreo branding
+ */
+function GitHubStarButton(): JSX.Element {
+  return (
+    <div className={styles.starButtonContainer}>
+      <a
+        href={GITHUB_REPO_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.starLink}
+        aria-label="Star OpenChoreo on GitHub"
+      >
+        <svg
+          aria-hidden="true"
+          height="20"
+          viewBox="0 0 16 16"
+          width="20"
+          className={styles.starIcon}
+        >
+          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.31a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+        </svg>
+        Star us on GitHub
+      </a>
+    </div>
+  );
+}
+
+// ============================================
+// COMMENTED OUT: Original star counter code
+// Keeping this for potential future reuse
+// ============================================
+/*
 const formatStarCount = (count: number): string => {
   if (count === 0) return '—';
   return count.toLocaleString('en-US');
@@ -48,6 +82,7 @@ function GitHubStarButton(): JSX.Element {
       setLoading(false);
     });
   }, [isClient]);
+ 
 
   return (
     <div className={styles.starButtonContainer}>
@@ -83,5 +118,6 @@ function GitHubStarButton(): JSX.Element {
     </div>
   );
 }
+  */
 
 export default GitHubStarButton;


### PR DESCRIPTION
## Purpose
Replace the github stars button with star the repo button.
<img width="1103" height="659" alt="Screenshot 2025-12-09 at 10 29 14" src="https://github.com/user-attachments/assets/d8587950-40f8-4a78-a1ab-aebdde35497f" />


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
