### PR TITLE
Add external-secrets.enabled=false for single-cluster setups

### DIFF
--- a/docs/getting-started/deploy-first-component.mdx
+++ b/docs/getting-started/deploy-first-component.mdx
@@ -13,7 +13,7 @@ This guide walks you through deploying your first component on OpenChoreo. By th
 
 Before you begin, ensure you have:
 
-- **OpenChoreo installed** in your Kubernetes cluster (see [Run on Your Laptop](./try-it-out/run-locally.mdx) or go to production with [Single Cluster](./production/single-cluster.mdx) or [Multi Cluster](./production/multi-cluster.mdx) setup)
+- **OpenChoreo installed** in your Kubernetes cluster (see [On Self-Hosted Kubernetes](./try-it-out/on-self-hosted-kubernetes.mdx) or go to production with [Single Cluster](./production/single-cluster.mdx) or [Multi Cluster](./production/multi-cluster.mdx) setup)
 - **kubectl** configured to access your cluster
 - **kubectl context** set to your cluster (should be `k3d-openchoreo` if following the k3d setup)
 

--- a/docs/getting-started/production/single-cluster.mdx
+++ b/docs/getting-started/production/single-cluster.mdx
@@ -455,6 +455,7 @@ kubectl get dataplane -n default
     --namespace openchoreo-build-plane \\
     --create-namespace \\
     --set clusterAgent.enabled=true \\
+    --set external-secrets.enabled=false \\
     --set global.baseDomain=openchoreo.\${DOMAIN}`}
 </CodeBlock>
 
@@ -557,6 +558,7 @@ Single-node OpenSearch for development or small deployments.
     --create-namespace \\
     --set openSearch.enabled=true \\
     --set openSearchCluster.enabled=false \\
+    --set external-secrets.enabled=false \\
     --set clusterAgent.enabled=true \\
     --timeout 10m`}
 </CodeBlock>
@@ -589,6 +591,7 @@ Install Observability Plane:
 {`helm upgrade --install openchoreo-observability-plane ${versions.helmSource}/openchoreo-observability-plane \\
     --version ${versions.helmChart} \\
     --namespace openchoreo-observability-plane \\
+    --set external-secrets.enabled=false \\
     --set clusterAgent.enabled=true \\
     --timeout 10m`}
 </CodeBlock>

--- a/docs/getting-started/try-it-out/on-local-vm.mdx
+++ b/docs/getting-started/try-it-out/on-local-vm.mdx
@@ -1,6 +1,6 @@
 ---
-title: Run on Your Laptop
-description: Run OpenChoreo on your local machine - zero cost, no cloud required.
+title: On Local/VM
+description: Run OpenChoreo on your local machine or VM - no public IP required, zero cloud costs.
 sidebar_position: 1
 ---
 
@@ -10,12 +10,12 @@ import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 import {versions} from '../../_constants.mdx';
 
-# Run on Your Laptop
+# On Local/VM
 
-Try OpenChoreo on your local machine. This is the fastest way to explore OpenChoreo without any cloud costs.
+Try OpenChoreo on your local machine or VM. No public IP or cloud provider required - perfect for development and testing.
 
 **What you'll get:**
-- Full OpenChoreo installation on your laptop
+- Full OpenChoreo installation on your cluster
 - All four planes: Control, Data, Build, and Observability
 - Access via `.localhost` domains
 - ~15-20 minutes to complete
@@ -353,7 +353,6 @@ kubectl get pods -n openchoreo-build-plane
     --set openSearch.enabled=true \\
     --set openSearchCluster.enabled=false \\
     --set external-secrets.enabled=false \\
-    --set fakeSecretStore.enabled=false \\
     --set clusterAgent.enabled=true \\
     --timeout 10m`}
 </CodeBlock>
@@ -409,6 +408,20 @@ kubectl logs -n openchoreo-observability-plane -l app=cluster-agent --tail=10
 | Deployed Apps | `http://<env>.openchoreoapis.localhost:19080/<component>/...` |
 
 **Default credentials:** `admin@openchoreo.dev` / `Admin@123`
+
+:::tip Remote Cluster Access
+If your cluster is running on a remote VM or server, use SSH tunneling to access OpenChoreo from your local machine:
+
+```bash
+ssh -L 8080:localhost:8080 -L 8443:localhost:8443 -L 19080:localhost:19080 -L 19443:localhost:19443 user@remote-host
+```
+
+This forwards:
+- **8080/8443**: Control Plane UI (Console and API)
+- **19080/19443**: Data Plane Gateway (Deployed applications)
+
+Keep this SSH session open and access OpenChoreo via `http://openchoreo.localhost:8080` in your local browser.
+:::
 
 ---
 

--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Run on Your Cluster
-description: Try OpenChoreo on your existing Kubernetes cluster with automatic TLS using nip.io domains.
+title: On Managed Kubernetes
+description: Try OpenChoreo on managed Kubernetes services (GKE, EKS, AKS) with automatic TLS using nip.io domains.
 sidebar_position: 2
 ---
 
@@ -10,9 +10,9 @@ import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 import {versions} from '../../_constants.mdx';
 
-# Run on Your Cluster
+# On Managed Kubernetes
 
-Try OpenChoreo on your existing Kubernetes cluster with automatic TLS certificates. This guide uses [nip.io](https://nip.io) for free wildcard DNS based on your LoadBalancer IP.
+Try OpenChoreo on managed Kubernetes services (GKE, EKS, AKS, etc.) with automatic TLS certificates. This guide uses [nip.io](https://nip.io) for free wildcard DNS based on your LoadBalancer IP.
 
 **What you'll get:**
 - OpenChoreo with real TLS certificates (Let's Encrypt)
@@ -392,6 +392,7 @@ EOF
     --create-namespace \\
     --set openSearch.enabled=true \\
     --set openSearchCluster.enabled=false \\
+    --set external-secrets.enabled=false \\
     --set clusterAgent.enabled=true \\
     --timeout 10m`}
 </CodeBlock>

--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -1,0 +1,504 @@
+---
+title: On Self-Hosted Kubernetes
+description: Run OpenChoreo on any self-hosted Kubernetes cluster - local machine, VM, or on-premise. Zero cloud costs.
+sidebar_position: 1
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import Link from '@docusaurus/Link';
+import {versions} from '../../_constants.mdx';
+
+# On Self-Hosted Kubernetes
+
+Try OpenChoreo on any self-hosted Kubernetes cluster - whether it's running on your laptop, a VM, or on-premise environment. This is the fastest way to explore OpenChoreo without cloud provider costs.
+
+**What you'll get:**
+- Full OpenChoreo installation on your cluster
+- All four planes: Control, Data, Build, and Observability
+- Access via `.localhost` domains
+- ~15-20 minutes to complete
+
+---
+
+## Step 1: Set Up Your Cluster
+
+<Tabs groupId="cluster-type">
+<TabItem value="existing" label="Existing Cluster" default>
+
+**Prerequisites**
+
+- **Kubernetes 1.28+** cluster with at least **8 GB RAM** and **4 CPU** cores
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** v1.32+ configured to access your cluster
+- **[Helm](https://helm.sh/docs/intro/install/)** v3.12+
+
+```bash
+kubectl version
+helm version --short
+kubectl get nodes
+kubectl auth can-i '*' '*' --all-namespaces
+```
+
+**Note Your Ingress Configuration**
+
+Check if you have an ingress controller:
+
+```bash
+kubectl get ingressclass
+```
+
+Common configurations:
+- **Rancher Desktop**: Built-in Traefik on ports 80/443, class name `traefik`
+- **Docker Desktop**: No default ingress
+- **OrbStack**: Built-in ingress on ports 80/443
+
+</TabItem>
+<TabItem value="k3d" label="k3d">
+
+[k3d](https://k3d.io) runs k3s in Docker containers.
+
+**Prerequisites**
+
+- **Docker** v26.0+ with at least **8 GB RAM** and **4 CPU** cores allocated
+- **Disk space**: ~10 GB free
+- **[k3d](https://k3d.io/stable/#installation)** v5.8+
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** v1.32+
+- **[Helm](https://helm.sh/docs/intro/install/)** v3.12+
+
+```bash
+docker --version && docker info > /dev/null
+k3d --version
+kubectl version --client
+helm version --short
+```
+
+:::note Colima Users
+Set `K3D_FIX_DNS=0` when creating clusters to avoid DNS issues. See [k3d-io/k3d#1449](https://github.com/k3d-io/k3d/issues/1449).
+:::
+
+**Create Cluster**
+
+<CodeBlock language="bash">
+{`curl -s https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/single-cluster/config.yaml | k3d cluster create --config=-`}
+</CodeBlock>
+
+This creates a cluster named `openchoreo` with:
+- 1 server node (no agents)
+- Port mappings: Control Plane (8080/8443), Data Plane (19080/19443), Build Plane (10081)
+- kubectl context set to `k3d-openchoreo`
+
+</TabItem>
+<TabItem value="kind" label="kind">
+
+[kind](https://kind.sigs.k8s.io) runs Kubernetes in Docker containers.
+
+**Prerequisites**
+
+- **Docker** v26.0+ with at least **8 GB RAM** and **4 CPU** cores allocated
+- **Disk space**: ~10 GB free
+- **[kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)** v0.20+
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** v1.32+
+- **[Helm](https://helm.sh/docs/intro/install/)** v3.12+
+
+```bash
+docker --version && docker info > /dev/null
+kind --version
+kubectl version --client
+helm version --short
+```
+
+**Create Cluster**
+
+```bash
+cat <<EOF | kind create cluster --name openchoreo --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8080
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 8443
+    protocol: TCP
+  - containerPort: 30080
+    hostPort: 19080
+    protocol: TCP
+  - containerPort: 30443
+    hostPort: 19443
+    protocol: TCP
+- role: worker
+EOF
+```
+
+This creates a cluster with NodePort mappings for the data plane gateway (30080→19080, 30443→19443).
+
+</TabItem>
+<TabItem value="minikube" label="minikube">
+
+[minikube](https://minikube.sigs.k8s.io) creates a local Kubernetes cluster in a VM or container.
+
+**Prerequisites**
+
+- **Docker** v26.0+ OR a hypervisor (VirtualBox, Hyper-V, etc.)
+- **8 GB RAM** and **4 CPU** cores available
+- **Disk space**: ~10 GB free
+- **[minikube](https://minikube.sigs.k8s.io/docs/start/)** v1.32+
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** v1.32+
+- **[Helm](https://helm.sh/docs/intro/install/)** v3.12+
+
+```bash
+minikube version
+kubectl version --client
+helm version --short
+```
+
+**Create Cluster**
+
+```bash
+minikube start --cpus=4 --memory=8192 --driver=docker --profile=openchoreo
+minikube addons enable ingress --profile=openchoreo
+```
+
+:::note Port Access
+minikube requires `minikube tunnel` to access LoadBalancer services. Run it in a separate terminal:
+```bash
+minikube tunnel --profile=openchoreo
+```
+:::
+
+</TabItem>
+<TabItem value="k3s" label="k3s">
+
+**Prerequisites**
+
+- **Linux** system with at least **8 GB RAM** and **4 CPU** cores
+- **Root access** or sudo privileges
+- **[kubectl](https://kubernetes.io/docs/tasks/tools/)** v1.32+
+- **[Helm](https://helm.sh/docs/intro/install/)** v3.12+
+
+**Install k3s**
+
+```bash
+curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
+```
+
+Configure kubectl:
+
+```bash
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+# Or copy to default location:
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+## Step 2: Install cert-manager
+
+:::tip
+Skip this step if cert-manager is already installed in your cluster.
+:::
+
+```bash
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --set crds.enabled=true
+```
+
+Wait for cert-manager to be ready:
+
+```bash
+kubectl wait --for=condition=available deployment/cert-manager -n cert-manager --timeout=120s
+```
+
+---
+
+## Step 3: Install Control Plane
+
+<CodeBlock language="bash">
+{`helm upgrade --install openchoreo-control-plane ${versions.helmSource}/openchoreo-control-plane \\
+    --version ${versions.helmChart} \\
+    --namespace openchoreo-control-plane \\
+    --create-namespace \\
+    --set global.baseDomain=openchoreo.localhost \\
+    --set global.port=":8080" \\
+    --set traefik.ports.web.exposedPort=8080 \\
+    --set traefik.ports.websecure.exposedPort=8443`}
+</CodeBlock>
+
+Wait for pods to be ready:
+
+```bash
+kubectl get pods -n openchoreo-control-plane -w
+```
+
+---
+
+## Step 4: Install Data Plane
+
+<CodeBlock language="bash">
+{`helm upgrade --install openchoreo-data-plane ${versions.helmSource}/openchoreo-data-plane \\
+    --version ${versions.helmChart} \\
+    --namespace openchoreo-data-plane \\
+    --create-namespace \\
+    --set gateway.httpPort=19080 \\
+    --set gateway.httpsPort=19443 \\
+    --set external-secrets.enabled=true`}
+</CodeBlock>
+
+:::note macOS Users
+If you're on macOS with Docker Desktop, k3d, kind, or Colima (with Rosetta), add this flag to fix Envoy temporary file issues:
+```
+--set gateway.envoy.mountTmpVolume=true
+```
+:::
+
+### Register the Data Plane
+
+```bash
+CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-data-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
+
+kubectl apply -f - <<EOF
+apiVersion: openchoreo.dev/v1alpha1
+kind: DataPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  agent:
+    enabled: true
+    clientCA:
+      value: |
+$(echo "$CA_CERT" | sed 's/^/        /')
+  gateway:
+    organizationVirtualHost: "openchoreoapis.internal"
+    publicVirtualHost: "openchoreoapis.localhost"
+  secretStoreRef:
+    name: default
+EOF
+```
+
+Verify:
+
+```bash
+kubectl get dataplane -n default
+kubectl logs -n openchoreo-data-plane -l app=cluster-agent --tail=10
+```
+
+---
+
+## Step 5: Install Build Plane (Optional)
+
+The Build Plane enables OpenChoreo's built-in CI capabilities.
+
+<CodeBlock language="bash">
+{`helm upgrade --install openchoreo-build-plane ${versions.helmSource}/openchoreo-build-plane \\
+    --version ${versions.helmChart} \\
+    --namespace openchoreo-build-plane \\
+    --create-namespace \\
+    --set external-secrets.enabled=false \\
+    --set clusterAgent.enabled=true`}
+</CodeBlock>
+
+### Register the Build Plane
+
+```bash
+BP_CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-build-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
+
+kubectl apply -f - <<EOF
+apiVersion: openchoreo.dev/v1alpha1
+kind: BuildPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  agent:
+    enabled: true
+    clientCA:
+      value: |
+$(echo "$BP_CA_CERT" | sed 's/^/        /')
+EOF
+```
+
+Verify:
+
+```bash
+kubectl get buildplane -n default
+kubectl get pods -n openchoreo-build-plane
+```
+
+---
+
+## Step 6: Install Observability Plane (Optional)
+
+<CodeBlock language="bash">
+{`helm upgrade --install openchoreo-observability-plane ${versions.helmSource}/openchoreo-observability-plane \\
+    --version ${versions.helmChart} \\
+    --namespace openchoreo-observability-plane \\
+    --create-namespace \\
+    --set openSearch.enabled=true \\
+    --set openSearchCluster.enabled=false \\
+    --set external-secrets.enabled=false \\
+    --set clusterAgent.enabled=true \\
+    --timeout 10m`}
+</CodeBlock>
+
+### Register the Observability Plane
+
+```bash
+OP_CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-observability-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
+
+kubectl apply -f - <<EOF
+apiVersion: openchoreo.dev/v1alpha1
+kind: ObservabilityPlane
+metadata:
+  name: default
+  namespace: default
+spec:
+  agent:
+    enabled: true
+    clientCA:
+      value: |
+$(echo "$OP_CA_CERT" | sed 's/^/        /')
+  observerURL: http://observer.openchoreo-observability-plane.svc.cluster.local:8080
+EOF
+```
+
+Configure the Data Plane to use the Observability Plane:
+
+```bash
+kubectl patch dataplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+```
+
+If you installed the Build Plane, configure it too:
+
+```bash
+kubectl patch buildplane default -n default --type merge -p '{"spec":{"observabilityPlaneRef":"default"}}'
+```
+
+Verify:
+
+```bash
+kubectl get observabilityplane -n default
+kubectl logs -n openchoreo-observability-plane -l app=cluster-agent --tail=10
+```
+
+---
+
+## Access OpenChoreo
+
+| Service | URL |
+|---------|-----|
+| Console | `http://openchoreo.localhost:8080` |
+| API | `http://api.openchoreo.localhost:8080` |
+| Deployed Apps | `http://<env>.openchoreoapis.localhost:19080/<component>/...` |
+
+**Default credentials:** `admin@openchoreo.dev` / `Admin@123`
+
+:::tip Remote Cluster Access
+If your cluster is running on a remote VM or server, use SSH tunneling to access OpenChoreo from your local machine:
+
+```bash
+ssh -L 8080:localhost:8080 -L 8443:localhost:8443 -L 19080:localhost:19080 -L 19443:localhost:19443 user@remote-host
+```
+
+This forwards:
+- **8080/8443**: Control Plane UI (Console and API)
+- **19080/19443**: Data Plane Gateway (Deployed applications)
+
+Keep this SSH session open and access OpenChoreo via `http://openchoreo.localhost:8080` in your local browser.
+:::
+
+---
+
+## Next Steps
+
+1. [Deploy your first component](../deploy-first-component.mdx)
+2. Explore the <Link to={`https://github.com/openchoreo/openchoreo/tree/${versions.githubRef}/samples`}>sample applications</Link>
+
+---
+
+## Cleanup
+
+Uninstall OpenChoreo components:
+
+```bash
+helm uninstall openchoreo-observability-plane -n openchoreo-observability-plane 2>/dev/null
+helm uninstall openchoreo-build-plane -n openchoreo-build-plane 2>/dev/null
+helm uninstall openchoreo-data-plane -n openchoreo-data-plane
+helm uninstall openchoreo-control-plane -n openchoreo-control-plane
+helm uninstall cert-manager -n cert-manager
+```
+
+Delete namespaces and plane registrations:
+
+```bash
+kubectl delete dataplane default -n default 2>/dev/null
+kubectl delete buildplane default -n default 2>/dev/null
+kubectl delete observabilityplane default -n default 2>/dev/null
+kubectl delete namespace openchoreo-control-plane openchoreo-data-plane openchoreo-build-plane openchoreo-observability-plane cert-manager 2>/dev/null
+```
+
+If you created a cluster for this guide:
+
+```bash
+# k3d
+k3d cluster delete openchoreo
+
+# kind
+kind delete cluster --name openchoreo
+
+# minikube
+minikube delete --profile=openchoreo
+
+# k3s
+/usr/local/bin/k3s-uninstall.sh
+```
+
+---
+
+## Troubleshooting
+
+### Pods stuck in Pending
+
+```bash
+kubectl describe pod <pod-name> -n <namespace>
+```
+
+Common causes:
+- Insufficient resources (increase RAM/CPU allocation)
+- PVC issues (check storage provisioner)
+
+### Agent not connecting
+
+```bash
+kubectl logs -n openchoreo-data-plane -l app=cluster-agent --tail=20
+kubectl logs -n openchoreo-control-plane -l app=cluster-gateway --tail=20
+```
+
+Common issues:
+- DataPlane/BuildPlane CR not created
+- CA certificate mismatch
+- Network connectivity between namespaces
+
+### Gateway pods crash on macOS
+
+If you see "Failed to create temporary file" errors:
+
+```bash
+helm upgrade openchoreo-data-plane ... --set gateway.envoy.mountTmpVolume=true
+```

--- a/docs/overview/what-is-openchoreo.mdx
+++ b/docs/overview/what-is-openchoreo.mdx
@@ -53,7 +53,7 @@ Ready to try OpenChoreo? Start here:
 
 1. **[Architecture](./architecture.mdx)** - Understand the multi-plane architecture
 2. **[Quick Start Guide](../getting-started/quick-start-guide.mdx)** - Try OpenChoreo in minutes using a Dev Container
-3. **Try It Out** - [Run on Your Laptop](../getting-started/try-it-out/run-locally.mdx) or [Run on Your Cluster](../getting-started/try-it-out/run-on-your-cluster.mdx)
+3. **Try It Out** - [On Self-Hosted Kubernetes](../getting-started/try-it-out/on-self-hosted-kubernetes.mdx) or [On Managed Kubernetes](../getting-started/try-it-out/on-managed-kubernetes.mdx)
 4. **Go to Production** - [Single Cluster](../getting-started/production/single-cluster.mdx) or [Multi Cluster](../getting-started/production/multi-cluster.mdx)
 5. **[Concepts](../concepts/developer-abstractions.md)** - Learn the platform abstractions
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -34,11 +34,11 @@ OpenChoreo focuses on:
 
 ### How do I install OpenChoreo?
 Choose your path:
-- **Quick Try**: [Run on Your Laptop](../getting-started/try-it-out/run-locally.mdx) or [Run on Your Cluster](../getting-started/try-it-out/run-on-your-cluster.mdx)
+- **Quick Try**: [On Self-Hosted Kubernetes](../getting-started/try-it-out/on-self-hosted-kubernetes.mdx) or [On Managed Kubernetes](../getting-started/try-it-out/on-managed-kubernetes.mdx)
 - **Production**: [Single Cluster](../getting-started/production/single-cluster.mdx) or [Multi Cluster](../getting-started/production/multi-cluster.mdx)
 
 ### Can I try OpenChoreo locally?
-Yes! The [Run on Your Laptop guide](../getting-started/try-it-out/run-locally.mdx) lets you try OpenChoreo on your laptop with k3d - no cloud required.
+Yes! The [On Self-Hosted Kubernetes guide](../getting-started/try-it-out/on-self-hosted-kubernetes.mdx) lets you try OpenChoreo on your laptop with k3d, kind, or any local/VM-hosted cluster - no cloud required.
 
 ### What's the simplest way to deploy my first application?
 Follow [Deploying your first component](../getting-started/deploy-first-component.mdx)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -34,8 +34,8 @@ const sidebars: SidebarsConfig = {
           label: 'Try It Out',
           collapsed: false,
           items: [
-            'getting-started/try-it-out/run-locally',
-            'getting-started/try-it-out/run-on-your-cluster',
+            'getting-started/try-it-out/on-self-hosted-kubernetes',
+            'getting-started/try-it-out/on-managed-kubernetes',
           ],
         },
         {


### PR DESCRIPTION
## Purpose
- Add missing --set external-secrets.enabled=false to Observability Plane in managed Kubernetes, self-hosted Kubernetes, and local VM guides
- Add missing --set external-secrets.enabled=false to Build Plane and Observability Plane in production single-cluster guide
- Remove unnecessary fakeSecretStore.enabled=false flag from all guides

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
