### PR TITLE
Enable Gateway API support for cert-manager

### DIFF
--- a/docs/getting-started/production/multi-cluster.mdx
+++ b/docs/getting-started/production/multi-cluster.mdx
@@ -58,7 +58,8 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
     --kube-context $CONTEXT \
     --namespace cert-manager \
     --create-namespace \
-    --set crds.enabled=true
+    --set crds.enabled=true \
+    --set config.enableGatewayAPI=true
 ```
 
 Wait for cert-manager to be ready:

--- a/docs/getting-started/production/single-cluster.mdx
+++ b/docs/getting-started/production/single-cluster.mdx
@@ -51,7 +51,8 @@ kubectl get nodes
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --set crds.enabled=true
+    --set crds.enabled=true \
+    --set config.enableGatewayAPI=true
 ```
 
 Wait for cert-manager to be ready:

--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -43,7 +43,8 @@ kubectl auth can-i '*' '*' --all-namespaces
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --set crds.enabled=true
+    --set crds.enabled=true \
+    --set config.enableGatewayAPI=true
 ```
 
 Wait for cert-manager to be ready:

--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -227,7 +227,8 @@ sudo chown $(id -u):$(id -g) ~/.kube/config
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --set crds.enabled=true
+    --set crds.enabled=true \
+    --set config.enableGatewayAPI=true
 ```
 
 Wait for cert-manager to be ready:

--- a/versioned_docs/version-v0.7.x/getting-started/single-cluster.mdx
+++ b/versioned_docs/version-v0.7.x/getting-started/single-cluster.mdx
@@ -184,7 +184,8 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager --create-namespace \
-  --set crds.enabled=true
+  --set crds.enabled=true \
+  --set config.enableGatewayAPI=true
 
 # Create ClusterIssuer (use YOUR email)
 export EMAIL="your-email@example.com"


### PR DESCRIPTION
## Purpose
This PR enables the Gateway API support for cert-manager. Previously this configuration was added to cert-manager values.yaml but with https://github.com/openchoreo/openchoreo/pull/1205, values.yaml got replaced with --set with helm install. This is required to automatically create TLS certificates for a dynamically provisioned gateways.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
