### PR TITLE
Create Gateway Certificates without Gateway annotations

### DIFF
--- a/docs/getting-started/production/multi-cluster.mdx
+++ b/docs/getting-started/production/multi-cluster.mdx
@@ -302,6 +302,8 @@ This saves `./agent-cas/server-ca.crt`.
     --kube-context \$DP_CONTEXT \\
     --namespace openchoreo-data-plane \\
     --create-namespace \\
+    --set gateway.httpPort=19080 \\
+    --set gateway.httpsPort=19443 \\
     --set-file clusterAgent.tls.serverCAValue=./agent-cas/server-ca.crt`}
 </CodeBlock>
 

--- a/docs/getting-started/production/single-cluster.mdx
+++ b/docs/getting-started/production/single-cluster.mdx
@@ -303,6 +303,8 @@ Use a wildcard cert (`*.openchoreo.${DOMAIN}`) or a SAN cert with all three doma
 {`helm upgrade --install openchoreo-data-plane ${versions.helmSource}/openchoreo-data-plane \\
     --version ${versions.helmChart} \\
     --namespace openchoreo-data-plane \\
+    --set gateway.httpPort=19080 \\
+    --set gateway.httpsPort=19443 \\
     --create-namespace`}
 </CodeBlock>
 

--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -246,6 +246,25 @@ export DP_DOMAIN="apps.openchoreo.${DP_LB_IP//./-}.nip.io"
 echo "Data Plane Domain: $DP_DOMAIN"
 ```
 
+**Configure TLS**
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-gateway-tls
+  namespace: openchoreo-data-plane
+spec:
+  secretName: openchoreo-gateway-tls
+  issuerRef:
+    name: openchoreo-selfsigned-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - "${DP_DOMAIN}"
+EOF
+```
+
 :::info Wildcard Certificates
 The data plane gateway requires a wildcard hostname (`*.apps.openchoreo...nip.io`) since each deployed component gets its own subdomain. HTTP-01 validation cannot issue wildcard certificates. The helm chart uses a self-signed certificate by default, which is sufficient for this tryout. For production with trusted certificates, configure DNS-01 validation with your DNS provider.
 :::

--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -149,6 +149,25 @@ Due to Rosetta emulation issues, macOS users (Rancher Desktop, Docker Desktop, k
     --set gateway.envoy.mountTmpVolume=true`}
 </CodeBlock>
 
+Create a Certificate for Gateway TLS:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-gateway-tls
+  namespace: openchoreo-data-plane
+spec:
+  secretName: openchoreo-gateway-tls
+  issuerRef:
+    name: openchoreo-selfsigned-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.openchoreoapis.localhost"
+EOF
+```
+
 Register with the control plane:
 
 ```bash


### PR DESCRIPTION
## Purpose
This is required after https://github.com/openchoreo/openchoreo.github.io/pull/178 as the automatic certificate creation for Gateway is removed due to cert-manager installation complexities.

This PR updates the following in dataplane installation.
- Try Out Self Hosted - Create a self signed certificate for Gateway TLS for `*.openchoreoapis.localhost`
- Try Out Managed - Create a self signed certificate for Gateway TLS for the configured domain
- Production Single cluster - Updates the gateway ports to `19080` and `19443`
- Production Multi cluster - Updates the gateway ports to `19080` and `19443`

