### PR TITLE
Fix OpenSearch operator installation command

### DIFF
--- a/docs/getting-started/production/multi-cluster.mdx
+++ b/docs/getting-started/production/multi-cluster.mdx
@@ -582,11 +582,13 @@ Clustered OpenSearch using the OpenSearch Operator for high availability.
 Install OpenSearch Operator:
 
 ```bash
-helm upgrade --install opensearch-operator \
-    oci://ghcr.io/opensearch-project/helm-charts/opensearch-operator \
+helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
+helm repo update
+helm upgrade --install opensearch-operator opensearch-operator/opensearch-operator \
+    --create-namespace \
     --kube-context $OP_CONTEXT \
     --namespace openchoreo-observability-plane \
-    --create-namespace
+    --version 2.8.0
 ```
 
 Wait for the operator to be ready:

--- a/docs/getting-started/production/single-cluster.mdx
+++ b/docs/getting-started/production/single-cluster.mdx
@@ -609,10 +609,12 @@ Clustered OpenSearch using the OpenSearch Operator for high availability.
 Install OpenSearch Operator:
 
 ```bash
-helm upgrade --install opensearch-operator \
-    oci://ghcr.io/opensearch-project/helm-charts/opensearch-operator \
+helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
+helm repo update
+helm upgrade --install opensearch-operator opensearch-operator/opensearch-operator \
+    --create-namespace \
     --namespace openchoreo-observability-plane \
-    --create-namespace
+    --version 2.8.0
 ```
 
 Wait for the operator to be ready:


### PR DESCRIPTION
## Purpose
OpenSearch operator install command was using an incorrect URL and it was returning an HTTP 403. This fixes it

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
