### PR TITLE
Update componenttype & trait pages to mention param envOverride separation

### DIFF
--- a/docs/reference/api/platform/componenttype.md
+++ b/docs/reference/api/platform/componenttype.md
@@ -122,7 +122,11 @@ Platform-computed metadata for resource generation:
 
 ##### parameters
 
-Merged component parameters with schema defaults applied. Fields depend on the ComponentType schema definition.
+Component parameters from `Component.spec.parameters` with schema defaults applied. Use for static configuration that doesn't change across environments.
+
+##### envOverrides
+
+Environment-specific overrides from `ReleaseBinding.spec.componentTypeEnvOverrides` with schema defaults applied. Use for values that vary per environment (resources, replicas, etc.).
 
 ##### workload
 

--- a/docs/reference/api/platform/trait.md
+++ b/docs/reference/api/platform/trait.md
@@ -109,7 +109,20 @@ Trait-specific metadata:
 
 ##### parameters
 
-Merged trait instance parameters with schema defaults applied. Fields depend on the Trait schema definition.
+Trait instance parameters from `Component.spec.traits[].parameters` with schema defaults applied. Use for static configuration that doesn't change across environments.
+
+##### envOverrides
+
+Environment-specific overrides from `ReleaseBinding.spec.traitOverrides[instanceName]` with schema defaults applied. Use for values that vary per environment.
+
+##### dataplane
+
+Data plane configuration:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `dataplane.secretStore` | string | Name of the ClusterSecretStore for external secrets |
+| `dataplane.publicVirtualHost` | string | Public virtual host for external access |
 
 ##### Helper Functions
 
@@ -198,10 +211,10 @@ spec:
         spec:
           accessModes:
             - ReadWriteOnce
-          storageClassName: ${parameters.storageClass}
+          storageClassName: ${envOverrides.storageClass}
           resources:
             requests:
-              storage: ${parameters.size}
+              storage: ${envOverrides.size}
 
   patches:
     - target:
@@ -279,10 +292,10 @@ spec:
       operations:
         - op: add
           path: /spec/template/spec/containers[?(@.name=='main')]/resources/limits/cpu
-          value: ${parameters.cpuLimit}
+          value: ${envOverrides.cpuLimit}
         - op: add
           path: /spec/template/spec/containers[?(@.name=='main')]/resources/limits/memory
-          value: ${parameters.memoryLimit}
+          value: ${envOverrides.memoryLimit}
 ```
 
 ### Multi-Container Trait with forEach
@@ -341,12 +354,9 @@ spec:
         volumeName: data
         mountPath: /var/data
         containerName: app
-      envOverrides:
-        size: 20Gi
-        storageClass: fast-ssd
 ```
 
-Platform engineers can also override trait parameters in ReleaseBinding:
+Platform engineers can set trait `envOverrides` in ReleaseBinding:
 
 ```yaml
 apiVersion: openchoreo.dev/v1alpha1
@@ -361,10 +371,9 @@ spec:
     projectName: default
 
   traitOverrides:
-    - instanceName: data-storage
-      parameters:
-        size: 100Gi
-        storageClass: production-ssd
+    data-storage:  # keyed by instanceName
+      size: 100Gi
+      storageClass: production-ssd
 ```
 
 ## Best Practices


### PR DESCRIPTION
## Purpose
Update the references to match the following change
> Env overrides now come only from release bindings and are exposed as their own map for CEL checks and template rendering

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1243

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
