### PR TITLE
Add content to Operations Guide documentation pages

### DIFF
--- a/docs/operations/backstage-configuration.mdx
+++ b/docs/operations/backstage-configuration.mdx
@@ -3,3 +3,310 @@ title: Backstage Configuration
 description: Customize and configure Backstage, OpenChoreo's developer portal.
 sidebar_position: 4
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Backstage Configuration
+
+OpenChoreo uses [Backstage](https://backstage.io/) as its developer portal, providing a unified interface for managing organizations, projects, components, and deployments. This guide covers configuration options for customizing Backstage in your OpenChoreo deployment.
+
+Backstage configuration is done via Helm values in the Control Plane chart.
+
+## Core Configuration
+
+**Console/UI URL:**
+
+```yaml
+backstage:
+  appConfig:
+    app:
+      baseUrl: "https://console.example.com"
+    backend:
+      baseUrl: "https://console.example.com"
+```
+
+**OpenChoreo API URL:**
+
+```yaml
+openchoreoApi:
+  ingress:
+    enabled: true
+    hosts:
+      - host: api.example.com
+        paths:
+          - path: /
+```
+
+## Authentication
+
+Backstage requires an OIDC-compatible identity provider.
+
+**OIDC Configuration:**
+
+```yaml
+backstage:
+  auth:
+    authorizationUrl: "https://your-idp/oauth2/authorize"
+    tokenUrl: "https://your-idp/oauth2/token"
+    clientId: "your-client-id"
+    clientSecret: "your-client-secret"
+    redirectUrls:
+      - "https://console.example.com/api/auth/default-idp/handler/frame"
+```
+
+**Security/JWT Configuration:**
+
+```yaml
+security:
+  enabled: true
+  oidc:
+    issuer: "https://your-idp"
+    jwksUrl: "https://your-idp/.well-known/jwks.json"
+  jwt:
+    audience: "openchoreo"
+```
+
+See [Identity Provider Configuration](./identity-provider/oidc.mdx) for detailed OIDC setup.
+
+## Feature Flags
+
+```yaml
+backstage:
+  features:
+    workflows:
+      enabled: true       # Requires Build Plane
+    observability:
+      enabled: true       # Requires Observability Plane
+```
+
+## Resource Configuration
+
+```yaml
+backstage:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+```
+
+## Environment Variables
+
+Add custom environment variables to the Backstage deployment:
+
+```yaml
+backstage:
+  env:
+    - name: NODE_ENV
+      value: production
+    - name: LOG_LEVEL
+      value: info
+    - name: PORT
+      value: "7007"
+```
+
+### Commonly Used Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NODE_ENV` | Node.js environment | `production` |
+| `LOG_LEVEL` | Logging verbosity | `info` |
+| `PORT` | HTTP server port | `7007` |
+| `OPENCHOREO_API_URL` | OpenChoreo API endpoint | Auto-configured |
+| `THUNDER_BASE_URL` | Thunder IdP URL | Auto-configured |
+
+## Ingress Configuration
+
+```yaml
+backstage:
+  ingress:
+    enabled: true
+    className: "your-ingress-class"
+    hosts:
+      - host: console.example.com
+        paths:
+          - path: /
+    tls:
+      - secretName: console-tls
+        hosts:
+          - console.example.com
+```
+
+## Service Configuration
+
+```yaml
+backstage:
+  service:
+    type: ClusterIP
+    port: 7007
+```
+
+## OpenChoreo API Integration
+
+Backstage communicates with the OpenChoreo API for backend operations:
+
+```yaml
+backstage:
+  openchoreoApi:
+    url: ""  # Auto-configured to internal service URL
+```
+
+The API URL defaults to `http://{release-name}-api.{namespace}.svc.cluster.local:8080/api/v1`.
+
+## Backend Secret
+
+For session encryption (should be stable across restarts):
+
+```yaml
+backstage:
+  backendSecret: "your-32-character-secret-here"
+```
+
+## Health Checks
+
+Backstage health checks are pre-configured:
+
+| Check | Endpoint | Default |
+|-------|----------|---------|
+| Liveness | `/healthcheck` | Enabled |
+| Readiness | `/healthcheck` | Enabled |
+
+## Example Configurations
+
+<Tabs>
+<TabItem value="development" label="Development">
+
+```yaml
+backstage:
+  enabled: true
+  replicas: 1
+  baseUrl: "http://localhost:7007"
+  ingress:
+    enabled: true
+    hosts:
+      - host: localhost
+        paths:
+          - path: /
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  features:
+    workflows:
+      enabled: true
+    observability:
+      enabled: true
+```
+
+</TabItem>
+<TabItem value="production" label="Production">
+
+```yaml
+backstage:
+  enabled: true
+  replicas: 2
+  baseUrl: "https://console.example.com"
+  backendSecret: "your-production-secret-32chars!"
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: console.example.com
+        paths:
+          - path: /
+    tls:
+      - secretName: console-tls
+        hosts:
+          - console.example.com
+
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 70
+
+  features:
+    workflows:
+      enabled: true
+    observability:
+      enabled: true
+```
+
+</TabItem>
+<TabItem value="api-only" label="API-only Mode">
+
+For headless deployments where only the API is needed:
+
+```yaml
+backstage:
+  enabled: false
+
+# Security can also be disabled for development
+security:
+  enabled: false
+```
+
+</TabItem>
+</Tabs>
+
+## Troubleshooting
+
+### Backstage Not Loading
+
+Check pod status and logs:
+
+```bash
+kubectl get pods -n openchoreo-control-plane -l app.kubernetes.io/name=backstage
+kubectl logs -n openchoreo-control-plane deployment/backstage
+```
+
+### Authentication Issues
+
+Verify OAuth configuration:
+
+```bash
+# Check Backstage environment variables
+kubectl exec -n openchoreo-control-plane deployment/backstage -- env | grep -E "(AUTH|THUNDER)"
+
+# Check Thunder is running
+kubectl get pods -n openchoreo-control-plane -l app.kubernetes.io/name=thunder
+```
+
+### API Connection Errors
+
+Verify OpenChoreo API is accessible:
+
+```bash
+# Check API pod
+kubectl get pods -n openchoreo-control-plane -l app.kubernetes.io/name=openchoreo-api
+
+# Test API from Backstage pod
+kubectl exec -n openchoreo-control-plane deployment/backstage -- \
+  curl -s http://openchoreo-control-plane-api:8080/api/v1/health
+```
+
+## Next Steps
+
+- [Identity Provider Configuration](./identity-provider/thunder.mdx): Configure Thunder or external IdP
+- [Deployment Topology](./deployment-topology.mdx): Set up organizations and environments
+- [Helm Charts Reference](/docs/reference/helm/control-plane.mdx): Complete Backstage configuration options

--- a/docs/operations/container-registry.mdx
+++ b/docs/operations/container-registry.mdx
@@ -1,5 +1,259 @@
 ---
 title: Container Registry Configuration
-description: Configure built-in or external container registries for OpenChoreo builds.
+description: Configure the Build Plane to push images to your container registry and Data Planes to pull them.
 sidebar_position: 7
 ---
+
+# Container Registry Configuration
+
+This guide explains how the Build Plane executes CI/CD workflows, how to configure registry credentials, and how Data Planes pull images for deployment.
+
+## Build Plane Overview
+
+The Build Plane provides CI/CD infrastructure using [Argo Workflows](https://argoproj.github.io/workflows/). When you trigger a build, OpenChoreo creates a Workflow that executes a series of steps to build your application, push the container image, and generate deployment artifacts.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                            Build Plane                                  │
+│                                                                         │
+│  ┌──────────────────┐      ┌──────────────────────────────────────┐     │
+│  │ Argo Workflows   │      │ ClusterWorkflowTemplate              │     │
+│  │ Controller       │─────▶│                                      │     │
+│  └──────────────────┘      │  ┌───────┐ ┌───────┐ ┌────────────┐  │     │
+│                            │  │ Clone │→│ Build │→│    Push    │  │     │
+│                            │  └───────┘ └───────┘ └────────────┘  │     │
+│                            │                             ↓        │     │
+│                            │                      ┌────────────┐  │     │
+│                            │                      │ Workload   │  │     │
+│                            │                      │ Create     │  │     │
+│                            │                      └────────────┘  │     │
+│                            └──────────────────────────────────────┘     │
+│                                           │                             │
+└───────────────────────────────────────────┼─────────────────────────────┘
+                                            │
+                                            ▼
+                                   Container Registry
+                                            │
+                                            ▼
+                                       Data Plane
+```
+
+The Argo Workflows controller watches for Workflow resources and executes them. Each workflow follows a `ClusterWorkflowTemplate` that defines the build pipeline steps.
+
+## Registry Configuration
+
+Before workflows can push images, you need to configure registry credentials. Create a docker registry secret in the `openchoreo-build-plane` namespace:
+
+```bash
+kubectl create secret docker-registry registry-credentials \
+  --docker-server=<registry-url> \
+  --docker-username=<username> \
+  --docker-password=<password> \
+  -n openchoreo-build-plane
+```
+
+For provider-specific credential setup, refer to:
+
+- [Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html)
+- [Google Artifact Registry](https://cloud.google.com/artifact-registry/docs/docker/authentication)
+- [Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication)
+- [Harbor](https://goharbor.io/docs/2.0.0/working-with-projects/working-with-images/pulling-pushing-images/)
+
+## ClusterWorkflowTemplate
+
+A `ClusterWorkflowTemplate` defines a reusable build pipeline. OpenChoreo uses these templates to build different types of applications (Dockerfile, Buildpacks, etc.). When a build is triggered, OpenChoreo creates a Workflow that references the appropriate template.
+
+The template defines four main steps:
+
+### Clone
+
+Clones your source repository. Supports both branch and specific commit checkout:
+
+```yaml
+- name: clone
+  outputs:
+    parameters:
+      - name: git-revision
+        valueFrom:
+          path: /tmp/git-revision.txt
+  container:
+    image: alpine/git
+    command: [sh, -c]
+    args:
+      - |
+        git clone --single-branch --branch "$BRANCH" --depth 1 "$REPO" /mnt/vol/source
+        cd /mnt/vol/source
+        git rev-parse HEAD | cut -c1-8 > /tmp/git-revision.txt
+    volumeMounts:
+      - name: workspace
+        mountPath: /mnt/vol
+```
+
+The short git revision is passed to subsequent steps for image tagging.
+
+### Build
+
+Builds the container image using Podman. The exact build command depends on your application type (Dockerfile, Buildpacks, etc.):
+
+```yaml
+- name: build
+  inputs:
+    parameters:
+      - name: git-revision
+  container:
+    image: ghcr.io/openchoreo/podman-runner:v1.0
+    command: [sh, -c]
+    args:
+      - |
+        IMAGE="$IMAGE_NAME:$IMAGE_TAG-{{inputs.parameters.git-revision}}"
+        podman build -t "$IMAGE" -f "$DOCKERFILE" "$CONTEXT"
+        podman save -o /mnt/vol/image.tar "$IMAGE"
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - name: workspace
+        mountPath: /mnt/vol
+```
+
+The built image is saved as a tar file to the shared workspace volume.
+
+### Push
+
+Loads the image and pushes it to your registry. This step mounts the registry credentials secret:
+
+```yaml
+- name: push
+  inputs:
+    parameters:
+      - name: git-revision
+  outputs:
+    parameters:
+      - name: image
+        valueFrom:
+          path: /tmp/image.txt
+  container:
+    image: ghcr.io/openchoreo/podman-runner:v1.0
+    command: [sh, -c]
+    args:
+      - |
+        export REGISTRY_AUTH_FILE=/auth/.dockerconfigjson
+        IMAGE="$IMAGE_NAME:$IMAGE_TAG-{{inputs.parameters.git-revision}}"
+        podman load -i /mnt/vol/image.tar
+        podman tag "$IMAGE" "$REGISTRY/$IMAGE"
+        podman push "$REGISTRY/$IMAGE"
+        echo -n "$REGISTRY/$IMAGE" > /tmp/image.txt
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - name: workspace
+        mountPath: /mnt/vol
+      - name: registry-auth
+        mountPath: /auth
+        readOnly: true
+  volumes:
+    - name: registry-auth
+      secret:
+        secretName: registry-credentials
+```
+
+The `REGISTRY_AUTH_FILE` environment variable tells Podman where to find the docker config credentials. The full image reference (registry + image + tag) is written to an output parameter for the next step.
+
+### Workload Create
+
+Generates the Workload CR using the `openchoreo-cli`. This step reads the `workload.yaml` descriptor from your source repository and combines it with the pushed image reference:
+
+```yaml
+- name: workload-create
+  inputs:
+    parameters:
+      - name: image
+  outputs:
+    parameters:
+      - name: workload-cr
+        valueFrom:
+          path: /mnt/vol/workload-cr.yaml
+  container:
+    image: ghcr.io/openchoreo/podman-runner:v1.0
+    command: [sh, -c]
+    args:
+      - |
+        DESCRIPTOR_PATH="/mnt/vol/source/$APP_PATH"
+        podman run --rm --network=none \
+          -v "$DESCRIPTOR_PATH:/app:rw" -w /app \
+          ghcr.io/openchoreo/openchoreo-cli:latest \
+            create workload \
+            --project "$PROJECT" \
+            --component "$COMPONENT" \
+            --image "{{inputs.parameters.image}}" \
+            --descriptor "workload.yaml" \
+            -o "workload-cr.yaml"
+        cp "$DESCRIPTOR_PATH/workload-cr.yaml" /mnt/vol/workload-cr.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+      - name: workspace
+        mountPath: /mnt/vol
+```
+
+The CLI reads your `workload.yaml` descriptor, injects the image reference, and outputs a complete Workload CR. This CR is then applied by the Build Plane controller to trigger deployment.
+
+### Shared Volume
+
+All steps share a workspace volume for passing artifacts:
+
+```yaml
+volumeClaimTemplates:
+  - metadata:
+      name: workspace
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 2Gi
+```
+
+## Data Plane Pull Configuration
+
+Data Planes need credentials to pull images from your registry. Create a pull secret in the Data Plane namespace:
+
+```bash
+kubectl create secret docker-registry registry-pull-secret \
+  --docker-server=<registry-url> \
+  --docker-username=<username> \
+  --docker-password=<password> \
+  -n openchoreo-data-plane
+```
+
+Reference it in your DataPlane resource:
+
+```yaml
+spec:
+  imagePullSecretRefs:
+    - "registry-pull-secret"
+```
+
+OpenChoreo propagates this secret to workload namespaces so deployed applications can pull images.
+
+For credentials that expire (like ECR tokens), use External Secrets Operator to rotate them automatically. See [Secret Management](./secret-management.mdx).
+
+## Troubleshooting
+
+**Workflow fails at push step:**
+
+```bash
+kubectl get workflows -n openchoreo-build-plane
+kubectl logs -n openchoreo-build-plane <workflow-pod> -c main
+```
+
+Check that `registry-credentials` secret exists and contains valid credentials.
+
+**Workload creation fails:**
+Ensure your repository contains a valid `workload.yaml` at the configured `app-path`.
+
+**Data Plane cannot pull images:**
+
+```bash
+kubectl describe pod <name> -n <namespace>
+```
+
+Verify `imagePullSecretRefs` in your DataPlane resource matches the secret name.

--- a/docs/operations/deployment-topology.mdx
+++ b/docs/operations/deployment-topology.mdx
@@ -3,3 +3,195 @@ title: Deployment Topology
 description: Configure OpenChoreo's planes, organizations, and environments for your deployment.
 sidebar_position: 5
 ---
+
+# Deployment Topology
+
+OpenChoreo uses a multi-plane architecture that separates concerns between control, runtime, build, and observability. This guide covers the topology options and how planes connect.
+
+## Architecture Overview
+
+| Plane | Required | Purpose |
+|-------|----------|---------|
+| Control Plane | Yes | Central management, API, UI |
+| Data Plane | Yes | Application runtime |
+| Build Plane | No | CI/CD workflows |
+| Observability Plane | No | Logging and monitoring |
+
+## Resource Hierarchy
+
+```
+Organization
+├── Environment
+│   └── references → DataPlane
+├── DataPlane
+│   └── references → ObservabilityPlane (optional)
+├── BuildPlane
+│   └── references → ObservabilityPlane (optional)
+└── ObservabilityPlane
+```
+
+## Common Topologies
+
+### Single-Cluster
+
+All planes run in the same Kubernetes cluster with namespace isolation. Communication happens via Kubernetes ClusterIP services.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Single Kubernetes Cluster               │
+├─────────────────┬─────────────────┬─────────────────────────┤
+│ Control Plane   │ Data Plane      │ Build & Observability   │
+│ Namespace       │ Namespace       │ Namespaces              │
+└─────────────────┴─────────────────┴─────────────────────────┘
+```
+
+### Multi-Cluster
+
+Separate clusters provide isolation and independent scaling. Cluster agents establish outbound WebSocket connections to the Control Plane.
+
+```
+┌──────────────────┐     ┌──────────────────┐
+│  Control Plane   │◀────│    Data Plane    │
+│     Cluster      │     │     Cluster      │
+└────────┬─────────┘     └──────────────────┘
+         │
+         │               ┌──────────────────┐
+         │◀──────────────│   Build Plane    │
+         │               │     Cluster      │
+         │               └──────────────────┘
+         │
+         │               ┌──────────────────┐
+         └───────────────│ Observability    │
+                         │     Cluster      │
+                         └──────────────────┘
+```
+
+Setup steps:
+1. Deploy Control Plane in the primary cluster
+2. Deploy plane Helm charts in respective clusters
+3. Create plane CRDs in Control Plane with agent enabled
+4. Distribute CA certificates to each plane (see [TLS Certificates](./tls-certificates.mdx#internal-mtls-cluster-agent-communication))
+
+### Multi-Region
+
+Central Control Plane with Data Planes across regions. Each Data Plane has a unique `gateway.publicVirtualHost` (e.g., `us.apps.example.com`, `eu.apps.example.com`).
+
+```
+                    ┌──────────────────┐
+                    │  Control Plane   │
+                    │    (Central)     │
+                    └────────┬─────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         ▼                   ▼                   ▼
+┌──────────────────┐ ┌──────────────────┐ ┌──────────────────┐
+│  Data Plane US   │ │  Data Plane EU   │ │  Data Plane APAC │
+└──────────────────┘ └──────────────────┘ └──────────────────┘
+```
+
+## Plane Resources
+
+### Organizations
+
+An **Organization** is the top-level tenant resource and the only cluster-scoped resource. All other OpenChoreo resources (Environment, DataPlane, BuildPlane, ObservabilityPlane) are namespaced within an organization.
+
+A default organization (`default-organization`) is created during installation.
+
+For complete configuration options, see the [Organization API Reference](/docs/reference/api/platform/organization).
+
+### Environments
+
+An **Environment** represents a deployment stage (development, staging, production) bound to a specific DataPlane.
+
+Key considerations:
+- The `dataPlaneRef` is **immutable** - to change the DataPlane, delete and recreate the Environment
+- The `gateway.dnsPrefix` determines the subdomain for deployed applications
+
+For complete configuration options, see the [Environment API Reference](/docs/reference/api/platform/environment).
+
+### DataPlane
+
+A **DataPlane** defines where application workloads run. It requires:
+- Cluster agent configuration with CA certificate for authentication
+- Gateway configuration with public virtual host for application endpoints
+
+For complete configuration options and examples, see the [DataPlane API Reference](/docs/reference/api/platform/dataplane).
+
+### BuildPlane (Optional)
+
+A **BuildPlane** provides infrastructure for CI/CD workflows. When enabled:
+- Requires cluster agent configuration with CA certificate
+- Can reference an ObservabilityPlane for build logs
+
+For complete configuration options, see the [BuildPlane API Reference](/docs/reference/api/platform/buildplane).
+
+### ObservabilityPlane (Optional)
+
+An **ObservabilityPlane** provides logging and monitoring infrastructure. Key fields:
+- `observerURL`: The Observer service endpoint
+- `agent`: Cluster agent configuration for communication
+
+Both DataPlane and BuildPlane can reference an ObservabilityPlane via `observabilityPlaneRef`.
+
+## Linking Planes
+
+Planes reference each other in their spec:
+
+| Resource | Reference Field | Target |
+|----------|----------------|--------|
+| Environment | `dataPlaneRef` | DataPlane |
+| DataPlane | `observabilityPlaneRef` | ObservabilityPlane |
+| DataPlane | `secretStoreRef` | ClusterSecretStore |
+| BuildPlane | `observabilityPlaneRef` | ObservabilityPlane |
+
+## Verifying Resources
+
+```bash
+kubectl get organizations
+kubectl get environments -n <organization-name>
+kubectl get dataplanes -n <organization-name>
+kubectl get buildplanes -n <organization-name>
+kubectl get observabilityplanes -n <organization-name>
+```
+
+## Troubleshooting
+
+### Agent Connection Issues
+
+```bash
+# Check agent pod status
+kubectl get pods -n openchoreo-data-plane -l app.kubernetes.io/name=cluster-agent
+
+# View agent logs
+kubectl logs -n openchoreo-data-plane deployment/cluster-agent
+```
+
+### Environment Not Ready
+
+```bash
+# Check environment conditions
+kubectl describe environment <name> -n <organization-name>
+
+# Verify referenced DataPlane exists
+kubectl get dataplane <dataplane-ref> -n <organization-name>
+```
+
+### Plane Status Not Updating
+
+```bash
+# Check controller-manager logs
+kubectl logs -n openchoreo-control-plane deployment/controller-manager
+
+# View plane conditions
+kubectl get dataplane <name> -n <organization-name> -o jsonpath='{.status.conditions}'
+```
+
+## Related Documentation
+
+- [DataPlane API Reference](/docs/reference/api/platform/dataplane)
+- [BuildPlane API Reference](/docs/reference/api/platform/buildplane)
+- [Environment API Reference](/docs/reference/api/platform/environment)
+- [Organization API Reference](/docs/reference/api/platform/organization)
+- [TLS Certificates](./tls-certificates.mdx) - Certificate configuration including agent mTLS
+- [Container Registry](./container-registry.mdx) - Registry configuration for Build Plane
+- [Secret Management](./secret-management.mdx) - External secret store integration

--- a/docs/operations/prerequisites.mdx
+++ b/docs/operations/prerequisites.mdx
@@ -3,3 +3,184 @@ title: Prerequisites
 description: Requirements and prerequisites for deploying OpenChoreo in production.
 sidebar_position: 1
 ---
+
+import {versions} from '../_constants.mdx';
+
+# Prerequisites
+
+Before deploying OpenChoreo to production, ensure your environment meets the following requirements.
+
+## Kubernetes Cluster
+
+| Requirement | Specification |
+|-------------|---------------|
+| Kubernetes Version | 1.32 or later |
+| Node Count | Minimum 3 nodes (for high availability) |
+| Node Resources | 4 CPU cores, 8 GB RAM per node (minimum) |
+| RBAC | Enabled |
+| LoadBalancer | Required for external access |
+| Storage Classes | At least one default StorageClass for PersistentVolumeClaims |
+
+:::note
+For development or testing, a single-node cluster with 8 GB RAM and 4 CPU cores is sufficient. Production deployments should use a multi-node cluster with appropriate resource allocation.
+:::
+
+## Required Tools
+
+Install the following tools on your workstation:
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | 1.32+ | Kubernetes CLI |
+| [Helm](https://helm.sh/docs/intro/install/) | 3.12+ | Package manager |
+| [cert-manager](https://cert-manager.io/docs/installation/) | 1.12+ | Required on all clusters where OpenChoreo planes are deployed |
+
+## LoadBalancer Requirements
+
+OpenChoreo services require LoadBalancer with the ability to dynamically assign IPs. In production, each plane exposing services on port 443 needs a separate IP address (since multiple services cannot share the same IP:port combination).
+
+If only a single IP is available, ports can be customized per service. Refer to the [Helm Charts Reference](/docs/reference/helm/control-plane.mdx) for port configuration options.
+
+### IPs and Ports by Plane
+
+**Control Plane:**
+
+| Port | Purpose |
+|------|---------|
+| 443 | Backstage UI, OpenChoreo API, Identity Provider |
+| 80 | HTTP to HTTPS redirect (optional) |
+
+**Data Plane:**
+
+| Port | Purpose |
+|------|---------|
+| 443 | Application endpoints, deployment invocations |
+| 80 | HTTP to HTTPS redirect (optional) |
+
+**Build Plane (Optional):**
+
+- No inbound ports required
+- Only outbound connectivity needed (to Control Plane, container registry)
+
+**Observability Plane (Optional):**
+
+| Port | Purpose |
+|------|---------|
+| 443 | OpenSearch ingestion endpoint |
+
+## Cluster Agent Connectivity
+
+OpenChoreo planes communicate via **Cluster Agents** using WebSocket connections. The agent runs in each remote plane and establishes an outbound connection to the Control Plane's Cluster Gateway.
+
+**Single-Cluster Mode:**
+Communication happens via Kubernetes ClusterIP services - no external networking required between planes.
+
+**Multi-Cluster Mode:**
+Each plane's cluster agent connects outbound to the Control Plane. Only the Control Plane needs to be reachable from other clusters.
+
+```mermaid
+graph TB
+    subgraph "Control Plane Cluster"
+        CG[Cluster Gateway]
+    end
+
+    subgraph "Data Plane Cluster"
+        DPA[Cluster Agent] -->|WebSocket outbound| CG
+    end
+
+    subgraph "Build Plane Cluster (Optional)"
+        BPA[Cluster Agent] -->|WebSocket outbound| CG
+    end
+
+    subgraph "Observability Plane Cluster (Optional)"
+        OPA[Cluster Agent] -->|WebSocket outbound| CG
+    end
+```
+
+## Domain Requirements
+
+Each plane requires its own domain(s). These do not need to share a common base domain - configure each independently as needed.
+
+| Plane | Domains Required |
+|-------|------------------|
+| Control Plane | Console UI domain, API domain, Identity Provider domain |
+| Data Plane | Application endpoints domain (wildcard for dynamic apps) |
+| Build Plane (Optional) | No external domain required |
+| Observability Plane (Optional) | OpenSearch/ingestion endpoint domain |
+
+Refer to the [Helm Charts Reference](/docs/reference/helm/control-plane.mdx) for domain configuration options.
+
+:::tip
+For local development, you can use `openchoreo.localhost` as the base domain with entries in `/etc/hosts` or a local DNS resolver.
+:::
+
+## TLS Certificate Requirements
+
+| Plane | Certificate Type | Domains |
+|-------|-----------------|---------|
+| Control Plane | Standard (SAN) | Console, API, Identity Provider |
+| Data Plane | Wildcard | `*.{apps-domain}` for application endpoints |
+| Build Plane (Optional) | None required (internal only) |
+| Observability Plane (Optional) | Standard | Ingestion endpoint |
+
+See [TLS & Certificates](./tls-certificates.mdx) for detailed configuration.
+
+## Resource Requirements
+
+### Control Plane
+
+| Component | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|-------------|-----------|----------------|--------------|
+| Backstage | 200m | 2000m | 256Mi | 2Gi |
+| OpenChoreo API | 100m | 500m | 256Mi | 512Mi |
+| Controller Manager | 100m | 500m | 128Mi | 512Mi |
+| Cluster Gateway | 100m | 500m | 128Mi | 256Mi |
+
+### Data Plane
+
+| Component | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|-------------|-----------|----------------|--------------|
+| KGateway | 100m | 1000m | 128Mi | 512Mi |
+| Cluster Agent | 50m | 200m | 64Mi | 128Mi |
+
+### Build Plane (Optional)
+
+| Component | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|-------------|-----------|----------------|--------------|
+| Argo Workflows | 100m | 500m | 256Mi | 512Mi |
+| Cluster Agent | 50m | 200m | 64Mi | 128Mi |
+
+### Observability Plane (Optional)
+
+| Component | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|-------------|-----------|----------------|--------------|
+| OpenSearch | 500m | 2000m | 2Gi | 4Gi |
+| Observer | 100m | 500m | 256Mi | 512Mi |
+| Cluster Agent | 50m | 200m | 64Mi | 128Mi |
+
+## Storage Requirements
+
+| Plane | Component | Minimum Size |
+|-------|-----------|--------------|
+| Control Plane | Database | 500Mi |
+| Build Plane (Optional) | Workflow artifacts | 10Gi |
+| Observability Plane (Optional) | OpenSearch | 50Gi+ |
+
+## Pre-Installation Checklist
+
+Before proceeding with installation:
+
+- [ ] Kubernetes cluster meets version and resource requirements
+- [ ] `kubectl` and `helm` are installed and configured
+- [ ] LoadBalancer service type is available
+- [ ] Storage class is configured for PersistentVolumeClaims
+- [ ] Base domain is registered and DNS is configurable
+- [ ] TLS certificate strategy is determined (cert-manager or BYOC)
+- [ ] Network connectivity between clusters is verified (for multi-cluster)
+- [ ] Required ports are accessible through firewalls
+
+## Next Steps
+
+- [TLS & Certificates](./tls-certificates.mdx): Configure TLS for secure communication
+- [Deployment Topology](./deployment-topology.mdx): Plan your plane architecture
+- [Helm Charts Reference](/docs/reference/helm/control-plane.mdx): Explore all configuration options

--- a/docs/operations/secret-management.mdx
+++ b/docs/operations/secret-management.mdx
@@ -3,3 +3,173 @@ title: Secret Management
 description: Manage secrets and sensitive configuration in OpenChoreo.
 sidebar_position: 8
 ---
+
+# Secret Management
+
+OpenChoreo integrates with [External Secrets Operator (ESO)](https://external-secrets.io/) to synchronize secrets from external secret stores into Kubernetes. This integration allows you to:
+
+- **Bring your own secret store**: Use any ESO-supported backend (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, and [many more](https://external-secrets.io/latest/provider/))
+- **Use existing External Secrets setup**: If you already have ESO deployed, OpenChoreo can work with your existing `ClusterSecretStore` configurations
+- **Centralized secret management**: Manage all secrets in your preferred external store and let ESO sync them to Kubernetes
+
+## Enabling External Secrets Operator
+
+ESO is included as an optional dependency in the plane Helm charts. Enable it by setting `external-secrets.enabled: true` in your values:
+
+**Data Plane:**
+
+```yaml
+external-secrets:
+  enabled: true
+```
+
+**Build Plane (if needed):**
+
+```yaml
+external-secrets:
+  enabled: true
+```
+
+**Observability Plane (if needed):**
+
+```yaml
+external-secrets:
+  enabled: true
+```
+
+:::tip Single vs. Multi-Cluster
+For single-cluster deployments, you typically only need ESO enabled in one plane (usually the Data Plane). For multi-cluster deployments, enable ESO in each cluster where you need secret synchronization.
+:::
+
+## Using Your Existing External Secrets Setup
+
+If you already have External Secrets Operator deployed in your cluster with a configured `ClusterSecretStore`, you can skip enabling ESO in the OpenChoreo charts and simply reference your existing store.
+
+Configure your DataPlane to use your existing SecretStore:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: DataPlane
+metadata:
+  name: default
+  namespace: my-organization
+spec:
+  secretStoreRef:
+    name: your-existing-secret-store
+  # ... other configuration
+```
+
+## Configuring a ClusterSecretStore
+
+To connect ESO to your secret backend, create a `ClusterSecretStore` resource. For provider-specific configuration (authentication methods, endpoints, etc.), refer to the official ESO provider documentation:
+
+- **[HashiCorp Vault](https://external-secrets.io/latest/provider/hashicorp-vault/)**
+- **[AWS Secrets Manager](https://external-secrets.io/latest/provider/aws-secrets-manager/)**
+- **[GCP Secret Manager](https://external-secrets.io/latest/provider/google-secrets-manager/)**
+- **[Azure Key Vault](https://external-secrets.io/latest/provider/azure-key-vault/)**
+- **[All Supported Providers](https://external-secrets.io/latest/provider/)**
+
+**Example structure:**
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: my-secret-store
+spec:
+  provider:
+    # Provider-specific configuration
+    # See: https://external-secrets.io/latest/provider/
+```
+
+## Development Setup (Fake Provider)
+
+For development and testing, you can use the built-in fake provider which defines static secrets directly in your Helm values:
+
+```yaml
+external-secrets:
+  enabled: true
+
+fakeSecretStore:
+  enabled: true
+  name: default
+  secrets:
+    - key: github-pat
+      value: "development-token"
+    - key: docker-username
+      value: "dev-user"
+    - key: docker-password
+      value: "dev-password"
+```
+
+:::warning
+The fake provider is for development only. Never use it in production environments.
+:::
+
+## Creating ExternalSecrets
+
+Create `ExternalSecret` resources to sync specific secrets from your backend. For complete documentation on ExternalSecret configuration, see the [ESO documentation](https://external-secrets.io/latest/api/externalsecret/).
+
+**Example:**
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: my-app
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: my-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: app-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: database-url
+      remoteRef:
+        key: my-app/database
+        property: url
+```
+
+## Platform Secrets
+
+These secrets are used by OpenChoreo infrastructure components:
+
+| Secret | Purpose | Plane |
+|--------|---------|-------|
+| `backstage-backend-secret` | Backstage session encryption | Control |
+| `thunder-client-secret` | OAuth client secret | Control |
+| `cluster-agent-tls` | Agent mTLS certificates | All |
+| `registry-credentials` | Container registry auth | Build/Data |
+
+## Troubleshooting
+
+### Check ExternalSecret Status
+
+```bash
+kubectl get externalsecret -A
+kubectl describe externalsecret <name> -n <namespace>
+```
+
+### Check ClusterSecretStore Status
+
+```bash
+kubectl get clustersecretstore
+kubectl describe clustersecretstore <name>
+```
+
+### Check ESO Logs
+
+```bash
+kubectl logs -n <plane-namespace> deployment/external-secrets
+```
+
+For detailed troubleshooting guidance, see the [ESO troubleshooting documentation](https://external-secrets.io/latest/guides/troubleshooting/).
+
+## Next Steps
+
+- [Container Registry Configuration](./container-registry.mdx): Use External Secrets for registry credentials
+- [Deployment Topology](./deployment-topology.mdx): Configure SecretStore references in planes
+- [External Secrets Operator Documentation](https://external-secrets.io/): Complete ESO reference

--- a/docs/operations/tls-certificates.mdx
+++ b/docs/operations/tls-certificates.mdx
@@ -3,3 +3,427 @@ title: TLS & Certificates
 description: Configure TLS certificates for OpenChoreo using cert-manager or your own certificates.
 sidebar_position: 2
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# TLS & Certificates
+
+OpenChoreo requires TLS certificates for secure communication between components and for exposing services externally. This guide covers certificate requirements and configuration options.
+
+## Certificate Requirements per Plane
+
+Each plane's domains can be configured independently - they do not need to share a base domain.
+
+| Plane | Certificate Type | Example Domains |
+|-------|------------------|-----------------|
+| Control Plane | Standard (SAN) | `console.example.com`, `api.example.com`, `idp.example.com` |
+| Data Plane | Wildcard | `*.apps.example.com` |
+| Build Plane (Optional) | Internal only | Self-signed (auto-generated for agent mTLS) |
+| Observability Plane (Optional) | Standard | `logs.example.com` |
+
+Refer to [Helm Charts Reference](/docs/reference/helm/control-plane.mdx) for configuring specific domain names.
+
+:::important
+The Data Plane requires a **wildcard certificate** because application endpoints are dynamically generated (e.g., `myapp.apps.example.com`). Wildcard certificates can only be issued using DNS-01 challenge, not HTTP-01.
+:::
+
+## Configuration Options
+
+<Tabs groupId="tls-strategy">
+<TabItem value="cert-manager" label="cert-manager" default>
+
+### Using cert-manager
+
+[cert-manager](https://cert-manager.io/) automates certificate provisioning and renewal. OpenChoreo integrates with cert-manager for TLS certificate management.
+
+#### cert-manager Installation
+
+cert-manager is required on all clusters where OpenChoreo planes are deployed.
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+```
+
+#### ACME Solvers
+
+cert-manager supports two challenge types for domain validation:
+
+<Tabs groupId="acme-solver">
+<TabItem value="dns01" label="DNS-01 (Recommended)" default>
+
+DNS-01 is required for wildcard certificates and works in private networks.
+
+**Create a ClusterIssuer with DNS-01 solver:**
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - dns01:
+          cloudflare:
+            email: your-cloudflare-email@example.com
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+```
+
+**Supported DNS providers include:**
+- Cloudflare
+- Google Cloud DNS
+- Azure DNS
+- DigitalOcean
+- [And many more](https://cert-manager.io/docs/configuration/acme/dns01/)
+
+</TabItem>
+<TabItem value="http01" label="HTTP-01">
+
+HTTP-01 works for standard certificates but **cannot issue wildcard certificates**.
+
+**Create a ClusterIssuer with HTTP-01 solver:**
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: openchoreo-traefik
+```
+
+:::warning
+HTTP-01 cannot issue wildcard certificates. Use DNS-01 for the Data Plane if you need wildcard certificates for application endpoints.
+:::
+
+</TabItem>
+</Tabs>
+
+#### Control Plane Configuration
+
+Create a Certificate resource for the Control Plane and reference it in ingress configuration:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: control-plane-tls
+  namespace: openchoreo-control-plane
+spec:
+  secretName: control-plane-tls
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - example.com
+    - api.example.com
+    - thunder.example.com
+```
+
+#### Data Plane Configuration
+
+Configure the Data Plane gateway with a ClusterIssuer for wildcard certificates:
+
+```yaml
+tls:
+  clusterIssuer: letsencrypt-prod
+  hostname: "*.apps.example.com"
+  certName: openchoreo-gateway-tls
+```
+
+The gateway will automatically request a wildcard certificate from the specified ClusterIssuer.
+
+#### Build Plane Configuration
+
+If exposing the container registry externally, configure ingress with TLS:
+
+```yaml
+registry:
+  ingress:
+    enabled: true
+    className: "your-ingress-class"
+    hosts:
+      - host: registry.example.com
+        paths:
+          - path: /
+    tls:
+      - secretName: registry-tls
+        hosts:
+          - registry.example.com
+```
+
+</TabItem>
+<TabItem value="byoc" label="Bring Your Own Certificates">
+
+### Bring Your Own Certificates
+
+If you have existing certificates from your organization's PKI or a commercial CA, you can provide them directly.
+
+#### Certificate Format
+
+Certificates must be in PEM format:
+- **Certificate file**: Full certificate chain (server cert + intermediate CAs)
+- **Private key**: RSA or ECDSA private key
+
+#### Creating TLS Secrets
+
+Create Kubernetes TLS secrets for each plane:
+
+**Control Plane:**
+
+```bash
+kubectl create secret tls control-plane-tls \
+  --cert=path/to/fullchain.pem \
+  --key=path/to/privkey.pem \
+  -n openchoreo-control-plane
+```
+
+**Data Plane (wildcard certificate):**
+
+```bash
+kubectl create secret tls openchoreo-gateway-tls \
+  --cert=path/to/wildcard-fullchain.pem \
+  --key=path/to/wildcard-privkey.pem \
+  -n openchoreo-data-plane
+```
+
+**Build Plane:**
+
+```bash
+kubectl create secret tls registry-tls \
+  --cert=path/to/registry-fullchain.pem \
+  --key=path/to/registry-privkey.pem \
+  -n openchoreo-build-plane
+```
+
+#### Helm Configuration
+
+Reference the secrets in your Helm values:
+
+**Control Plane:**
+
+```yaml
+backstage:
+  ingress:
+    tls:
+      - secretName: control-plane-tls
+        hosts:
+          - console.example.com
+openchoreoApi:
+  ingress:
+    tls:
+      - secretName: control-plane-tls
+        hosts:
+          - api.example.com
+thunder:
+  ocIngress:
+    tls:
+      - secretName: control-plane-tls
+        hosts:
+          - idp.example.com
+```
+
+**Data Plane:**
+
+```yaml
+gateway:
+  tls:
+    clusterIssuer: ""  # Leave empty when using BYOC
+    hostname: "*.apps.example.com"
+    certName: openchoreo-gateway-tls
+```
+
+**Build Plane:**
+
+```yaml
+registry:
+  ingress:
+    tls:
+      - secretName: registry-tls
+        hosts:
+          - registry.example.com
+```
+
+#### Certificate Renewal
+
+When using BYOC, you are responsible for certificate renewal. Before certificates expire:
+
+1. Obtain new certificates from your CA
+2. Update the Kubernetes secrets:
+
+```bash
+kubectl create secret tls control-plane-tls \
+  --cert=path/to/new-fullchain.pem \
+  --key=path/to/new-privkey.pem \
+  -n openchoreo-control-plane \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+3. Restart affected pods to pick up new certificates (or wait for automatic reload)
+
+</TabItem>
+</Tabs>
+
+## Internal mTLS (Cluster Agent Communication)
+
+OpenChoreo uses mutual TLS for secure communication between the Control Plane and remote planes.
+
+**How it works:**
+
+1. Control Plane generates a CA certificate (10-year validity)
+2. CA is stored in ConfigMap `cluster-gateway-ca`
+3. Each plane's cluster agent generates a client certificate signed by this CA
+4. Cluster Gateway validates agent certificates during WebSocket connection
+
+### Single-Cluster Mode
+
+```mermaid
+graph LR
+    subgraph "Single Kubernetes Cluster"
+        CG[Cluster Gateway<br/>ClusterIP Service]
+        DPA[Data Plane Agent]
+        BPA[Build Plane Agent<br/>Optional]
+        OPA[Obs Plane Agent<br/>Optional]
+
+        DPA -->|mTLS via ClusterIP| CG
+        BPA -->|mTLS via ClusterIP| CG
+        OPA -->|mTLS via ClusterIP| CG
+    end
+```
+
+### Multi-Cluster Mode
+
+```mermaid
+graph TB
+    subgraph "Control Plane Cluster"
+        CG[Cluster Gateway<br/>LoadBalancer/Ingress]
+        CA[CA Certificate]
+        CA -->|Signs| CG
+    end
+
+    subgraph "Data Plane Cluster"
+        DPA[Cluster Agent]
+        DPC[Agent Cert<br/>Signed by CA]
+        DPC --> DPA
+        DPA -->|mTLS WebSocket| CG
+    end
+
+    subgraph "Build Plane Cluster (Optional)"
+        BPA[Cluster Agent]
+        BPC[Agent Cert<br/>Signed by CA]
+        BPC --> BPA
+        BPA -->|mTLS WebSocket| CG
+    end
+
+    subgraph "Observability Plane Cluster (Optional)"
+        OPA[Cluster Agent]
+        OPC[Agent Cert<br/>Signed by CA]
+        OPC --> OPA
+        OPA -->|mTLS WebSocket| CG
+    end
+```
+
+### Agent Certificate Configuration
+
+```yaml
+clusterAgent:
+  tls:
+    enabled: true
+    generateCerts: true
+    secretName: cluster-agent-tls
+    duration: 2160h      # 90 days
+    renewBefore: 360h    # 15 days
+```
+
+For multi-cluster, the CA certificate from Control Plane must be provided to other planes:
+
+```yaml
+clusterAgent:
+  tls:
+    enabled: true
+    generateCerts: true
+    caValue: |
+      -----BEGIN CERTIFICATE-----
+      ... (CA from Control Plane)
+      -----END CERTIFICATE-----
+```
+
+## Troubleshooting
+
+### Certificate Not Issued
+
+Check cert-manager logs and Certificate status:
+
+```bash
+# Check Certificate status
+kubectl get certificate -A
+
+# Describe a specific certificate
+kubectl describe certificate control-plane-tls -n openchoreo-control-plane
+
+# Check CertificateRequest
+kubectl get certificaterequest -A
+
+# Check cert-manager logs
+kubectl logs -n cert-manager deployment/cert-manager
+```
+
+### DNS-01 Challenge Failing
+
+Verify DNS provider credentials and permissions:
+
+```bash
+# Check ClusterIssuer status
+kubectl describe clusterissuer letsencrypt-prod
+
+# Check Challenge resources
+kubectl get challenges -A
+kubectl describe challenge <challenge-name> -n <namespace>
+```
+
+### Wildcard Certificate Issues
+
+- Ensure you're using DNS-01 solver (HTTP-01 cannot issue wildcards)
+- Verify DNS provider API credentials have permission to create TXT records
+- Check that the DNS zone matches your domain
+
+### Agent Certificate Errors
+
+For cluster agent mTLS issues:
+
+```bash
+# Check cluster agent logs
+kubectl logs -n openchoreo-data-plane deployment/cluster-agent
+
+# Verify CA ConfigMap exists
+kubectl get configmap cluster-gateway-ca -n openchoreo-control-plane
+
+# Check agent certificate
+kubectl get certificate cluster-agent-tls -n openchoreo-data-plane
+```
+
+## Next Steps
+
+- [Deployment Topology](./deployment-topology.mdx): Configure organizations, environments, and planes
+- [Identity Provider Configuration](./identity-provider/thunder.mdx): Set up authentication
+- [Helm Charts Reference](/docs/reference/helm/control-plane.mdx): Complete TLS configuration options


### PR DESCRIPTION
## Purpose
Add documentation content to the Operations Guide placeholder pages created in #187:

- **Prerequisites**: Kubernetes requirements, tools, LoadBalancer, domain, TLS, and resource requirements
- **Deployment Topology**: Multi-plane architecture, resource hierarchy, common topologies, plane resources
- **Backstage Configuration**: Core config, authentication, feature flags, resource settings, ingress
- **TLS Certificates**: External TLS, internal mTLS, cert-manager integration, troubleshooting
- **Container Registry**: Build Plane overview, registry credentials, ClusterWorkflowTemplate, Data Plane pull config
- **Secret Management**: External Secrets Operator setup, provider configurations, workload secrets

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1227

## Checklist
- [x] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)