### PR TITLE
Update cluster setup adding planeId

### DIFF
--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -281,6 +281,10 @@ The data plane gateway requires a wildcard hostname (`*.apps.openchoreo...nip.io
 
 **Register**
 
+:::important PlaneID Consistency
+The `planeID` in the DataPlane CR must match the `clusterAgent.planeId` Helm value (default: `"default-dataplane"`). If you customized `clusterAgent.planeId` during Helm installation, update the `planeID` field below to match.
+:::
+
 ```bash
 CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-data-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
 
@@ -291,8 +295,8 @@ metadata:
   name: default
   namespace: default
 spec:
-  agent:
-    enabled: true
+  planeID: "default-dataplane"
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$CA_CERT" | sed 's/^/        /')
@@ -378,6 +382,10 @@ kubectl get certificate registry-tls -n openchoreo-build-plane -w
 
 **Register**
 
+:::important PlaneID Consistency
+The `planeID` in the BuildPlane CR must match the `clusterAgent.planeId` Helm value (default: `"default-buildplane"`). If you customized `clusterAgent.planeId` during Helm installation, update the `planeID` field below to match.
+:::
+
 ```bash
 BP_CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-build-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
 
@@ -388,8 +396,8 @@ metadata:
   name: default
   namespace: default
 spec:
-  agent:
-    enabled: true
+  planeID: "default-buildplane"
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$BP_CA_CERT" | sed 's/^/        /')
@@ -421,6 +429,10 @@ kubectl get pods -n openchoreo-build-plane
 
 Register with the control plane:
 
+:::important PlaneID Consistency
+The `planeID` in the ObservabilityPlane CR must match the `clusterAgent.planeId` Helm value (default: `"default-observabilityplane"`). If you customized `clusterAgent.planeId` during Helm installation, update the `planeID` field below to match.
+:::
+
 ```bash
 OP_CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-observability-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
 
@@ -431,8 +443,8 @@ metadata:
   name: default
   namespace: default
 spec:
-  agent:
-    enabled: true
+  planeID: "default-observabilityplane"
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$OP_CA_CERT" | sed 's/^/        /')

--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -170,6 +170,10 @@ EOF
 
 Register with the control plane:
 
+:::important PlaneID Consistency
+The `planeID` in the DataPlane CR must match the `clusterAgent.planeId` Helm value (default: `"default-dataplane"`). If you customized `clusterAgent.planeId` during Helm installation, update the `planeID` field below to match.
+:::
+
 ```bash
 CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-data-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
 
@@ -180,8 +184,8 @@ metadata:
   name: default
   namespace: default
 spec:
-  agent:
-    enabled: true
+  planeID: "default-dataplane"
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$CA_CERT" | sed 's/^/        /')
@@ -253,6 +257,10 @@ The Build Plane deploys an HTTP container registry. You may need to configure tw
 
 Register with the control plane:
 
+:::important PlaneID Consistency
+The `planeID` in the BuildPlane CR must match the `clusterAgent.planeId` Helm value (default: `"default-buildplane"`). If you customized `clusterAgent.planeId` during Helm installation, update the `planeID` field below to match.
+:::
+
 ```bash
 BP_CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-build-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
 
@@ -263,8 +271,8 @@ metadata:
   name: default
   namespace: default
 spec:
-  agent:
-    enabled: true
+  planeID: "default-buildplane"
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$BP_CA_CERT" | sed 's/^/        /')
@@ -290,11 +298,14 @@ kubectl logs -n openchoreo-build-plane -l app=cluster-agent --tail=10
     --set openSearch.enabled=true \\
     --set openSearchCluster.enabled=false \\
     --set external-secrets.enabled=false \\
-    --set clusterAgent.enabled=true \\
     --timeout 10m`}
 </CodeBlock>
 
 Register with the control plane:
+
+:::important PlaneID Consistency
+The `planeID` in the ObservabilityPlane CR must match the `clusterAgent.planeId` Helm value (default: `"default-observabilityplane"`). If you customized `clusterAgent.planeId` during Helm installation, update the `planeID` field below to match.
+:::
 
 ```bash
 OP_CA_CERT=$(kubectl get secret cluster-agent-tls -n openchoreo-observability-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
@@ -306,8 +317,8 @@ metadata:
   name: default
   namespace: default
 spec:
-  agent:
-    enabled: true
+  planeID: "default-observabilityplane"
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$OP_CA_CERT" | sed 's/^/        /')
@@ -418,6 +429,7 @@ kubectl logs -n openchoreo-control-plane -l app=cluster-gateway --tail=20
 
 Common issues:
 - DataPlane/BuildPlane CR not created
+- **PlaneID mismatch**: The `planeID` in the plane CR must match the `clusterAgent.planeId` Helm value
 - CA certificate mismatch
 - Network connectivity between namespaces
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
         'operations/api-management',
         'operations/container-registry',
         'operations/secret-management',
+        'operations/cluster-agent-rbac',
         'operations/observability-alerting',
         'operations/upgrades',
       ]


### PR DESCRIPTION
## Purpose

This pull request updates the documentation for both managed and self-hosted Kubernetes setups to clarify and enforce the consistency of the `planeID` configuration between the Custom Resource (CR) manifests and Helm values for DataPlane, BuildPlane, and ObservabilityPlane. It also introduces a new troubleshooting tip for PlaneID mismatches and adds a sidebar entry for cluster agent RBAC documentation.

**Improvements to configuration documentation:**

* Added prominent notes in the registration steps for DataPlane, BuildPlane, and ObservabilityPlane CRs in both `on-managed-kubernetes.mdx` and `on-self-hosted-kubernetes.mdx` to emphasize that the `planeID` field in the CR must match the `clusterAgent.planeId` Helm value. This helps prevent misconfiguration issues. [[1]](diffhunk://#diff-c9a8095a252f4a91e10a4ffb771c8a6b7def751030d3cce0f6cffee4fcc5a134R284-R287) [[2]](diffhunk://#diff-c9a8095a252f4a91e10a4ffb771c8a6b7def751030d3cce0f6cffee4fcc5a134R385-R388) [[3]](diffhunk://#diff-c9a8095a252f4a91e10a4ffb771c8a6b7def751030d3cce0f6cffee4fcc5a134R432-R435) [[4]](diffhunk://#diff-f6a3822dc18d506605ccd62687e66b14fc7219b1a8ef4c4138ce53f4770aaca9R173-R176) [[5]](diffhunk://#diff-f6a3822dc18d506605ccd62687e66b14fc7219b1a8ef4c4138ce53f4770aaca9R260-R263) [[6]](diffhunk://#diff-f6a3822dc18d506605ccd62687e66b14fc7219b1a8ef4c4138ce53f4770aaca9L293-R309)
* Updated the example CR manifests in the documentation to use the new `planeID` and `clusterAgent` fields, replacing the deprecated `agent.enabled` field for all planes. [[1]](diffhunk://#diff-c9a8095a252f4a91e10a4ffb771c8a6b7def751030d3cce0f6cffee4fcc5a134L294-R299) [[2]](diffhunk://#diff-c9a8095a252f4a91e10a4ffb771c8a6b7def751030d3cce0f6cffee4fcc5a134L391-R400) [[3]](diffhunk://#diff-c9a8095a252f4a91e10a4ffb771c8a6b7def751030d3cce0f6cffee4fcc5a134L434-R447) [[4]](diffhunk://#diff-f6a3822dc18d506605ccd62687e66b14fc7219b1a8ef4c4138ce53f4770aaca9L183-R188) [[5]](diffhunk://#diff-f6a3822dc18d506605ccd62687e66b14fc7219b1a8ef4c4138ce53f4770aaca9L266-R275) [[6]](diffhunk://#diff-f6a3822dc18d506605ccd62687e66b14fc7219b1a8ef4c4138ce53f4770aaca9L309-R321)

**Troubleshooting and navigation enhancements:**

* Added a new troubleshooting bullet for PlaneID mismatch to the common issues section in `on-self-hosted-kubernetes.mdx`.
* Added a new sidebar entry for cluster agent RBAC documentation to improve navigation.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
