### PR TITLE
Add JWKS URL to Observability plane helm install command in self-hosted deployment

### DIFF
--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -297,6 +297,7 @@ kubectl logs -n openchoreo-build-plane -l app=cluster-agent --tail=10
     --create-namespace \\
     --set openSearch.enabled=true \\
     --set openSearchCluster.enabled=false \\
+    --set security.oidc.jwksUrl="http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090/oauth2/jwks" \\
     --set external-secrets.enabled=false \\
     --timeout 10m`}
 </CodeBlock>


### PR DESCRIPTION
## Purpose
Update the observability plane helm install command in the self hosted deployment to set the JWKS URL

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1306

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
