### PR TITLE
Set JWKS URL in managed K8s observability plane deployment command

### DIFF
--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -422,6 +422,7 @@ kubectl get pods -n openchoreo-build-plane
     --create-namespace \\
     --set openSearch.enabled=true \\
     --set openSearchCluster.enabled=false \\
+    --set security.oidc.jwksUrl="https://thunder.\${CP_DOMAIN}/oauth2/jwks" \\
     --set external-secrets.enabled=false \\
     --set clusterAgent.enabled=true \\
     --timeout 10m`}


### PR DESCRIPTION
## Purpose
Update the observability plane helm install command in the managed Kubernetes deployment to set the JWKS URL

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1306

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
