### PR TITLE
Updates wait condition in self-hosted k8s guide

### DIFF
--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -124,10 +124,11 @@ Common configurations:
     --set thunder.configuration.gateClient.scheme="http"`}
 </CodeBlock>
 
-Wait for pods to be ready:
+Wait for deployment to be ready:
 
 ```bash
-kubectl get pods -n openchoreo-control-plane -w
+kubectl wait -n openchoreo-control-plane --for=condition=available --timeout=300s deployment --all
+kubectl wait -n openchoreo-control-plane --for=condition=complete  job --all
 ```
 
 ---


### PR DESCRIPTION
## Purpose
$Subejct. Earlier wait condition was faulty

## Related Issues


## Checklist
- [x] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
