### PR TITLE
Update self managed installation docs for control plane kgateway

### DIFF
--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -117,19 +117,24 @@ Common configurations:
 
 ## Step 1: Setup Control Plane
 
+:::note macOS Users
+Due to Rosetta emulation issues, macOS users (Rancher Desktop, Docker Desktop, k3d, kind, or Colima) should add `--set gateway.envoy.mountTmpVolume=true`. Non-macOS users can omit this flag if needed.
+:::
+
 <CodeBlock language="bash">
-{`helm upgrade --install openchoreo-control-plane ${versions.helmSource}/openchoreo-control-plane \\
+  {`helm upgrade --install openchoreo-control-plane ${versions.helmSource}/openchoreo-control-plane \\
     --version ${versions.helmChart} \\
     --namespace openchoreo-control-plane \\
     --create-namespace \\
     --set global.baseDomain=openchoreo.localhost \\
     --set global.port=":8080" \\
-    --set traefik.ports.web.exposedPort=8080 \\
-    --set traefik.ports.websecure.exposedPort=8443 \\
+    --set gateway.httpPort=80 \\
+    --set gateway.httpsPort=443 \\
     --set thunder.configuration.server.publicUrl=http://thunder.openchoreo.localhost:8080 \\
     --set thunder.configuration.gateClient.hostname=thunder.openchoreo.localhost \\
     --set thunder.configuration.gateClient.port=8080 \\
-    --set thunder.configuration.gateClient.scheme="http"`}
+    --set thunder.configuration.gateClient.scheme="http" \\
+    --set gateway.envoy.mountTmpVolume=true`}
 </CodeBlock>
 
 Wait for deployment to be ready:
@@ -137,6 +142,25 @@ Wait for deployment to be ready:
 ```bash
 kubectl wait -n openchoreo-control-plane --for=condition=available --timeout=300s deployment --all
 kubectl wait -n openchoreo-control-plane --for=condition=complete  job --all
+```
+
+Create a Certificate for Gateway TLS:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: control-plane-tls
+  namespace: openchoreo-control-plane
+spec:
+  secretName: control-plane-tls
+  issuerRef:
+    name: openchoreo-selfsigned-issuer
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.openchoreo.localhost"
+EOF
 ```
 
 ---
@@ -148,14 +172,16 @@ Due to Rosetta emulation issues, macOS users (Rancher Desktop, Docker Desktop, k
 :::
 
 <CodeBlock language="bash">
-{`helm upgrade --install openchoreo-data-plane ${versions.helmSource}/openchoreo-data-plane \\
+  {`helm upgrade --install openchoreo-data-plane ${versions.helmSource}/openchoreo-data-plane \\
     --version ${versions.helmChart} \\
     --namespace openchoreo-data-plane \\
     --create-namespace \\
     --set gateway.httpPort=19080 \\
     --set gateway.httpsPort=19443 \\
     --set external-secrets.enabled=true \\
-    --set gateway.envoy.mountTmpVolume=true`}
+    --set gatewayController.enabled=false \\
+    --set gateway.envoy.mountTmpVolume=true \\
+    --set gateway.selfSignedIssuer.enabled=false`}
 </CodeBlock>
 
 Create a Certificate for Gateway TLS:


### PR DESCRIPTION
## Purpose
This PR updates the self managed k8s installation docs related to Kgateway for Ingress.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1386

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
