### PR TITLE
Add instructions on how to generate machine id required by fluent-bit

### DIFF
--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -63,6 +63,23 @@ This creates a cluster named `openchoreo` with:
 - Port mappings: Control Plane (8080/8443), Data Plane (19080/19443), Build Plane (10081)
 - kubectl context set to `k3d-openchoreo`
 
+:::note Generate machine id (Required if Observability will be enabled)
+
+Fluent Bit (used for observability log collection) requires a unique Machine ID (/etc/machine-id) to start. By default, k3d node containers do not generate this file.
+If you are enabling observability, you must manually generate this ID on every node in your cluster before installation:
+
+```bash
+docker exec <node name> sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+```
+
+For example, to generate the machine ID for the k3d-openchoreo-op-server-0 node:
+
+```bash
+docker exec k3d-openchoreo-op-server-0 sh -c "cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id"
+```
+
+:::
+
 **Install cert-manager**
 
 ```bash


### PR DESCRIPTION
## Purpose
Fluent Bit requires a machine id to identify hosts uniquely. k3d nodes do not generate this by default and needs to be generated manually. This PR adds the instructions to do so.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/689

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
