### PR TITLE
Add instructions for enabling logs collection in self-hosted guide

### DIFF
--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -376,6 +376,16 @@ kubectl get observabilityplane -n default
 kubectl logs -n openchoreo-observability-plane -l app=cluster-agent --tail=10
 ```
 
+Enable logs collection:
+<CodeBlock language="bash">
+{`helm upgrade --install openchoreo-observability-plane ${versions.helmSource}/openchoreo-observability-plane \\
+    --version ${versions.helmChart} \\
+    --namespace openchoreo-observability-plane \\
+    --reuse-values \\
+    --set fluent-bit.enabled=true \\
+    --timeout 10m`}
+</CodeBlock>
+
 ---
 
 ## Access OpenChoreo
@@ -492,4 +502,3 @@ If you see "Failed to create temporary file" errors:
 ```bash
 helm upgrade openchoreo-data-plane ... --set gateway.envoy.mountTmpVolume=true
 ```
-


### PR DESCRIPTION
## Purpose
Fluent-Bit is disabled in all planes by default. This change add instruction to enable logs collection in the single cluster setup after installing optional observability plane

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
