### PR TITLE
Fix gateway service names and cert-manager config for kgateway

### DIFF
--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -37,13 +37,24 @@ kubectl auth can-i '*' '*' --all-namespaces
 ```
 
 <details>
-<summary>Install cert-manager</summary>
+<summary>Install cert-manager with Gateway API support</summary>
+
+Install Gateway API CRDs (required for cert-manager to issue certificates via Gateway):
+
+```bash
+kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml"
+```
+
+Install cert-manager with Gateway API support enabled:
 
 ```bash
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
     --namespace cert-manager \
     --create-namespace \
-    --set crds.enabled=true
+    --set crds.enabled=true \
+    --set config.apiVersion="controller.config.cert-manager.io/v1alpha1" \
+    --set config.kind="ControllerConfiguration" \
+    --set config.enableGatewayAPI=true
 ```
 
 Wait for cert-manager to be ready:
@@ -77,7 +88,7 @@ This installs:
 - `backstage`: the web console for managing your platform.
 - `thunder`: built-in identity provider handling authentication and OAuth flows.
 - `cluster-gateway`: accepts WebSocket connections from cluster-agents in remote planes.
-- `Kgateway`: Gateway controller for routing external traffic to services.
+- `kgateway`: gateway controller for routing external traffic to services.
 - OpenChoreo CRDs: Organization, Project, Component, Environment, DataPlane, BuildPlane, and others that define the platform's API.
 
 The control plane is OpenChoreo's brain. In production, you'd typically run this in its own dedicated cluster, isolated from your workloads.
@@ -92,13 +103,13 @@ For all available configuration options, see the [Control Plane Helm Reference](
 Wait for LoadBalancer to get an external IP (press Ctrl+C once EXTERNAL-IP appears):
 
 ```bash
-kubectl get svc openchoreo-traefik -n openchoreo-control-plane -w
+kubectl get svc gateway-default -n openchoreo-control-plane -w
 ```
 
 Get the IP address:
 
 ```bash
-CP_LB_IP=$(kubectl get svc openchoreo-traefik -n openchoreo-control-plane -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+CP_LB_IP=$(kubectl get svc gateway-default -n openchoreo-control-plane -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
 
 </TabItem>
@@ -109,20 +120,20 @@ EKS LoadBalancers are private by default and return a hostname instead of an IP.
 Make the LoadBalancer internet-facing:
 
 ```bash
-kubectl patch svc openchoreo-traefik -n openchoreo-control-plane \
+kubectl patch svc gateway-default -n openchoreo-control-plane \
   -p '{"metadata":{"annotations":{"service.beta.kubernetes.io/aws-load-balancer-scheme":"internet-facing"}}}'
 ```
 
 Wait for the new LoadBalancer to be provisioned (this may take 1-2 minutes). Press Ctrl+C once EXTERNAL-IP (hostname) appears:
 
 ```bash
-kubectl get svc openchoreo-traefik -n openchoreo-control-plane -w
+kubectl get svc gateway-default -n openchoreo-control-plane -w
 ```
 
 Get the hostname and resolve to IP:
 
 ```bash
-CP_LB_HOSTNAME=$(kubectl get svc openchoreo-traefik -n openchoreo-control-plane -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+CP_LB_HOSTNAME=$(kubectl get svc gateway-default -n openchoreo-control-plane -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 CP_LB_IP=$(dig +short $CP_LB_HOSTNAME | head -1)
 ```
 
@@ -155,8 +166,10 @@ spec:
       name: letsencrypt-http01
     solvers:
       - http01:
-          ingress:
-            ingressClassName: openchoreo-traefik
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: gateway-default
+                namespace: openchoreo-control-plane
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -220,7 +233,7 @@ This upgrades the control plane with these settings:
 
 This installs the data plane into the `openchoreo-data-plane` namespace, with these settings:
 
-- `gateway.httpPort` and `gateway.httpsPort`: the ports where the Kgateway listens for traffic to your applications.
+- `gateway.httpPort` and `gateway.httpsPort`: the ports where KGateway listens for traffic to your applications.
 
 This installs:
 
@@ -393,8 +406,10 @@ spec:
       name: letsencrypt-http01
     solvers:
       - http01:
-          ingress:
-            ingressClassName: openchoreo-traefik
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: gateway-default
+                namespace: openchoreo-control-plane
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -155,7 +155,7 @@ This installs the control plane into the `openchoreo-control-plane` namespace, w
 
 - `global.baseDomain`: the base domain for all services. The console will be at `openchoreo.localhost`, the API at `api.openchoreo.localhost`.
 - `global.port`: appended to URLs since we're using non-standard port 8080.
-- `gateway.httpPort` and `gateway.httpsPort`: the ports the ingress listens on.
+- `gateway.httpPort` and `gateway.httpsPort`: the ports where KGateway listens for incoming traffic.
 - `thunder.configuration.*`: configures Thunder, the built-in identity provider. These settings tell Thunder where it's accessible and how to reach the API gateway.
 
 This installs:
@@ -165,7 +165,7 @@ This installs:
 - `backstage`: the web console for managing your platform.
 - `thunder`: built-in identity provider handling authentication and OAuth flows.
 - `cluster-gateway`: accepts WebSocket connections from cluster-agents in remote planes.
-- `Kgateway`: Gateway controller for routing external traffic to services.
+- `kgateway`: gateway controller for routing external traffic to services.
 - OpenChoreo CRDs: Organization, Project, Component, Environment, DataPlane, BuildPlane, and others that define the platform's API.
 
 The control plane is OpenChoreo's brain. In production, you'd typically run this in its own dedicated cluster, isolated from your workloads.
@@ -215,7 +215,7 @@ EOF
 
 This installs the data plane into the `openchoreo-data-plane` namespace, with these settings:
 
-- `gateway.httpPort` and `gateway.httpsPort`: the ports where the Kgateway listens for traffic to your applications. We use 19080/19443 to keep it distinct from the control plane's ports.
+- `gateway.httpPort` and `gateway.httpsPort`: the ports where KGateway listens for traffic to your applications. We use 19080/19443 to keep it distinct from the control plane's ports.
 - `external-secrets.enabled`: installs the External Secrets Operator for syncing secrets from external stores.
 - `gateway.envoy.mountTmpVolume`: fixes Envoy crashes on macOS. Non-macOS users can omit this flag.
 


### PR DESCRIPTION
## Summary

Follow-up fixes for the kgateway migration in try-it-out guides:

- **Service name updates**: Change `openchoreo-traefik` to `gateway-default` in kubectl commands (the actual service name created by kgateway)
- **cert-manager Gateway API support**: Update HTTP-01 solver to use `gatewayHTTPRoute` instead of `ingressClassName` (required for Gateway API)
- **cert-manager prerequisites**: Add Gateway API CRDs installation and `enableGatewayAPI=true` flag
- **Consistent capitalization**: Use lowercase `kgateway` in backticks, "KGateway" in prose

## Changes

### on-managed-kubernetes.mdx
- Update cert-manager installation to include Gateway API CRDs and enable Gateway API support
- Change service references from `openchoreo-traefik` to `gateway-default`
- Update cert-manager Issuer to use `gatewayHTTPRoute` solver instead of `ingressClassName`
- Fix capitalization: `Kgateway` → `kgateway` (in backticks), `Kgateway` → `KGateway` (in prose)

### on-self-hosted-kubernetes.mdx
- Fix capitalization: `Kgateway` → `kgateway` (in backticks), `Kgateway` → `KGateway` (in prose)
- Add "KGateway" context to port descriptions

## Why these changes?

1. The control plane gateway service is named `gateway-default` (from the Gateway resource metadata.name in the helm chart), not `openchoreo-traefik`
2. cert-manager requires `config.enableGatewayAPI=true` and Gateway API CRDs to use the `gatewayHTTPRoute` HTTP-01 solver
3. The `ingressClassName` solver doesn't work with kgateway since it uses Gateway API, not Ingress API

## Test plan
- [ ] Verify cert-manager installation commands work with Gateway API support
- [ ] Verify `kubectl get svc gateway-default` returns the correct service
- [ ] Verify Let's Encrypt certificate issuance works with gatewayHTTPRoute solver

🤖 Generated with [Claude Code](https://claude.com/claude-code)