### PR TITLE
Fix LLM copy menu on mobile view

### DIFF
--- a/src/theme/DocBreadcrumbs/MarkdownButton.tsx
+++ b/src/theme/DocBreadcrumbs/MarkdownButton.tsx
@@ -89,6 +89,8 @@ export default function MarkdownButton({ markdownUrl }: MarkdownButtonProps): JS
       </button>
 
       {isOpen && (
+        <>
+        <div className={styles.mobileBackdrop} onClick={() => setIsOpen(false)} />
         <div className={styles.dropdownMenu}>
           <button className={styles.dropdownItem} onClick={handleCopyPage}>
             <CopyIcon />
@@ -135,6 +137,7 @@ export default function MarkdownButton({ markdownUrl }: MarkdownButtonProps): JS
             <ExternalIcon />
           </button>
         </div>
+        </>
       )}
     </div>
   );

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -126,3 +126,42 @@
 [data-theme='dark'] .dropdownItem:hover {
   background-color: var(--ifm-color-emphasis-200);
 }
+
+/* Mobile backdrop - hidden by default */
+.mobileBackdrop {
+  display: none;
+}
+
+/* Mobile responsive styles */
+@media (max-width: 768px) {
+  .mobileBackdrop {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+  }
+
+  .dropdownMenu {
+    position: fixed;
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    min-width: unset;
+    width: 100%;
+    border-radius: 16px 16px 0 0;
+    max-height: 70vh;
+    overflow-y: auto;
+    padding: 1rem;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+    z-index: 1000;
+  }
+
+  .dropdownItem {
+    padding: 0.875rem 1rem;
+  }
+}


### PR DESCRIPTION
Fixes the LLM copy menu dropdown that was overlapping with page content on mobile devices. The dropdown now displays as a bottom sheet that slides up from the bottom of the screen with a semi-transparent backdrop overlay, providing a better mobile user experience.

Related issue: https://github.com/openchoreo/openchoreo/issues/1405