### PR TITLE
Fix DataPlane/BuildPlane CRD docs to use clusterAgent instead of agent

### DIFF
--- a/docs/operations/multi-cluster-connectivity.mdx
+++ b/docs/operations/multi-cluster-connectivity.mdx
@@ -176,8 +176,7 @@ metadata:
   name: production-us-east
   namespace: default  # Or your organization's namespace
 spec:
-  agent:
-    enabled: true
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$AGENT_CERT" | sed 's/^/        /')
@@ -297,4 +296,4 @@ If the Control Plane rejects the agent's connection:
 kubectl logs -n openchoreo-control-plane deployment/controller-manager
 ```
 
-Ensure the DataPlane/BuildPlane/ObservabilityPlane CRD has the correct agent certificate in `spec.agent.clientCA.value`
+Ensure the DataPlane/BuildPlane/ObservabilityPlane CRD has the correct agent certificate in `spec.clusterAgent.clientCA.value`

--- a/docs/reference/configuration-schema.md
+++ b/docs/reference/configuration-schema.md
@@ -88,32 +88,37 @@ metadata:
   name: string                    # Required: DataPlane name
   namespace: string               # Required: Organization namespace
 spec:
+  # Plane identifier for multi-tenancy scenarios
+  planeID: string                 # Optional: Defaults to CR name. Max 63 chars, lowercase alphanumeric with hyphens.
+
+  # Cluster Agent Configuration (mandatory for secure communication)
+  clusterAgent:                   # Required: Cluster agent communication config
+    clientCA:                     # Required: CA certificate for verifying agent's client cert
+      secretRef:                  # Optional: Reference to secret containing CA cert
+        name: string              # Required: Secret name
+        namespace: string         # Optional: Secret namespace (defaults to parent's namespace)
+        key: string               # Required: Key within the secret
+      value: string               # Optional: Inline CA certificate value
+
   # API Gateway Configuration
   gateway:                        # Required: Gateway configuration
-    organizationVirtualHost: string  # Required: Organization virtual host
     publicVirtualHost: string     # Required: Public virtual host
-  
-  # Kubernetes Cluster Configuration
-  kubernetesCluster:              # Required: Target cluster
-    name: string                  # Required: Cluster name
-    credentials:                  # Required: Authentication details
-      apiServerURL: string        # Required: Kubernetes API server URL
-      caCert: string              # Required: Base64-encoded CA certificate
-      clientCert: string          # Required: Base64-encoded client certificate
-      clientKey: string           # Required: Base64-encoded client private key
-  
-  # Container Registry Configuration
-  registry:                       # Required: Registry configuration
-    prefix: string                # Required: Registry domain and namespace
-    secretRef: string             # Optional: Registry credentials secret
-  
-  # Observer API Integration
-  observer:                       # Optional: Observer API
-    url: string                   # Required: Observer API base URL
-    authentication:               # Required: Authentication
-      basicAuth:                  # Required: Basic auth credentials
-        username: string          # Required: Username
-        password: string          # Required: Password
+    organizationVirtualHost: string  # Required: Organization virtual host
+    publicHTTPPort: integer       # Optional: Default 19080
+    publicHTTPSPort: integer      # Optional: Default 19443
+    organizationHTTPPort: integer # Optional: Default 19081
+    organizationHTTPSPort: integer # Optional: Default 19444
+
+  # Image Pull Secrets
+  imagePullSecretRefs:            # Optional: References to SecretReference resources
+    - string
+
+  # External Secrets Operator Integration
+  secretStoreRef:                 # Optional: ESO ClusterSecretStore reference
+    name: string                  # Required: ClusterSecretStore name
+
+  # Observability Integration
+  observabilityPlaneRef: string   # Optional: Reference to ObservabilityPlane
 
 status:
   conditions:                     # Standard Kubernetes conditions
@@ -134,22 +139,24 @@ metadata:
   name: string                    # Required: BuildPlane name
   namespace: string               # Required: Organization namespace
 spec:
-  # Kubernetes Cluster for Build Workloads
-  kubernetesCluster:              # Required: Build cluster
-    name: string                  # Required: Cluster name
-    credentials:                  # Required: Same structure as DataPlane
-      apiServerURL: string
-      caCert: string
-      clientCert: string
-      clientKey: string
-  
-  # Observer API Integration (Optional)
-  observer:                       # Optional: Same structure as DataPlane
-    url: string
-    authentication:
-      basicAuth:
-        username: string
-        password: string
+  # Plane identifier for multi-tenancy scenarios
+  planeID: string                 # Optional: Defaults to CR name. Max 63 chars, lowercase alphanumeric with hyphens.
+
+  # Cluster Agent Configuration (mandatory for secure communication)
+  clusterAgent:                   # Required: Cluster agent communication config
+    clientCA:                     # Required: CA certificate for verifying agent's client cert
+      secretRef:                  # Optional: Reference to secret containing CA cert
+        name: string              # Required: Secret name
+        namespace: string         # Optional: Secret namespace
+        key: string               # Required: Key within the secret
+      value: string               # Optional: Inline CA certificate value
+
+  # External Secrets Operator Integration
+  secretStoreRef:                 # Optional: ESO ClusterSecretStore reference
+    name: string                  # Required: ClusterSecretStore name
+
+  # Observability Integration
+  observabilityPlaneRef: string   # Optional: Reference to ObservabilityPlane
 
 status: {}                        # Minimal status implementation
 ```

--- a/versioned_docs/version-v0.11.x/operations/multi-cluster-connectivity.mdx
+++ b/versioned_docs/version-v0.11.x/operations/multi-cluster-connectivity.mdx
@@ -176,8 +176,7 @@ metadata:
   name: production-us-east
   namespace: default  # Or your organization's namespace
 spec:
-  agent:
-    enabled: true
+  clusterAgent:
     clientCA:
       value: |
 $(echo "$AGENT_CERT" | sed 's/^/        /')
@@ -297,4 +296,4 @@ If the Control Plane rejects the agent's connection:
 kubectl logs -n openchoreo-control-plane deployment/controller-manager
 ```
 
-Ensure the DataPlane/BuildPlane/ObservabilityPlane CRD has the correct agent certificate in `spec.agent.clientCA.value`
+Ensure the DataPlane/BuildPlane/ObservabilityPlane CRD has the correct agent certificate in `spec.clusterAgent.clientCA.value`


### PR DESCRIPTION
fixes field mismatch from https://github.com/openchoreo/openchoreo/issues/1501

docs were still showing `spec.agent.enabled` and `kubernetesCluster` fields but the API changed to `spec.clusterAgent` in https://github.com/openchoreo/openchoreo/pull/1294. users following the multi-cluster guide would get invalid CRD errors.

changes:
- multi-cluster-connectivity.mdx: `spec.agent` → `spec.clusterAgent`, removed `enabled` field
- configuration-schema.md: replaced `kubernetesCluster` with `clusterAgent` for DataPlane and BuildPlane schemas
- added missing fields like `planeID`, gateway ports, `imagePullSecretRefs`, `secretStoreRef`
- same fixes in v0.11.x versioned docs

relates to https://github.com/openchoreo/openchoreo/pull/1294