### PR TITLE
Update Alerts documentation with webhook notification channel support

### DIFF
--- a/docs/operations/observability-alerting.mdx
+++ b/docs/operations/observability-alerting.mdx
@@ -337,6 +337,12 @@ OpenChoreo currently supports the following notification channel types:
 - **Webhook**: Sends alerts as HTTP POST requests to an external endpoint.
 
 #### Email Notification Channel Example
+
+Email templates support CEL expressions for dynamic content.
+Available CEL variables for templates include: `${alertName}`, `${alertSeverity}`, `${alertDescription}`,
+`${alertValue}`, `${alertTimestamp}`, `${alertThreshold}`, `${alertType}`, `${component}`, `${project}`,
+`${environment}`, `${componentId}`, `${projectId}`, `${environmentId}`, and `${alertAIRootCauseAnalysisEnabled}`.
+
 ```yaml
 apiVersion: openchoreo.dev/v1alpha1
 kind: ObservabilityAlertsNotificationChannel
@@ -382,7 +388,11 @@ spec:
 
 Use a webhook notification channel to deliver alerts to an HTTP endpoint
 (for example, a custom incident management system, notification system such as Slack, or a chatops bridge).
-The payloadTemplate can be templated using CEL expressions.
+The `payloadTemplate` can be templated using CEL expressions. If `payloadTemplate` is omitted, the full alert payload is sent as JSON.
+
+Available CEL variables for templates include: `${alertName}`, `${alertSeverity}`, `${alertDescription}`,
+`${alertValue}`, `${alertTimestamp}`, `${alertThreshold}`, `${alertType}`, `${component}`, `${project}`,
+`${environment}`, `${componentId}`, `${projectId}`, `${environmentId}`, and `${alertAIRootCauseAnalysisEnabled}`.
 
 ```yaml
 apiVersion: openchoreo.dev/v1alpha1


### PR DESCRIPTION
## Purpose
This pull request updates the documentation for `ObservabilityAlertsNotificationChannel` to add support for webhook-based notifications in addition to email, and restructures the configuration fields to be more explicit and type-specific. The changes clarify supported notification types, provide configuration examples, and expand the API reference to include webhook-specific fields and templating.

**Notification channel type support and configuration:**

* Added support for `webhook` notification channels alongside `email`, and updated all documentation to reflect both types as supported. [[1]](diffhunk://#diff-a08beb03aeb4d2a853a9c0684e55aa5f72ee7cf74f39c9016cf8694be51d0ebfR334-R339) [[2]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L13-R13) [[3]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L39-R90)
* Changed the channel configuration field from a generic `config` to `emailConfig` (for email) and `webhookConfig` (for webhook), with required fields and examples for each. [[1]](diffhunk://#diff-a08beb03aeb4d2a853a9c0684e55aa5f72ee7cf74f39c9016cf8694be51d0ebfL344-R350) [[2]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L39-R90) [[3]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L122-R137)

**Webhook notification details:**

* Added a detailed example and documentation for configuring a webhook notification channel, including fields for `url`, `headers` (with secret support), and `payloadTemplate` for custom payloads using CEL expressions. [[1]](diffhunk://#diff-a08beb03aeb4d2a853a9c0684e55aa5f72ee7cf74f39c9016cf8694be51d0ebfR381-R415) [[2]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L39-R90)

**Email notification configuration updates:**

* Made `template`, `auth`, and `tls` required fields for `emailConfig`, and provided an updated example with these fields. [[1]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L39-R90) [[2]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790L122-R137) [[3]](diffhunk://#diff-9f664b77511c07b7bb456087d8f83b0d22a6bd04e93095e85873813fc7a4f790R154-R155)

**API reference improvements:**

* Expanded the API reference to include new types (`WebhookConfig`, `WebhookHeaderValue`), clarified required fields, and improved descriptions for both email and webhook channel configurations.

These changes make notification channel configuration more flexible and extensible, and provide clear, actionable documentation for platform engineers.

Related code changes:  https://github.com/openchoreo/openchoreo/pull/1537


## Related Issues
https://github.com/openchoreo/openchoreo/issues/1385

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
