### PR TITLE
Fix control plane namespace label

### DIFF
--- a/docs/concepts/platform-abstractions.md
+++ b/docs/concepts/platform-abstractions.md
@@ -14,7 +14,7 @@ compliance.
 
 OpenChoreo uses Kubernetes namespaces to organize and isolate groups of related resources. Namespace-scoped resources such as projects, environments, dataplanes, and deployment pipelines are created within namespaces, enabling platform teams to organize resources by department, team, application domain, or any other logical grouping. OpenChoreo also supports cluster-scoped resources that can be referenced across namespaces, providing flexibility in resource organization while leveraging native Kubernetes isolation, RBAC, and resource management capabilities.
 
-OpenChoreo identifies and manages namespaces through a label (`openchoreo.dev/managed-by: control-plane`). The control plane uses this label to discover namespaces, perform list/get operations, and organize platform resources. When an OpenChoreo cluster is created, the default namespace is automatically labeled with this identifier, enabling immediate platform resource creation.
+OpenChoreo identifies and manages namespaces through a label (`openchoreo.dev/controlplane-namespace: true`). The control plane uses this label to discover namespaces, perform list/get operations, and organize platform resources. When an OpenChoreo cluster is created, the default namespace is automatically labeled with this identifier, enabling immediate platform resource creation.
 
 ## Infrastructure Planes
 

--- a/docs/getting-started/quick-start-guide.mdx
+++ b/docs/getting-started/quick-start-guide.mdx
@@ -174,7 +174,7 @@ The setup uses a preconfigured Dev Container that includes all required dependen
 
     The installation automatically provisions the following OpenChoreo abstractions:
 
-    - Namespace (Kubernetes namespace labeled with `openchoreo.dev/managed-by: control-plane`)
+    - Namespace (Kubernetes namespace labeled with `openchoreo.dev/controlplane-namespace: true`)
     - Data Plane
     - Build Plane
     - Environments (e.g., Development, Staging, Production)
@@ -185,7 +185,7 @@ The setup uses a preconfigured Dev Container that includes all required dependen
     View these resources using the following commands:
 
     ```bash
-    kubectl get namespaces -l openchoreo.dev/managed-by=control-plane
+    kubectl get namespaces -l openchoreo.dev/controlplane-namespace=true
     kubectl get dataplanes
     kubectl get environments
     kubectl get projects

--- a/docs/operations/deployment-topology.mdx
+++ b/docs/operations/deployment-topology.mdx
@@ -300,7 +300,7 @@ Central Control Plane with Data Planes across regions. Each Data Plane has a uni
 
 Kubernetes **Namespace**s are used to group resources. OpenChoreo resources such as Environment, DataPlane, BuildPlane, ObservabilityPlane are created within a namespace.
 
-OpenChoreo identifies and manages namespaces using the label `openchoreo.dev/managed-by: control-plane`. The control plane discovers namespaces, performs list/get operations, and organizes platform resources based on this label. During installation, a default namespace is automatically created and labeled, enabling immediate use for organizing platform resources.
+OpenChoreo identifies and manages namespaces using the label `openchoreo.dev/controlplane-namespace: true`. The control plane discovers namespaces, performs list/get operations, and organizes platform resources based on this label. During installation, a default namespace is automatically created and labeled, enabling immediate use for organizing platform resources.
 
 **Creating Additional Namespaces**
 
@@ -308,7 +308,7 @@ To create additional namespaces for organizing resources:
 
 ```bash
 kubectl create namespace <namespace-name>
-kubectl label namespace <namespace-name> openchoreo.dev/managed-by=control-plane
+kubectl label namespace <namespace-name> openchoreo.dev/controlplane-namespace=true
 ```
 
 ### Environments


### PR DESCRIPTION
## Purpose
This PR corrects the OC controlplane namespace identifying label.
Correct label: `openchoreo.dev/controlplane-namespace: true`

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1521

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
