### PR TITLE
Update quick start guide invoke url ports

### DIFF
--- a/docs/getting-started/quick-start-guide.mdx
+++ b/docs/getting-started/quick-start-guide.mdx
@@ -110,7 +110,7 @@ The setup uses a preconfigured Dev Container that includes all required dependen
 
     ```text
     [SUCCESS] React Starter web application is ready!
-    🌍 Access the application at: http://react-starter-development.openchoreoapis.localhost:9080
+    🌍 Access the application at: http://react-starter-development.openchoreoapis.localhost:19080
     Open this URL in your browser to see the React starter application.
 
     [INFO] To clean up and delete this application, run:
@@ -223,7 +223,7 @@ The setup uses a preconfigured Dev Container that includes all required dependen
 
     :::important
     When running samples in the Dev Container, you don't need to expose the OpenChoreo Gateway manually; it's already
-    available on port 9080 (HTTP) and port 9443 (HTTPS) of the host machine.
+    available on port 19080 (HTTP) and port 19443 (HTTPS) of the host machine.
     :::
 </div>
 


### PR DESCRIPTION
## Purpose
This pull request updates the documentation to reflect new port numbers for accessing the React Starter web application and the OpenChoreo Gateway. The changes ensure that users have accurate instructions for accessing services in the development environment.

**Documentation updates:**

* Updated the example application URL in the quick start guide to use port `19080` instead of `9080` for accessing the React Starter web application.
* Changed the documented OpenChoreo Gateway ports from `9080`/`9443` to `19080`/`19443` to match the new configuration in the Dev Container instructions.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
