### PR TITLE
docs: add step to apply default resources after control plane install

### DIFF
--- a/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-managed-kubernetes.mdx
@@ -218,6 +218,22 @@ This upgrades the control plane with these settings:
 - `global.tls.enabled` and `global.tls.secretName`: enables TLS using the certificate we just created.
 - `thunder.configuration.*`: updates Thunder to use HTTPS on port 443.
 
+**Apply Default Resources**
+
+The control plane needs default resources (project, environments, component types, workflows) to function. These are normally created by Helm post-install hooks, but hooks can fail silently on some clusters (especially EKS). Apply them explicitly to ensure they exist:
+
+<CodeBlock language="bash">
+{`kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/samples/getting-started/all.yaml`}
+</CodeBlock>
+
+Verify the resources were created:
+
+```bash
+kubectl get project,environment,componenttype -n default
+```
+
+You should see the `default` project, three environments (development, staging, production), and component types (service, web-application, scheduled-task).
+
 ---
 
 ## Step 2: Setup Data Plane

--- a/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
+++ b/docs/getting-started/try-it-out/on-self-hosted-kubernetes.mdx
@@ -235,6 +235,22 @@ spec:
 EOF
 ```
 
+**Apply Default Resources**
+
+The control plane needs default resources (project, environments, component types, workflows) to function. These are normally created by Helm post-install hooks, but hooks can fail silently on some clusters. Apply them explicitly to ensure they exist:
+
+<CodeBlock language="bash">
+{`kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/samples/getting-started/all.yaml`}
+</CodeBlock>
+
+Verify the resources were created:
+
+```bash
+kubectl get project,environment,componenttype -n default
+```
+
+You should see the `default` project, three environments (development, staging, production), and component types (service, web-application, scheduled-task).
+
 ---
 
 ## Step 2: Setup Data Plane

--- a/docs/operations/deployment-topology.mdx
+++ b/docs/operations/deployment-topology.mdx
@@ -217,6 +217,7 @@ When building your production environment, follow this general sequence to ensur
    - Deploy the `openchoreo-control-plane` chart
    - Configure TLS certificates for the Console, API, and IdP
    - **Crucial**: Configure the **Cluster Gateway** ingress and certificate - this is the entry point for all other planes
+   - Apply default resources (project, environments, component types, workflows) from [getting-started samples](https://github.com/openchoreo/openchoreo/tree/main/samples/getting-started)
 
 2. **Establish Trust** (Multi-Cluster Only):
    - Extract the Cluster Gateway CA certificate from the Control Plane


### PR DESCRIPTION
relates to openchoreo/openchoreo#1556

helm post-install hooks fail silently on some clusters. users end up confused when ComponentTypes or Environments are missing.

this adds explicit steps in the getting-started guides to apply default resources via kubectl. more reliable than relying on hooks.

changes:
- on-self-hosted-kubernetes.mdx: added "Apply Default Resources" step after control plane install
- on-managed-kubernetes.mdx: same, with note about EKS specifically
- deployment-topology.mdx: mentioned in deployment workflow order of operations

the samples are added in openchoreo/openchoreo#1685