### PR TITLE
chore: modify component type applying command and add a note

### DIFF
--- a/docs/operations/namespace-management.mdx
+++ b/docs/operations/namespace-management.mdx
@@ -113,12 +113,31 @@ Component Types define reusable templates for different workload types. OpenChor
 
 **Apply default component types:**
 
-<CodeBlock language="bash">
-{`# Get existing component types, update namespace, and apply
-kubectl get componenttype service -o yaml | yq eval ".metadata.namespace = \\"$NAMESPACE_NAME\\"" - | kubectl apply -f -
-kubectl get componenttype scheduled-task -o yaml | yq eval ".metadata.namespace = \\"$NAMESPACE_NAME\\"" - | kubectl apply -f -
-kubectl get componenttype web-application -o yaml | yq eval ".metadata.namespace = \\"$NAMESPACE_NAME\\"" - | kubectl apply -f -`}
-</CodeBlock>
+<CodeBlock language="bash">                                                                                                                                       
+  {`# Get existing component types, update namespace, and apply
+  # Services
+  kubectl get componenttype service -o yaml | yq eval "                                                                                                               
+    .metadata.namespace = \\"$NAMESPACE_NAME\\" |                                                                                                                       
+    (.spec.resources[] | select(.id == \\"httproute\\") | .template.spec.hostnames[0]) =                                                                                
+  \\"$NAMESPACE_NAME.\\\${metadata.environmentName}.\\\${dataplane.publicVirtualHost}\\"                                                                                
+  " - | kubectl apply -f -
+  
+  # Scheduled Tasks
+  kubectl get componenttype scheduled-task -o yaml | yq eval ".metadata.namespace = \\"$NAMESPACE_NAME\\"" - | kubectl apply -f -
+
+  # Web Applications
+  kubectl get componenttype web-application -o yaml | yq eval "                                                                                                       
+    .metadata.namespace = \\"$NAMESPACE_NAME\\" |                                                                                                                       
+    (.spec.resources[] | select(.id == \\"httproute\\") | .template.spec.hostnames[0]) =                                                                                
+  \\"$NAMESPACE_NAME.\\\${metadata.environmentName}.\\\${dataplane.publicVirtualHost}\\"                                                                                
+  " - | kubectl apply -f -`
+  }                                                                                                                                            
+  </CodeBlock>  
+
+:::tip Hostname for the Services and Web Applications
+  The hostname of the service and web applications are prefixed with the namespace name of the newly created namespace to avoid hostname collisions.
+  Eg: `engineering.development.openchoreoapis.localhost` where the namespace name is `engineering`
+:::
 
 **Verification:**
 


### PR DESCRIPTION
## Purpose
When two components are created with the same name in 2 namespaces, the hostname collides with the default component types. This PR updates the command to apply the component types.


## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
