### PR TITLE
feat(docs): add permission configuration step to external CI guide

### DIFF
--- a/docs/user-guide/ci/external-ci.mdx
+++ b/docs/user-guide/ci/external-ci.mdx
@@ -70,7 +70,34 @@ For long-running CI pipelines, configure a longer token validity period in the a
 
 If you've configured a different OIDC provider, create a service account following your provider's documentation. The token must include claims that OpenChoreo can validate against your security configuration.
 
-## Step 2: Create Component with External CI
+## Step 2: Configure Permissions
+
+The Jenkins service account needs permission to create workloads via the OpenChoreo API. Without this, API calls will return **403 Forbidden**. Configure permissions through the **Access Control** UI in Backstage.
+
+### Create a Role
+
+1. Navigate to **Access Control** in the Backstage left sidebar
+2. Go to the **Roles** tab → **Cluster** sub-tab
+3. Click **New Cluster Role**
+4. Enter a name, e.g. `jenkins-ci`
+5. Select the `workload:create` action
+6. Click **Create**
+
+### Create a Role Binding
+
+1. Go to the **Role Bindings** tab → **Cluster** sub-tab
+2. Click **New Cluster Role Binding**
+3. **Step 1** — Select the `jenkins-ci` role you just created
+4. **Step 2** — Select subject type **Service User** and enter the Jenkins OAuth **Client ID** (from Step 1) as the value for the `sub` claim
+5. **Step 3** — Leave scope as cluster-wide (no narrowing needed unless you want to restrict to specific namespaces/projects)
+6. **Step 4** — Set Effect to **Allow**; the auto-generated name is fine
+7. **Step 5** — Review the summary and click **Create**
+
+:::tip
+For a deeper look at roles, bindings, and scoping options, see [Custom Roles and Bindings](../authorization/custom-roles.mdx).
+:::
+
+## Step 3: Create Component with External CI
 
 When creating a new component in Backstage:
 
@@ -82,7 +109,7 @@ When creating a new component in Backstage:
 
 The component is created without a workload. Your CI pipeline will create workloads when builds complete.
 
-## Step 3: Configure Your CI Pipeline
+## Step 4: Configure Your CI Pipeline
 
 ### Jenkins
 
@@ -149,7 +176,7 @@ pipeline {
 }
 ```
 
-## Step 4: Enable Jenkins Visibility in Backstage
+## Step 5: Enable Jenkins Visibility in Backstage
 
 OpenChoreo Backstage includes a built-in Jenkins plugin that displays build status and history directly in the portal.
 

--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -37,7 +37,7 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 16217
+    "stars": 16218
   },
   {
     "id": "3",
@@ -57,7 +57,7 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 61679
+    "stars": 61693
   },
   {
     "id": "4",
@@ -77,7 +77,7 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 2516
+    "stars": 2518
   },
   {
     "id": "5",
@@ -97,7 +97,7 @@
     "moduleUrl": "",
     "core": true,
     "released": true,
-    "stars": 5327
+    "stars": 5328
   },
   {
     "id": "6",
@@ -177,7 +177,7 @@
     "moduleUrl": "",
     "core": true,
     "released": true,
-    "stars": 12396
+    "stars": 12400
   },
   {
     "id": "10",
@@ -197,7 +197,7 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 17916
+    "stars": 17917
   },
   {
     "id": "11",
@@ -217,7 +217,7 @@
     "moduleUrl": "",
     "core": true,
     "released": true,
-    "stars": 7880
+    "stars": 7879
   },
   {
     "id": "12",
@@ -237,7 +237,7 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 21990
+    "stars": 21996
   },
   {
     "id": "13",
@@ -257,7 +257,7 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 5854
+    "stars": 5855
   },
   {
     "id": "14",
@@ -277,6 +277,6 @@
     "moduleUrl": "",
     "core": false,
     "released": false,
-    "stars": 25018
+    "stars": 25020
   }
 ]


### PR DESCRIPTION
  Add Step 2 documenting how to configure RBAC permissions for the
  Jenkins service account via the Backstage Access Control UI, including
  role creation with workload:create action and role binding setup.
  Renumber existing steps 2-4 to 3-5 accordingly.

<img width="1728" height="874" alt="image" src="https://github.com/user-attachments/assets/99d9f012-1db1-4bec-9dae-f2a5625e1a40" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded External CI integration guide with new permissions configuration section covering Backstage access control
  * Added detailed Jenkins pipeline examples demonstrating API integration for workload management
  * Reorganized steps and enhanced troubleshooting guidance

* **Chores**
  * Updated marketplace plugin popularity metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->