### PR TITLE
chore: Update authz overview to clarify RBAC concepts

### DIFF
--- a/docs/platform-engineer-guide/authorization/overview.md
+++ b/docs/platform-engineer-guide/authorization/overview.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Authorization in OpenChoreo
 
-OpenChoreo RBAC is a role-based authorization system that controls who can perform what actions on which OpenChoreo resources. It is managed declaratively through Kubernetes Custom Resource Definitions alongside your workloads.
+OpenChoreo RBAC controls who can perform what actions on which OpenChoreo resources. It is managed declaratively through Kubernetes Custom Resource Definitions alongside your workloads.
 
 :::note
 Authorization can be disabled for testing purposes. When disabled, a passthrough implementation allows all requests without any policy evaluation.

--- a/docs/platform-engineer-guide/authorization/overview.md
+++ b/docs/platform-engineer-guide/authorization/overview.md
@@ -1,16 +1,36 @@
 ---
 title: Overview
-description: Understand how authorization works in OpenChoreo using hierarchical RBAC
+description: Understand how authorization works in OpenChoreo
 sidebar_position: 1
 ---
 
 # Authorization in OpenChoreo
 
-OpenChoreo provides a Kubernetes-native, **Hierarchical Role-Based Access Control (RBAC)** system that controls who can perform what actions on which resources. The authorization system is built on four Custom Resource Definitions (CRDs) that define roles, permissions, and bindings — all managed declaratively alongside your workloads.
+OpenChoreo RBAC is a role-based authorization system that controls who can perform what actions on which OpenChoreo resources. It is managed declaratively through Kubernetes Custom Resource Definitions alongside your workloads.
 
 :::note
 Authorization can be disabled for testing purposes. When disabled, a passthrough implementation allows all requests without any policy evaluation.
 :::
+
+## What can I do with OpenChoreo RBAC?
+
+Here are some examples of what you can do with OpenChoreo RBAC:
+
+- Allow one team to manage components in a single project, while another team has read-only access across the whole namespace.
+- Give a developer permission to create and update components in the `crm` project, but not delete them.
+- Grant a platform engineer cluster-wide permission to manage data planes, component types, and workflows.
+- Allow a service account to view logs and metrics for a specific component, and nothing else.
+- Restrict an auditor to read-only access across every namespace in the cluster.
+
+## How OpenChoreo RBAC works
+
+You control access in OpenChoreo RBAC by defining **roles** and creating **role bindings**. A role is a named collection of allowed actions. A role binding attaches a role to a subject at a specific scope, answering the question "who can do what, and where?"
+
+- **Subject** — _who_ is being granted access.
+- **Role** — _what_ actions are allowed.
+- **Scope** — _where_ in the resource hierarchy the permissions apply.
+
+The rest of this page walks through each of these in detail, followed by how OpenChoreo evaluates a request against them.
 
 ## Core Concepts
 
@@ -77,6 +97,25 @@ Two key properties:
 
 - **Permissions cascade downward.** Granting `component:view` at the namespace scope allows viewing components in every project within that namespace.
 - **Permissions do not cascade upward.** Even if a role includes actions for higher-level resources (e.g., `environment:view`), a binding scoped to a project will **not** grant access to namespace-level or cluster-level resources. If a user needs visibility into those, add supplementary role mappings at the appropriate scope — see [Scoping Roles Below Cluster Level](../authorization.md#scoping-roles-below-cluster-level).
+
+Each role binding also carries an `effect` field — either `allow` or `deny` (default: `allow`). A `deny` binding is an explicit exception: it revokes access that would otherwise be granted by an `allow` binding at the same or a higher scope. See [How OpenChoreo RBAC determines access](#how-openchoreo-rbac-determines-access) for exactly how allow and deny bindings are combined.
+
+## How OpenChoreo RBAC determines access
+
+When a request arrives, OpenChoreo evaluates it against every role binding the subject matches. For each binding, all of the following must hold for the binding to apply:
+
+1. **The subject matches.** One of the caller's entitlement values (e.g., `groups:platformEngineer`) equals the binding's subject.
+2. **The resource is within scope.** The target resource lies at or below the binding's scope in the resource hierarchy. A binding at `namespace: acme` applies to everything inside `acme`; a `ClusterAuthzRoleBinding` with no scope applies cluster-wide.
+3. **The role grants the action.** The role referenced by the binding lists the requested action, either exactly (`component:create`) or via a wildcard (`component:*`, `*`).
+
+A request is **allowed** only if:
+
+- **at least one** matching binding has `effect: allow`, **and**
+- **no** matching binding has `effect: deny`.
+
+A single matching `deny` is enough to block the request, even when multiple `allow` bindings would otherwise grant it. Deny applies across role kinds — a namespace-scoped `AuthzRoleBinding` with `effect: deny` can block access that a `ClusterAuthzRoleBinding` would otherwise allow.
+
+Bindings default to `effect: allow`. Set `effect: deny` explicitly only when you need to create a targeted exception to a broader allow — for example, granting `developer` access across the `acme` namespace but denying it on the `secret` project within it.
 
 ## Authorization CRDs
 

--- a/versioned_docs/version-v1.0.x/platform-engineer-guide/authorization/overview.md
+++ b/versioned_docs/version-v1.0.x/platform-engineer-guide/authorization/overview.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Authorization in OpenChoreo
 
-OpenChoreo RBAC is a role-based authorization system that controls who can perform what actions on which OpenChoreo resources. It is managed declaratively through Kubernetes Custom Resource Definitions alongside your workloads.
+OpenChoreo RBAC controls who can perform what actions on which OpenChoreo resources. It is managed declaratively through Kubernetes Custom Resource Definitions alongside your workloads.
 
 :::note
 Authorization can be disabled for testing purposes. When disabled, a passthrough implementation allows all requests without any policy evaluation.

--- a/versioned_docs/version-v1.0.x/platform-engineer-guide/authorization/overview.md
+++ b/versioned_docs/version-v1.0.x/platform-engineer-guide/authorization/overview.md
@@ -1,16 +1,36 @@
 ---
 title: Overview
-description: Understand how authorization works in OpenChoreo using hierarchical RBAC
+description: Understand how authorization works in OpenChoreo
 sidebar_position: 1
 ---
 
 # Authorization in OpenChoreo
 
-OpenChoreo provides a Kubernetes-native, **Hierarchical Role-Based Access Control (RBAC)** system that controls who can perform what actions on which resources. The authorization system is built on four Custom Resource Definitions (CRDs) that define roles, permissions, and bindings — all managed declaratively alongside your workloads.
+OpenChoreo RBAC is a role-based authorization system that controls who can perform what actions on which OpenChoreo resources. It is managed declaratively through Kubernetes Custom Resource Definitions alongside your workloads.
 
 :::note
 Authorization can be disabled for testing purposes. When disabled, a passthrough implementation allows all requests without any policy evaluation.
 :::
+
+## What can I do with OpenChoreo RBAC?
+
+Here are some examples of what you can do with OpenChoreo RBAC:
+
+- Allow one team to manage components in a single project, while another team has read-only access across the whole namespace.
+- Give a developer permission to create and update components in the `crm` project, but not delete them.
+- Grant a platform engineer cluster-wide permission to manage data planes, component types, and workflows.
+- Allow a service account to view logs and metrics for a specific component, and nothing else.
+- Restrict an auditor to read-only access across every namespace in the cluster.
+
+## How OpenChoreo RBAC works
+
+You control access in OpenChoreo RBAC by defining **roles** and creating **role bindings**. A role is a named collection of allowed actions. A role binding attaches a role to a subject at a specific scope, answering the question "who can do what, and where?"
+
+- **Subject** — _who_ is being granted access.
+- **Role** — _what_ actions are allowed.
+- **Scope** — _where_ in the resource hierarchy the permissions apply.
+
+The rest of this page walks through each of these in detail, followed by how OpenChoreo evaluates a request against them.
 
 ## Core Concepts
 
@@ -77,6 +97,25 @@ Two key properties:
 
 - **Permissions cascade downward.** Granting `component:view` at the namespace scope allows viewing components in every project within that namespace.
 - **Permissions do not cascade upward.** Even if a role includes actions for higher-level resources (e.g., `environment:view`), a binding scoped to a project will **not** grant access to namespace-level or cluster-level resources. If a user needs visibility into those, add supplementary role mappings at the appropriate scope — see [Scoping Roles Below Cluster Level](../authorization.md#scoping-roles-below-cluster-level).
+
+Each role binding also carries an `effect` field — either `allow` or `deny` (default: `allow`). A `deny` binding is an explicit exception: it revokes access that would otherwise be granted by an `allow` binding at the same or a higher scope. See [How OpenChoreo RBAC determines access](#how-openchoreo-rbac-determines-access) for exactly how allow and deny bindings are combined.
+
+## How OpenChoreo RBAC determines access
+
+When a request arrives, OpenChoreo evaluates it against every role binding the subject matches. For each binding, all of the following must hold for the binding to apply:
+
+1. **The subject matches.** One of the caller's entitlement values (e.g., `groups:platformEngineer`) equals the binding's subject.
+2. **The resource is within scope.** The target resource lies at or below the binding's scope in the resource hierarchy. A binding at `namespace: acme` applies to everything inside `acme`; a `ClusterAuthzRoleBinding` with no scope applies cluster-wide.
+3. **The role grants the action.** The role referenced by the binding lists the requested action, either exactly (`component:create`) or via a wildcard (`component:*`, `*`).
+
+A request is **allowed** only if:
+
+- **at least one** matching binding has `effect: allow`, **and**
+- **no** matching binding has `effect: deny`.
+
+A single matching `deny` is enough to block the request, even when multiple `allow` bindings would otherwise grant it. Deny applies across role kinds — a namespace-scoped `AuthzRoleBinding` with `effect: deny` can block access that a `ClusterAuthzRoleBinding` would otherwise allow.
+
+Bindings default to `effect: allow`. Set `effect: deny` explicitly only when you need to create a targeted exception to a broader allow — for example, granting `developer` access across the `acme` namespace but denying it on the `secret` project within it.
 
 ## Authorization CRDs
 


### PR DESCRIPTION
## Purpose
### Summary                                                                                                                      
                                                                                                                               
  "Hierarchical RBAC" collides with the NIST/INCITS 359 term, which means role-to-role inheritance. OpenChoreo roles are flat; 
  the hierarchy is over resources, not roles. This PR drops the label, restructures the authz overview, and documents the      
  effect: allow | deny rule that was previously missing from the overview.                                                     
                                                                                                                               
  
### Changes                          

<img width="3022" height="6496" alt="screencapture-localhost-3000-docs-platform-engineer-guide-authorization-overview-2026-04-07-12_56_44 (1)" src="https://github.com/user-attachments/assets/6c56e110-6c33-4d8b-8cc1-86d98d13cd11" />
                                                                                           
                                                                                                                               
  Applied to both docs/platform-engineer-guide/authorization/overview.md and                                               
  versioned_docs/version-v1.0.x/platform-engineer-guide/authorization/overview.md:                                            
                                                                                                                              
  - Removed "Hierarchical" from the title, description, and opening paragraph. Introduced OpenChoreo RBAC as the canonical     
  name.                                                                                                                       
  - Added "What can I do with OpenChoreo RBAC?" — use-case bullets.                                                            
  - Added "How OpenChoreo RBAC works" — short intro with the Subject / Role / Scope model.                                     
  - Core Concepts kept unchanged.                                                                                             
  - Added a paragraph to Effective Permissions introducing effect: allow | deny.                                               
  - Added "How OpenChoreo RBAC determines access" — documents the three per-binding match conditions and the                   
  deny-overrides-allow rule.        

## Related Issues
Refer discussion: https://github.com/openchoreo/openchoreo/discussions/2958#discussioncomment-16469015
## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
