### PR TITLE
docs: add agent-manager module path

### DIFF
--- a/src/data/marketplace-plugins.source.json
+++ b/src/data/marketplace-plugins.source.json
@@ -264,9 +264,9 @@
     "logoUrl": "https://wso2.cachefly.net/wso2/sites/all/image_resources/logos/WSO2-Logo-Black.webp",
     "author": "OpenChoreo",
     "repo": "wso2/agent-manager",
-    "moduleUrl": "",
+    "moduleUrl": "https://github.com/openchoreo/community-modules/tree/main/ai-wso2-agent-manager",
     "core": false,
-    "released": false,
+    "released": true,
     "moduleType": "openchoreo"
   }
 ]


### PR DESCRIPTION
Dependent on https://github.com/openchoreo/community-modules/pull/72

This pull request makes a minor update to the `src/data/marketplace-plugins.json` file, adding a `moduleUrl` for the WSO2 Agent Manager plugin to point to its GitHub repository.