### PR TITLE
feat: add error status fields to tracing-adaptor spec and update tracing-opensearch module version

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -610,7 +610,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```

--- a/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
+++ b/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
@@ -29,7 +29,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -977,7 +977,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```

--- a/static/api-specs/observability-tracing-adapter-api.yaml
+++ b/static/api-specs/observability-tracing-adapter-api.yaml
@@ -314,6 +314,9 @@ components:
                 type: integer
                 format: int64
                 description: The duration of the trace in nanoseconds
+              hasErrors:
+                type: boolean
+                description: Whether any span in the trace has an error status.
         total:
           type: integer
           description: The total number of matching traces, capped at 1000
@@ -355,6 +358,10 @@ components:
               parentSpanId:
                 type: string
                 description: The parent span ID
+              status:
+                type: string
+                enum: [ok, error, unset]
+                description: The execution status of the span. One of "ok", "error", or "unset".
         total:
           type: integer
           description: The total number of matching spans, capped at 1000
@@ -390,6 +397,10 @@ components:
         parentSpanId:
           type: string
           description: The parent span ID
+        status:
+          type: string
+          enum: [ok, error, unset]
+          description: The execution status of the span. One of "ok", "error", or "unset".
         attributes:
           type: array
           items:

--- a/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-k3d-locally.mdx
@@ -610,7 +610,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```

--- a/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
+++ b/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
@@ -29,7 +29,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 

--- a/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-your-environment.mdx
@@ -977,7 +977,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.3.10 \
+  --version 0.3.11 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```


### PR DESCRIPTION
## Purpose
This pull request updates the `observability-tracing-adapter-api.yaml` specification to enhance trace and span metadata. The changes add new fields to better indicate error states and execution status for traces and spans.
Based on new fields added via https://github.com/openchoreo/openchoreo/pull/3185

**Trace and Span Metadata Enhancements:**

* Added a `hasErrors` boolean field to the trace object to indicate if any span in the trace has an error status.
* Added a `status` string field to both span summary and span detail objects, describing the execution status as "ok", "error", or "unset". [[1]](diffhunk://#diff-4b3da1b069753e0ff2500d2e877dc0cb72dc929b51fa61a9c662efe71cda21a2R361-R363) [[2]](diffhunk://#diff-4b3da1b069753e0ff2500d2e877dc0cb72dc929b51fa61a9c662efe71cda21a2R399-R401)

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3067

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
