### PR TITLE
fix: restore Ask AI sidepanel on desktop via !important override

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -278,3 +278,21 @@ html[data-theme='dark'] {
 .footer__copyright {
   font-size: 0.85rem;
 }
+
+/* Hotfix for DocSearch Ask AI sidepanel on desktop.
+ *
+ * The production CSS bundle ends up with two copies of the sidepanel CSS,
+ * landing in two different cascade layers:
+ *   - docusaurus.theme-classic contains a closed-state `transform: translateX(100%)`
+ *   - docusaurus.theme-search-algolia.docsearch contains the matching open-state
+ *     reset `transform: none`
+ * Per spec, the later-declared docsearch layer should win, but the closed-state
+ * rule from theme-classic keeps the panel translated off-screen on open.
+ * An `!important` override wins regardless of layer resolution.
+ *
+ * Affects: @docsearch/docusaurus-adapter 4.6.2 + @docusaurus/preset-classic 3.9.2.
+ * Remove once the underlying cascade interaction is resolved upstream. */
+.DocSearch-Sidepanel-Container.inline.side-right.is-open,
+.DocSearch-Sidepanel-Container.inline.side-left.is-open {
+  transform: none !important;
+}


### PR DESCRIPTION
## Purpose

Follow-up fix for #554. On the live site, the Ask AI sidepanel opens but renders off-screen on desktop — clicking the Ask AI button appears to do nothing. This PR adds a small CSS override in `src/css/custom.css` that pins the open-state transform so the panel is visible.

The override is scoped to the open-state selector only, so the closed-state slide-off animation still works. A comment in the file documents why the override exists and the adapter versions affected so it can be removed once resolved upstream.

## Related Issues

Related: openchoreo/openchoreo#3194

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)