### PR TITLE
chore: update 1.0.x docs to use 1.0.1-hotfix.1 as the oc version

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,11 +7,12 @@ description: Release history for OpenChoreo
 
 ## v1.x Releases
 
-| Version     | Date       | Changelog                                                                             |
-| ----------- | ---------- | ------------------------------------------------------------------------------------- |
-| v1.0.0      | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)     |
-| v1.0.0-rc.2 | 2026-03-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100-rc2) |
-| v1.0.0-rc.1 | 2026-03-15 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100-rc1) |
+| Version         | Date       | Changelog                                                                                         |
+| --------------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| v1.0.1-hotfix.1 | 2026-04-16 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v101-hotfix1) |
+| v1.0.0          | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)                 |
+| v1.0.0-rc.2     | 2026-03-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100-rc2)             |
+| v1.0.0-rc.1     | 2026-03-15 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100-rc1)             |
 
 ## v0.x Releases
 

--- a/versioned_docs/version-v1.0.x/_constants.mdx
+++ b/versioned_docs/version-v1.0.x/_constants.mdx
@@ -1,9 +1,9 @@
 [//] # (This file stores the constants used across the documentation.)
 
 export const versions = {
-  dockerTag: "v1.0.0",
+  dockerTag: "v1.0.1-hotfix.1",
   githubRef: "release-v1.0", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
-  helmChart: "1.0.0",
+  helmChart: "1.0.1-hotfix.1",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };
 

--- a/versioned_docs/version-v1.0.x/changelog.md
+++ b/versioned_docs/version-v1.0.x/changelog.md
@@ -7,9 +7,10 @@ description: Release history for OpenChoreo
 
 ## v1.x Releases
 
-| Version     | Date       | Changelog                                                                             |
-| ----------- | ---------- | ------------------------------------------------------------------------------------- |
-| v1.0.0      | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)     |
+| Version          | Date       | Changelog                                                                                           |
+| ---------------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| v1.0.1-hotfix.1  | 2026-04-16 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v101-hotfix1)          |
+| v1.0.0           | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)                  |
 | v1.0.0-rc.2 | 2026-03-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100-rc2) |
 | v1.0.0-rc.1 | 2026-03-15 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100-rc1) |
 


### PR DESCRIPTION
This pull request updates documentation to reflect the release of version `v1.0.1-hotfix.1` of OpenChoreo. The main changes ensure that the new hotfix version is referenced consistently across release notes, support tables, and documentation constants.

Release documentation updates:

* Added `v1.0.1-hotfix.1` to the release history tables in both `docs/changelog.md` and `versioned_docs/version-v1.0.x/changelog.md`, including links to the new changelog section.
* Updated the support status table in `docs/releases/release-and-support-process.md` to set `v1.0.1-hotfix.1` as the latest patch for the `v1.0` minor release.

Documentation constants update:

* Updated version constants in `versioned_docs/version-v1.0.x/_constants.mdx` to reference `v1.0.1-hotfix.1` for both the Docker tag and Helm chart version.