### PR TITLE
fix: restore Ask AI submit/stop button colors in light theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -296,3 +296,18 @@ html[data-theme='dark'] {
 .DocSearch-Sidepanel-Container.inline.side-left.is-open {
   transform: none !important;
 }
+
+/* Hotfix for Ask AI submit and stop buttons in the light theme.
+ *
+ * The adapter aliases --docsearch-sidepanel-white to --ifm-background-color,
+ * which Infima sets to `transparent` in its light theme. That leaves the
+ * submit button arrow (SVG stroke="currentColor") invisible and the stop
+ * button (shown while a response streams) with a transparent background.
+ * In dark mode, Infima resolves the var to a solid color, so the existing
+ * rendering is fine — scope the override to light theme only. */
+html:not([data-theme='dark']) .DocSearch-Sidepanel-Prompt--submit {
+  color: #fff;
+}
+html:not([data-theme='dark']) .DocSearch-Sidepanel-Prompt--stop {
+  background-color: #fff;
+}


### PR DESCRIPTION
## Purpose

Follow-up fix for the Ask AI sidepanel. In the light theme, the submit button's arrow is invisible and the "Stop streaming" button has a transparent background. Dark theme is unaffected.

This PR adds a scoped CSS override in `src/css/custom.css` that restores both buttons in light mode. The dark-theme rendering is left alone because it already looks fine.

## Related Issues

Related: openchoreo/openchoreo#3194

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)