### PR TITLE
feat: add observability metrics adapter OpenAPI specification and metrics module building guide

### DIFF
--- a/docs/platform-engineer-guide/modules/building-a-module.md
+++ b/docs/platform-engineer-guide/modules/building-a-module.md
@@ -110,9 +110,25 @@ The module's Helm chart should deploy both the backend and the adapter, and conf
 
 Reference implementation: [observability-logs-openobserve module](https://github.com/openchoreo/community-modules/tree/main/observability-logs-openobserve)
 
+##### Observability Metrics Module
+
+Like the logs module, a metrics module follows the same adapter pattern. The module must provide two components:
+
+1. **A metrics backend** — The storage and query engine for metrics (e.g., Prometheus).
+2. **A metrics adapter** — A service that implements the [Metrics Adapter API](../observability-metrics-adapter-api) and acts as the bridge between the Observer and the metrics backend.
+
+The metrics adapter must:
+
+- Implement the endpoints defined in the [Metrics Adapter API specification](../observability-metrics-adapter-api)
+- Translate the standardized metrics query parameters (time range, search scope, metric names) into the backend's native query format.
+- Return metrics data in the standardized response format, including metric metadata and data points.
+- Support alert rule management endpoints for creating, updating, and deleting alert rules in the metrics backend.
+
+The module's Helm chart should deploy both the backend and the adapter, and configure the adapter's service endpoint so the Observer can discover and communicate with it.
+
 ##### Observability Tracing Module
 
-Like the logs module, a tracing module follows the same adapter pattern. The module must provide two components:
+Like the logs and metrics modules, a tracing module follows the same adapter pattern. The module must provide two components:
 
 1. **A trace aggregation backend** — The storage and query engine for traces (e.g., OpenSearch, Jaeger, Tempo).
 2. **A tracing adapter** — A service that implements the [Tracing Adapter API](../observability-tracing-adapter-api) and acts as the bridge between the Observer and the trace backend.

--- a/docs/platform-engineer-guide/modules/observability-metrics-adapter-api.mdx
+++ b/docs/platform-engineer-guide/modules/observability-metrics-adapter-api.mdx
@@ -1,0 +1,15 @@
+---
+title: Metrics Adapter API Reference
+description: OpenAPI specification for the metrics adapter that integrates a metrics backend with the OpenChoreo Observer.
+sidebar_position: 6
+---
+
+import SwaggerUI from "@site/src/components/SwaggerUI";
+
+# Metrics Adapter API Reference
+
+This is the OpenAPI specification that a metrics adapter must implement to integrate with the OpenChoreo Observer. The Observer calls these endpoints to query metrics and manage alert rules from the metrics backend your module provides.
+
+For an overview of the adapter pattern and how it fits into the observability architecture, see [Building an Observability Module](../building-a-module#observability-modules).
+
+<SwaggerUI specUrl="/api-specs/observability-metrics-adapter.yaml" />

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -207,7 +207,8 @@ const sidebars: SidebarsConfig = {
               },
               items: [
                 "platform-engineer-guide/modules/observability-logging-adapter-api",
-                "platform-engineer-guide/modules/observability-tracing-adapter-api",
+                "platform-engineer-guide/modules/observability-metrics-adapter-api",
+                "platform-engineer-guide/modules/observability-tracing-adapter-api"
               ],
             },
           ],

--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -1,0 +1,581 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+openapi: 3.0.3
+info:
+  title: OpenChoreo Observability Metrics Adapter API
+  description: |
+    This API specification defines the contract that a metrics adapter must implement
+    to integrate with the OpenChoreo Observer. The Observer calls these endpoints to
+    query metrics from the metrics backend provided by the module.
+  version: 1.0.0
+  contact:
+    name: OpenChoreo Team
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+tags:
+  - name: Metrics
+    description: Metrics retrieval endpoints
+  - name: Alerts
+    description: Alert rule management endpoints
+  - name: Health
+    description: Health check endpoints
+
+paths:
+  /healthz:
+    get:
+      tags:
+        - Health
+      summary: Health check
+      description: Check the health status of the metrics adapter service
+      operationId: health
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+        "503":
+          description: Service is unhealthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: unhealthy
+                  error:
+                    type: string
+                    example: "metrics backend: connection failed"
+
+  # Metrics query endpoint
+  /api/v1/metrics/query:
+    post:
+      tags:
+        - Metrics
+      summary: Query metrics
+      description: Query metrics from the metrics adapter service
+      operationId: queryMetrics
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetricsQueryRequest"
+      responses:
+        "200":
+          description: Metrics queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetricsQueryResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/rules:
+    post:
+      tags:
+        - Alerts
+      summary: Create alert rule
+      description: Create an alert rule in the metrics backend
+      operationId: createAlertRule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AlertRuleRequest"
+      responses:
+        "201":
+          description: Alert rule created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Alert rule already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/webhook:
+    post:
+      tags:
+        - Alerts
+      summary: Handles triggered alerts from the alerting backend
+      description: Handles triggered alerts from the alerting backend
+      operationId: handleAlertWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: The request body can be any JSON object, as different alerting backends may send different payloads.
+      responses:
+        "200":
+          description: Alert webhook handled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertWebhookResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/v1alpha1/alerts/rules/{ruleName}:
+    parameters:
+      - name: ruleName
+        in: path
+        required: true
+        description: The name of the alert rule
+        schema:
+          type: string
+    get:
+      tags:
+        - Alerts
+      summary: Get alert rule
+      description: Get an alert rule from the metrics backend
+      operationId: getAlertRule
+      responses:
+        "200":
+          description: Alert rule retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertRuleResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - Alerts
+      summary: Update alert rule
+      description: Update an alert rule in the metrics backend
+      operationId: updateAlertRule
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AlertRuleRequest"
+      responses:
+        "200":
+          description: Alert rule updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    delete:
+      tags:
+        - Alerts
+      summary: Delete alert rule
+      description: Delete an alert rule in the metrics backend
+      operationId: deleteAlertRule
+      responses:
+        "200":
+          description: Alert rule deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AlertingRuleSyncResponse"
+        "404":
+          description: Alert rule not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The error message
+          enum:
+            - badRequest
+            - unauthorized
+            - forbidden
+            - internalServerError
+        errorCode:
+          type: string
+          description: The error code from observer service
+          example: OBS-V1-M-22
+        detail:
+          type: string
+          description: The error message
+          example: "Missing required fields 'startTime' and 'endTime'"
+
+    ComponentSearchScope:
+      type: object
+      properties:
+        namespace:
+          type: string
+        projectUid:
+          type: string
+        componentUid:
+          type: string
+        environmentUid:
+          type: string
+      required: [namespace]
+
+    # Request schemas for metrics
+    MetricsQueryRequest:
+      type: object
+      properties:
+        metric:
+          type: string
+          description: The type of query to execute
+          enum:
+            - resource
+            - http
+        startTime:
+          type: string
+          description: The start time of the query
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query
+          format: date-time
+        step:
+          type: string
+          description: The step of the query to determine the number of points to return. E.g. 1m, 5m, 15m, 30m, 1h
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+      required: [metric, startTime, endTime, searchScope]
+
+    # Response schemas for metrics
+    MetricsTimeSeriesItem:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          description: The timestamp of the time series item
+          format: date-time
+        value:
+          type: number
+          format: double
+          description: The value of the time series item
+
+    ResourceMetricsTimeSeries:
+      type: object
+      properties:
+        cpuUsage:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        cpuRequests:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        cpuLimits:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        memoryUsage:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        memoryRequests:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        memoryLimits:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+
+    HttpMetricsTimeSeries:
+      type: object
+      properties:
+        requestCount:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        successfulRequestCount:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        unsuccessfulRequestCount:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        meanLatency:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        latencyP50:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        latencyP90:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+        latencyP99:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetricsTimeSeriesItem"
+
+    MetricsQueryResponse:
+      oneOf:
+        - $ref: "#/components/schemas/ResourceMetricsTimeSeries"
+        - $ref: "#/components/schemas/HttpMetricsTimeSeries"
+
+    # Request schemas for alert rules
+    AlertRuleRequest:
+      type: object
+      required: [metadata, source, condition]
+      properties:
+        metadata:
+          type: object
+          required: [name, namespace, projectUid, environmentUid, componentUid]
+          properties:
+            name:
+              type: string
+              description: The name of the alert rule
+            namespace:
+              type: string
+              description: The namespace of the alert rule CR
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID to query
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID to query
+              format: uuid
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID to query
+              format: uuid
+        source:
+          type: object
+          required: [metric]
+          properties:
+            metric:
+              type: string
+              description: The metric to query for metric based alerts
+              enum:
+                - cpu_usage
+                - memory_usage
+        condition:
+          type: object
+          required: [enabled, window, interval, operator, threshold]
+          properties:
+            enabled:
+              type: boolean
+              description: Whether the alert rule is enabled
+            window:
+              type: string
+              description: The window of time to query for the alert rule
+            interval:
+              type: string
+              description: The interval of time to query for the alert rule
+            operator:
+              type: string
+              description: The operator to use for the alert rule
+              enum:
+                - gt
+                - gte
+                - lt
+                - lte
+                - eq
+                - neq
+            threshold:
+              type: number
+              description: The threshold value to use for the alert rule
+
+    # Response schemas for alert rules
+    AlertRuleResponse:
+      type: object
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the alert rule
+            namespace:
+              type: string
+              description: The namespace of the alert rule CR
+            projectUid:
+              type: string
+              description: The OpenChoreo project UID to query
+              format: uuid
+            environmentUid:
+              type: string
+              description: The OpenChoreo environment UID to query
+              format: uuid
+            componentUid:
+              type: string
+              description: The OpenChoreo component UID to query
+              format: uuid
+        source:
+          type: object
+          properties:
+            metric:
+              type: string
+              description: The metric to query for metric based alerts
+              enum:
+                - cpu_usage
+                - memory_usage
+        condition:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+              description: Whether the alert rule is enabled
+            window:
+              type: string
+              description: The window of time to query for the alert rule
+            interval:
+              type: string
+              description: The interval of time to query for the alert rule
+            operator:
+              type: string
+              description: The operator to use for the alert rule
+              enum:
+                - gt
+                - gte
+                - lt
+                - lte
+                - eq
+                - neq
+            threshold:
+              type: number
+              description: The threshold value to use for the alert rule
+
+    AlertingRuleSyncResponse:
+      type: object
+      properties:
+        action:
+          type: string
+          description: The action taken on the alert rule
+          enum:
+            - created
+            - updated
+            - unchanged
+            - deleted
+        lastSyncedAt:
+          type: string
+          description: The timestamp of the last sync
+        status:
+          type: string
+          description: The status of the alert rule
+          enum:
+            - synced
+            - failed
+        ruleLogicalId:
+          type: string
+          description: The logical ID (name) of the alert rule
+        ruleBackendId:
+          type: string
+          description: The backend ID (UID from observability backend) of the alert rule
+
+    # Response schema for alert webhook
+    AlertWebhookResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message of the alert webhook
+        status:
+          type: string
+          description: The status of the alert webhook
+          enum:
+            - success
+            - error


### PR DESCRIPTION
## Purpose
Add the OpenAPI specification for the observability metrics adapter
Add guide on how to build a metrics module

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2964

## Checklist
- [x] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
