### PR TITLE
docs: add Observer external IDP configuration steps

### DIFF
--- a/docs/platform-engineer-guide/identity-configuration.mdx
+++ b/docs/platform-engineer-guide/identity-configuration.mdx
@@ -179,6 +179,10 @@ The following components require OAuth client configuration:
 
 - For configuration steps, see the [Workload Publishing Credentials](./workflows/workflow-workload-configuration.mdx) guide
 
+**Observer (uid-resolver):**
+
+- For configuration steps, refer to the [Observer External IDP Configuration](./observability-alerting.mdx#observer-external-idp-configuration) guide
+
 :::tip
 Store sensitive values like client secrets using Kubernetes secrets rather than directly in helm values. Refer to the [Secret Management](./secret-management.mdx) guide for best practices.
 :::

--- a/docs/platform-engineer-guide/observability-alerting.mdx
+++ b/docs/platform-engineer-guide/observability-alerting.mdx
@@ -500,6 +500,101 @@ Apply the updated values with `helm upgrade`.
 
 For all available alert storage configuration options, see the [Observability Plane Helm Reference](../reference/helm/observability-plane.mdx#observer).
 
+## Observer External IDP Configuration
+
+By default, OpenChoreo configures Thunder as the identity provider for the Observer with a pre-configured OAuth client.
+If you are using an external identity provider, configure the uid-resolver as described below.
+
+The uid-resolver is a sub-component of the Observer service that resolves component/project/environment identities
+by calling the OpenChoreo control plane API. It uses the OAuth2 `client_credentials` grant to authenticate as a service account when making those calls.
+
+### Step 1: Create an OAuth Client in Your Identity Provider
+
+Create an OAuth 2.0 client with the following settings in your identity provider:
+
+- **Grant type**: `client_credentials`
+- **Client ID**: Choose a name (e.g., `openchoreo-observer-resource-reader-client`)
+- **Scopes**: No specific scopes are required by default. Set this only if your identity provider requires
+  a non-empty scope for the `client_credentials` grant (e.g., `"api://<client-id>/.default"` for Azure AD).
+
+### Step 2: Store the OAuth Client Secret
+
+Store the client secret so the Observer can access it. For example, if you are using OpenBao:
+
+```bash
+kubectl exec -n openbao openbao-0 -- \
+  env BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=root \
+  bao kv put secret/observer-oauth-client-secret value="<YOUR_OAUTH_CLIENT_SECRET>"
+```
+
+Add `UID_RESOLVER_OAUTH_CLIENT_SECRET` to the existing `observer-secret` ExternalSecret in the `openchoreo-observability-plane` namespace:
+
+```bash
+kubectl patch externalsecret observer-secret -n openchoreo-observability-plane --type=json \
+  -p '[{"op":"add","path":"/spec/data/-","value":{"secretKey":"UID_RESOLVER_OAUTH_CLIENT_SECRET","remoteRef":{"key":"observer-oauth-client-secret","property":"value"}}}]'
+```
+
+### Step 3: Configure the Observability Plane
+
+Update your Helm values with the OAuth client ID and the token endpoint of your identity provider:
+
+```yaml
+security:
+  oidc:
+    tokenUrl: "<your-idp-token-url>"
+
+observer:
+  oauthClientId: "<your-client-id>"
+  secretName: "observer-secret"
+```
+
+For environments that use self-signed certificates on the identity provider's token endpoint, also set:
+
+```yaml
+security:
+  oidc:
+    uidResolverTlsInsecureSkipVerify: "true"
+```
+
+:::warning
+Only set `uidResolverTlsInsecureSkipVerify: "true"` in development or testing environments.
+For production deployments, ensure your identity provider uses valid TLS certificates.
+:::
+
+Apply the changes using `helm upgrade` with your updated values.
+
+### Step 4: Grant Control Plane Access
+
+The Observer uses the `observer-resource-reader` role to read resource metadata (projects, components, environments, namespaces) from the control plane API.
+The API matches the `sub` claim in the issued JWT to identify the caller, so the new client must be granted the `observer-resource-reader` role via a bootstrap authorization mapping.
+
+Add the following to your Control Plane values override, replacing `<your-client-id>` with the same client ID used in Step 1:
+
+```yaml
+openchoreoApi:
+  config:
+    security:
+      authorization:
+        bootstrap:
+          mappings:
+            - name: observer-resource-reader-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: observer-resource-reader
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: "<your-client-id>"
+              effect: allow
+```
+
+:::warning
+When overriding the `bootstrap.mappings` array, the entire array is replaced. Make sure to include all other default bindings you want to keep.
+See the [Authorization Configuration](./authorization.md#customizing-bootstrap-roles-and-bindings) guide for details.
+:::
+
 ---
 
 ## Configuration Reference

--- a/docs/reference/helm/observability-plane.mdx
+++ b/docs/reference/helm/observability-plane.mdx
@@ -173,6 +173,12 @@ OpenChoreo Observer service configuration - REST API that abstracts OpenSearch f
 | `observer.tracingAdapter.timeout`     | Timeout for tracing adapter requests                                                                                                                                                                                                             | `string`  | `30s`                                        |
 | `observer.tracingAdapter.url`         | URL of the tracing adapter service                                                                                                                                                                                                               | `string`  | `http://tracing-adapter:9100`                |
 
+:::note
+The Observer includes a **uid-resolver** component that uses the OAuth2 `client_credentials` grant to call the control plane API for component/project/environment identity resolution.
+The relevant values are `observer.oauthClientId`, the `UID_RESOLVER_OAUTH_CLIENT_SECRET` key in `observer.secretName` secret, and `security.oidc.tokenUrl`.
+When using an external identity provider, refer to [Observer External IDP Configuration](../../platform-engineer-guide/observability-alerting.mdx#observer-external-idp-configuration) for setup steps.
+:::
+
 ## Rca
 
 AI-powered Root Cause Analysis agent configuration

--- a/versioned_docs/version-v1.0.x/platform-engineer-guide/identity-configuration.mdx
+++ b/versioned_docs/version-v1.0.x/platform-engineer-guide/identity-configuration.mdx
@@ -179,6 +179,10 @@ The following components require OAuth client configuration:
 
 - For configuration steps, see the [Workload Publishing Credentials](./workflows/workflow-workload-configuration.mdx) guide
 
+**Observer (uid-resolver):**
+
+- For configuration steps, refer to the [Observer External IDP Configuration](./observability-alerting.mdx#observer-external-idp-configuration) guide
+
 :::tip
 Store sensitive values like client secrets using Kubernetes secrets rather than directly in helm values. Refer to the [Secret Management](./secret-management.mdx) guide for best practices.
 :::

--- a/versioned_docs/version-v1.0.x/platform-engineer-guide/observability-alerting.mdx
+++ b/versioned_docs/version-v1.0.x/platform-engineer-guide/observability-alerting.mdx
@@ -500,6 +500,101 @@ Apply the updated values with `helm upgrade`.
 
 For all available alert storage configuration options, see the [Observability Plane Helm Reference](../reference/helm/observability-plane.mdx#observer).
 
+## Observer External IDP Configuration
+
+By default, OpenChoreo configures Thunder as the identity provider for the Observer with a pre-configured OAuth client.
+If you are using an external identity provider, configure the uid-resolver as described below.
+
+The uid-resolver is a sub-component of the Observer service that resolves component/project/environment identities
+by calling the OpenChoreo control plane API. It uses the OAuth2 `client_credentials` grant to authenticate as a service account when making those calls.
+
+### Step 1: Create an OAuth Client in Your Identity Provider
+
+Create an OAuth 2.0 client with the following settings in your identity provider:
+
+- **Grant type**: `client_credentials`
+- **Client ID**: Choose a name (e.g., `openchoreo-observer-resource-reader-client`)
+- **Scopes**: No specific scopes are required by default. Set this only if your identity provider requires
+  a non-empty scope for the `client_credentials` grant (e.g., `"api://<client-id>/.default"` for Azure AD).
+
+### Step 2: Store the OAuth Client Secret
+
+Store the client secret so the Observer can access it. For example, if you are using OpenBao:
+
+```bash
+kubectl exec -n openbao openbao-0 -- \
+  env BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=root \
+  bao kv put secret/observer-oauth-client-secret value="<YOUR_OAUTH_CLIENT_SECRET>"
+```
+
+Add `UID_RESOLVER_OAUTH_CLIENT_SECRET` to the existing `observer-secret` ExternalSecret in the `openchoreo-observability-plane` namespace:
+
+```bash
+kubectl patch externalsecret observer-secret -n openchoreo-observability-plane --type=json \
+  -p '[{"op":"add","path":"/spec/data/-","value":{"secretKey":"UID_RESOLVER_OAUTH_CLIENT_SECRET","remoteRef":{"key":"observer-oauth-client-secret","property":"value"}}}]'
+```
+
+### Step 3: Configure the Observability Plane
+
+Update your Helm values with the OAuth client ID and the token endpoint of your identity provider:
+
+```yaml
+security:
+  oidc:
+    tokenUrl: "<your-idp-token-url>"
+
+observer:
+  oauthClientId: "<your-client-id>"
+  secretName: "observer-secret"
+```
+
+For environments that use self-signed certificates on the identity provider's token endpoint, also set:
+
+```yaml
+security:
+  oidc:
+    uidResolverTlsInsecureSkipVerify: "true"
+```
+
+:::warning
+Only set `uidResolverTlsInsecureSkipVerify: "true"` in development or testing environments.
+For production deployments, ensure your identity provider uses valid TLS certificates.
+:::
+
+Apply the changes using `helm upgrade` with your updated values.
+
+### Step 4: Grant Control Plane Access
+
+The Observer uses the `observer-resource-reader` role to read resource metadata (projects, components, environments, namespaces) from the control plane API.
+The API matches the `sub` claim in the issued JWT to identify the caller, so the new client must be granted the `observer-resource-reader` role via a bootstrap authorization mapping.
+
+Add the following to your Control Plane values override, replacing `<your-client-id>` with the same client ID used in Step 1:
+
+```yaml
+openchoreoApi:
+  config:
+    security:
+      authorization:
+        bootstrap:
+          mappings:
+            - name: observer-resource-reader-binding
+              kind: ClusterAuthzRoleBinding
+              system: true
+              roleMappings:
+                - roleRef:
+                    name: observer-resource-reader
+                    kind: ClusterAuthzRole
+              entitlement:
+                claim: sub
+                value: "<your-client-id>"
+              effect: allow
+```
+
+:::warning
+When overriding the `bootstrap.mappings` array, the entire array is replaced. Make sure to include all other default bindings you want to keep.
+See the [Authorization Configuration](./authorization.md#customizing-bootstrap-roles-and-bindings) guide for details.
+:::
+
 ---
 
 ## Configuration Reference

--- a/versioned_docs/version-v1.0.x/reference/helm/observability-plane.mdx
+++ b/versioned_docs/version-v1.0.x/reference/helm/observability-plane.mdx
@@ -173,6 +173,12 @@ OpenChoreo Observer service configuration - REST API that abstracts OpenSearch f
 | `observer.tracingAdapter.timeout`     | Timeout for tracing adapter requests                                                                                                                                                                                                             | `string`  | `30s`                                        |
 | `observer.tracingAdapter.url`         | URL of the tracing adapter service                                                                                                                                                                                                               | `string`  | `http://tracing-adapter:9100`                |
 
+:::note
+The Observer includes a **uid-resolver** component that uses the OAuth2 `client_credentials` grant to call the control plane API for component/project/environment identity resolution.
+The relevant values are `observer.oauthClientId`, the `UID_RESOLVER_OAUTH_CLIENT_SECRET` key in `observer.secretName` secret, and `security.oidc.tokenUrl`.
+When using an external identity provider, refer to [Observer External IDP Configuration](../../platform-engineer-guide/observability-alerting.mdx#observer-external-idp-configuration) for setup steps.
+:::
+
 ## Rca
 
 AI-powered Root Cause Analysis agent configuration


### PR DESCRIPTION
## Purpose
This pull request enhances the documentation for configuring the Observer API service to use an external OAuth2 identity provider for authentication. It introduces a new section with step-by-step instructions, updates identity configuration references, and clarifies relevant Helm chart values. These changes are applied both to the main and versioned documentation.

**Key documentation improvements:**

*Observer External IDP Setup:*
- Added a detailed "Observer External IDP Configuration" section describing how to configure the `uid-resolver` with an external OAuth2 identity provider, including OAuth client creation, secret management, Helm value updates, and control plane authorization mapping. [[1]](diffhunk://#diff-9c83745204ac3eec66b0cc394ea6d41f8d689f117ad290fda691e748d133fdc6R503-R597) [[2]](diffhunk://#diff-431ab475408a8fa012ce935f5841dce1c2c41e8b93949ba0a0d24af5cfed77b8R503-R597)

*Identity Configuration References:*
- Updated the identity configuration guides to include the Observer (`uid-resolver`) as a component requiring OAuth client setup, with a link to the new configuration instructions. [[1]](diffhunk://#diff-e9aa96f7e91252e8fdee36941e9df8be3e7b08d6eec8ddccaee0b265dc0bcb8dR182-R185) [[2]](diffhunk://#diff-85755b72a6af61dafcd8c0ab0babde76ba2e9fe4e09d4280ebf6807b692c06baR182-R185)

*Helm Reference Documentation:*
- Added an explanatory note to the Observer Helm reference, clarifying the role of the `uid-resolver` and listing the relevant Helm values and secret keys for OAuth2 configuration. [[1]](diffhunk://#diff-9ca804bc0314231c4177ac9c15821ac52ac904eead8ca2b2e89adb0be49cb7b3R176-R181) [[2]](diffhunk://#diff-9ee0ada1307640a348e21720cecd75f7451024cd23f74cde44a997e287f52ff2R176-R181)

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
