### PR TITLE
Add support for including span and resource attributes in traces query response

### DIFF
--- a/static/api-specs/observability-tracing-adapter-api.yaml
+++ b/static/api-specs/observability-tracing-adapter-api.yaml
@@ -267,6 +267,10 @@ components:
           default: desc
         searchScope:
           $ref: "#/components/schemas/ComponentSearchScope"
+        includeAttributes:
+          type: boolean
+          description: Whether to include span attributes in the response. Defaults to false.
+          default: false
       required: [startTime, endTime, searchScope]
 
 
@@ -362,6 +366,14 @@ components:
                 type: string
                 enum: [ok, error, unset]
                 description: The execution status of the span. One of "ok", "error", or "unset".
+              attributes:
+                type: object
+                description: The span attributes
+                additionalProperties: true
+              resourceAttributes:
+                type: object
+                description: The resource attributes
+                additionalProperties: true
         total:
           type: integer
           description: The total number of matching spans, capped at 1000


### PR DESCRIPTION
## Purpose
> This pull request adds the ability to include span and resource attributes in the traces query response.

## Related Issues
> None.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)

