### PR TITLE
feat: add scroll caret buttons for overflowing tabs

### DIFF
--- a/src/pages/ecosystem/item.module.css
+++ b/src/pages/ecosystem/item.module.css
@@ -222,10 +222,80 @@
 
 /* --- Tab Bar --- */
 .tabBar {
+  position: relative;
   border-top: 1px solid var(--ifm-color-emphasis-200);
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
   overflow: hidden;
   padding: 0 0.5rem;
+}
+
+.tabBar::before,
+.tabBar::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2.5rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 1;
+}
+
+.tabBar::before {
+  left: 0;
+  background: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
+}
+
+.tabBar::after {
+  right: 0;
+  background: linear-gradient(to left, #fff, rgba(255, 255, 255, 0));
+}
+
+.tabBarLeftFaded::before {
+  opacity: 1;
+}
+
+.tabBarRightFaded::after {
+  opacity: 1;
+}
+
+.tabScrollBtn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 9999px;
+  background: #fff;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.tabScrollBtn:hover {
+  color: var(--ifm-color-emphasis-900);
+  background: var(--ifm-color-emphasis-50);
+}
+
+.tabScrollBtn svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.tabScrollBtnLeft {
+  left: 0.25rem;
+}
+
+.tabScrollBtnRight {
+  right: 0.25rem;
 }
 
 .tabList {
@@ -529,6 +599,25 @@ html[data-theme='dark'] .externalButton:hover {
 
 html[data-theme='dark'] .tabBar {
   border-color: var(--ifm-color-emphasis-200);
+}
+
+html[data-theme='dark'] .tabBar::before {
+  background: linear-gradient(to right, #1c1c1e, rgba(28, 28, 30, 0));
+}
+
+html[data-theme='dark'] .tabBar::after {
+  background: linear-gradient(to left, #1c1c1e, rgba(28, 28, 30, 0));
+}
+
+html[data-theme='dark'] .tabScrollBtn {
+  background: #1c1c1e;
+  border-color: var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-600);
+}
+
+html[data-theme='dark'] .tabScrollBtn:hover {
+  color: #fff;
+  background: #2a2a2d;
 }
 
 html[data-theme='dark'] .tab {

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -301,18 +301,21 @@ export default function EcosystemItem(): ReactNode {
   const [canScrollRight, setCanScrollRight] = useState(false);
 
   const updateTabAffordances = useCallback(() => {
-    const el = tabListRef.current;
-    if (!el) return;
-    const { scrollLeft, scrollWidth, clientWidth } = el;
+    const tabListEl = tabListRef.current;
+    if (!tabListEl) return;
+    const { scrollLeft, scrollWidth, clientWidth } = tabListEl;
     setCanScrollLeft(scrollLeft > 1);
     setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
   }, []);
 
   const scrollTabs = useCallback((dir: 'left' | 'right') => {
-    const el = tabListRef.current;
-    if (!el) return;
-    const delta = el.clientWidth * 0.7;
-    el.scrollBy({ left: dir === 'left' ? -delta : delta, behavior: 'smooth' });
+    const tabListEl = tabListRef.current;
+    if (!tabListEl) return;
+    const scrollDistance = tabListEl.clientWidth * 0.7;
+    tabListEl.scrollBy({
+      left: dir === 'left' ? -scrollDistance : scrollDistance,
+      behavior: 'smooth',
+    });
   }, []);
 
   const rawUrl = plugin?.sourceUrl ? toRawDocUrl(plugin.sourceUrl, plugin.group) : null;
@@ -356,16 +359,16 @@ export default function EcosystemItem(): ReactNode {
   );
 
   useEffect(() => {
-    const el = tabListRef.current;
-    if (!el) {
+    const tabListEl = tabListRef.current;
+    if (!tabListEl) {
       setCanScrollLeft(false);
       setCanScrollRight(false);
       return;
     }
     updateTabAffordances();
-    const ro = new ResizeObserver(updateTabAffordances);
-    ro.observe(el);
-    return () => ro.disconnect();
+    const resizeObserver = new ResizeObserver(updateTabAffordances);
+    resizeObserver.observe(tabListEl);
+    return () => resizeObserver.disconnect();
   }, [parsed.sections.length, updateTabAffordances]);
 
   const logoSrc = plugin?.logoUrl && !logoFailed ? plugin.logoUrl : defaultLogo;

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
@@ -296,6 +296,25 @@ export default function EcosystemItem(): ReactNode {
   const [readmeError, setReadmeError] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
 
+  const tabListRef = useRef<HTMLElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateTabAffordances = useCallback(() => {
+    const el = tabListRef.current;
+    if (!el) return;
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    setCanScrollLeft(scrollLeft > 1);
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+  }, []);
+
+  const scrollTabs = useCallback((dir: 'left' | 'right') => {
+    const el = tabListRef.current;
+    if (!el) return;
+    const delta = el.clientWidth * 0.7;
+    el.scrollBy({ left: dir === 'left' ? -delta : delta, behavior: 'smooth' });
+  }, []);
+
   const rawUrl = plugin?.sourceUrl ? toRawDocUrl(plugin.sourceUrl, plugin.group) : null;
 
   useEffect(() => {
@@ -335,6 +354,19 @@ export default function EcosystemItem(): ReactNode {
     () => (readmeRaw && isSkill ? parseSkillFrontmatter(readmeRaw) : null),
     [readmeRaw, isSkill],
   );
+
+  useEffect(() => {
+    const el = tabListRef.current;
+    if (!el) {
+      setCanScrollLeft(false);
+      setCanScrollRight(false);
+      return;
+    }
+    updateTabAffordances();
+    const ro = new ResizeObserver(updateTabAffordances);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [parsed.sections.length, updateTabAffordances]);
 
   const logoSrc = plugin?.logoUrl && !logoFailed ? plugin.logoUrl : defaultLogo;
   const groupLabel = plugin ? (GROUP_LABELS[plugin.group] ?? plugin.group) : '';
@@ -536,11 +568,38 @@ export default function EcosystemItem(): ReactNode {
                   <>
                     {/* Tab bar */}
                     {hasTabs && (
-                      <div className={styles.tabBar}>
+                      <div
+                        className={[
+                          styles.tabBar,
+                          canScrollLeft ? styles.tabBarLeftFaded : '',
+                          canScrollRight ? styles.tabBarRightFaded : '',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                      >
+                        {canScrollLeft && (
+                          <button
+                            type="button"
+                            className={`${styles.tabScrollBtn} ${styles.tabScrollBtnLeft}`}
+                            aria-label="Scroll tabs left"
+                            onClick={() => scrollTabs('left')}
+                          >
+                            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M15 19l-7-7 7-7"
+                              />
+                            </svg>
+                          </button>
+                        )}
                         <nav
+                          ref={tabListRef as React.RefObject<HTMLElement>}
                           className={styles.tabList}
                           role="tablist"
                           aria-label="Section tabs"
+                          onScroll={updateTabAffordances}
                         >
                           {parsed.sections.map((section, idx) => {
                             const isActive = idx === activeTab;
@@ -565,6 +624,23 @@ export default function EcosystemItem(): ReactNode {
                             );
                           })}
                         </nav>
+                        {canScrollRight && (
+                          <button
+                            type="button"
+                            className={`${styles.tabScrollBtn} ${styles.tabScrollBtnRight}`}
+                            aria-label="Scroll tabs right"
+                            onClick={() => scrollTabs('right')}
+                          >
+                            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M9 5l7 7-7 7"
+                              />
+                            </svg>
+                          </button>
+                        )}
                       </div>
                     )}
 


### PR DESCRIPTION
## Purpose
Add scroll caret buttons for overflowing tabs

## Screenshot
<img width="894" height="330" alt="image" src="https://github.com/user-attachments/assets/ffe2448d-6849-47f8-b870-9a68ddb85763" />
