### PR TITLE
docs: recommend pairing MCP with agent skills

### DIFF
--- a/docs/ai/mcp-servers.mdx
+++ b/docs/ai/mcp-servers.mdx
@@ -302,6 +302,15 @@ Access tokens expire (default: 1 hour). When your token expires, re-run the `cur
 </TabItem>
 </Tabs>
 
+:::tip To get the most out of MCP, pair it with skills
+MCP gives your agent the **capabilities** to talk to OpenChoreo. **Skills** teach it how to use them well, so it gets it right first try instead of you correcting it along the way. You can stay in your agentic environment instead of jumping to the UI or CLI. To get started, install one (or both) of the skills below:
+
+- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
+- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
+
+Browse [our ecosystem](https://openchoreo.dev/ecosystem/?group=skill) for all available skills.
+:::
+
 ## Advanced Configuration
 
 For custom AI agents, non-default IdP configurations, or custom OAuth application setups.


### PR DESCRIPTION
## Summary

- Adds a tip block after the Quick Start setup tabs in `docs/ai/mcp-servers.mdx` pointing readers to the `openchoreo-developer` and `openchoreo-platform-engineer` skills.
- Frames MCP as the **capabilities** layer and skills as how the agent learns to use them effectively, so users get correct results on the first prompt instead of nudging the agent along.
- Links out to the [OpenChoreo Skills ecosystem](https://openchoreo.dev/ecosystem/?group=skill) so readers can discover more skills as they're added.

Targets only `docs/` (next/unreleased); released versions under `versioned_docs/` are intentionally untouched.

## Test plan

- [ ] `npm run start` and confirm the new `:::tip` renders correctly on `/docs/ai/mcp-servers/` between the Quick Start tabs and the Advanced Configuration section.
- [ ] Confirm the ecosystem link resolves.
- [ ] `npm run build` passes.