### PR TITLE
feat(ecosystem): render skill marketplace pages from _marketplace.md

### DIFF
--- a/src/pages/ecosystem/item.module.css
+++ b/src/pages/ecosystem/item.module.css
@@ -347,14 +347,85 @@
 
 /* --- Content Card --- */
 .contentCard {
-  padding: 1.75rem 2rem;
+  padding: 1.25rem 2rem;
+}
+
+.contentCard + .contentCard {
+  border-top: 1px solid var(--ifm-color-emphasis-200);
 }
 
 .singleSectionTitle {
   font-size: 1.2rem;
   font-weight: 600;
   color: var(--ifm-color-emphasis-900);
-  margin: 0 0 1.25rem 0;
+  margin: 0 0 0.75rem 0;
+}
+
+.contentCard > :global(*:last-child),
+.contentCard .markdownContent > :global(*:last-child) {
+  margin-bottom: 0;
+}
+
+/* --- Sample blocks (whole-sample toggle) --- */
+.sampleBlock {
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.sampleBlock:first-child {
+  border-top: none;
+}
+
+.sampleBlockToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0.625rem 0;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: var(--ifm-color-emphasis-900);
+}
+
+.sampleBlockToggle:hover .sampleBlockTitle {
+  color: var(--ifm-color-primary);
+}
+
+.sampleBlockChevron {
+  flex: 0 0 auto;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid var(--ifm-color-emphasis-700);
+  border-bottom: 2px solid var(--ifm-color-emphasis-700);
+  transform: rotate(-45deg);
+  transition: transform 0.15s ease;
+  margin-left: 2px;
+}
+
+.sampleBlockChevronOpen {
+  transform: rotate(45deg);
+  margin-top: -2px;
+}
+
+.sampleBlockTitle {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.sampleBlockBody {
+  padding: 0 0 0.875rem 1.125rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.sampleBlockBody > :global(p) {
+  margin: 0 0 0.625rem 0;
+  font-size: 0.9rem;
+}
+
+.sampleBlockBody > :global(*:last-child) {
+  margin-bottom: 0;
 }
 
 /* --- Markdown Content --- */
@@ -477,8 +548,8 @@
   font-size: 0.825rem;
   line-height: 1.6;
   color: #334155;
-  overflow-x: auto;
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   margin: 0;
 }
 

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -136,6 +136,61 @@ function getSkillRefs(sourceUrl: string): { repo: string; name: string } | null 
   return { repo: match[1], name: match[2] };
 }
 
+function toSkillMarketplaceRawUrl(sourceUrl: string): string | null {
+  const refs = getSkillRefs(sourceUrl);
+  if (!refs) return null;
+  const branchMatch = sourceUrl.match(
+    /github\.com\/[^/]+\/[^/]+\/tree\/([^/]+)\//,
+  );
+  if (!branchMatch) return null;
+  return `https://raw.githubusercontent.com/${refs.repo}/${branchMatch[1]}/skills/${refs.name}/assets/_marketplace.md`;
+}
+
+type MarketplaceSection = { title: string; body: string };
+type MarketplaceSample = { title: string; body: string };
+
+function parseMarketplaceSections(markdown: string): MarketplaceSection[] {
+  const lines = markdown.split('\n');
+  const out: MarketplaceSection[] = [];
+  let title: string | null = null;
+  let buf: string[] = [];
+  const flush = () => {
+    if (title !== null) out.push({ title, body: buf.join('\n').trim() });
+    buf = [];
+  };
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      flush();
+      title = line.slice(3).trim();
+    } else if (title !== null) {
+      buf.push(line);
+    }
+  }
+  flush();
+  return out;
+}
+
+function parseMarketplaceSamples(body: string): MarketplaceSample[] {
+  const lines = body.split('\n');
+  const out: MarketplaceSample[] = [];
+  let current: { title: string; lines: string[] } | null = null;
+  const flush = () => {
+    if (!current) return;
+    out.push({ title: current.title, body: current.lines.join('\n').trim() });
+    current = null;
+  };
+  for (const line of lines) {
+    if (line.startsWith('### ')) {
+      flush();
+      current = { title: line.slice(4).trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  flush();
+  return out;
+}
+
 function parseSkillFrontmatter(markdown: string): SkillFrontmatter | null {
   const lines = markdown.split('\n');
   if (lines[0]?.trim() !== '---') return null;
@@ -187,6 +242,58 @@ function parseSkillFrontmatter(markdown: string): SkillFrontmatter | null {
   }
 
   return result;
+}
+
+function SampleBlock({
+  sample,
+  components,
+}: {
+  sample: MarketplaceSample;
+  components: ReturnType<typeof createMdComponents>;
+}) {
+  const [open, setOpen] = useState(false);
+  const inlineComponents = useMemo(
+    () => ({
+      ...components,
+      p: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    }),
+    [components],
+  );
+  return (
+    <div className={styles.sampleBlock}>
+      <button
+        type="button"
+        className={styles.sampleBlockToggle}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span
+          className={`${styles.sampleBlockChevron} ${
+            open ? styles.sampleBlockChevronOpen : ''
+          }`}
+          aria-hidden
+        />
+        <span className={styles.sampleBlockTitle}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={inlineComponents as any}
+          >
+            {sample.title}
+          </ReactMarkdown>
+        </span>
+      </button>
+      {open && sample.body && (
+        <div className={styles.sampleBlockBody}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={components as any}
+          >
+            {sample.body}
+          </ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -294,6 +401,7 @@ export default function EcosystemItem(): ReactNode {
   const [readmeRaw, setReadmeRaw] = useState<string | null>(null);
   const [readmeLoading, setReadmeLoading] = useState(false);
   const [readmeError, setReadmeError] = useState(false);
+  const [marketplaceRaw, setMarketplaceRaw] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState(0);
 
   const tabListRef = useRef<HTMLElement | null>(null);
@@ -319,6 +427,10 @@ export default function EcosystemItem(): ReactNode {
   }, []);
 
   const rawUrl = plugin?.sourceUrl ? toRawDocUrl(plugin.sourceUrl, plugin.group) : null;
+  const marketplaceUrl =
+    plugin?.group === 'skill' && plugin.sourceUrl
+      ? toSkillMarketplaceRawUrl(plugin.sourceUrl)
+      : null;
 
   useEffect(() => {
     setReadmeRaw(null);
@@ -344,6 +456,20 @@ export default function EcosystemItem(): ReactNode {
       });
     return () => controller.abort();
   }, [rawUrl]);
+
+  useEffect(() => {
+    setMarketplaceRaw(null);
+    if (!marketplaceUrl) return;
+    const controller = new AbortController();
+    fetch(marketplaceUrl, { signal: controller.signal })
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((text) => setMarketplaceRaw(text))
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        // 404 / network: silently omit the marketplace sections
+      });
+    return () => controller.abort();
+  }, [marketplaceUrl]);
 
   const isSkill = plugin?.group === 'skill';
 
@@ -381,6 +507,19 @@ export default function EcosystemItem(): ReactNode {
   // Base URL for resolving relative image paths in the README
   const rawBaseUrl = rawUrl ? rawUrl.slice(0, rawUrl.lastIndexOf('/') + 1) : '';
   const mdComponents = useMemo(() => createMdComponents(rawBaseUrl), [rawBaseUrl]);
+
+  const marketplaceBaseUrl = marketplaceUrl
+    ? marketplaceUrl.slice(0, marketplaceUrl.lastIndexOf('/') + 1)
+    : '';
+  const marketplaceMdComponents = useMemo(
+    () => createMdComponents(marketplaceBaseUrl),
+    [marketplaceBaseUrl],
+  );
+
+  const marketplaceSections = useMemo(
+    () => (marketplaceRaw ? parseMarketplaceSections(marketplaceRaw) : []),
+    [marketplaceRaw],
+  );
 
   if (!plugin) {
     return (
@@ -513,41 +652,78 @@ export default function EcosystemItem(): ReactNode {
             {/* Skill: About (frontmatter description) + Installation. SKILL.md body is agent-facing and skipped. */}
             {!readmeLoading && readmeRaw && isSkill && (
               <>
-                {skillInfo?.description && (
-                  <div className={styles.contentCard}>
-                    <h2 className={styles.singleSectionTitle}>About</h2>
-                    <div className={styles.markdownContent}>
-                      <ReactMarkdown
-                        remarkPlugins={[remarkGfm]}
-                        components={mdComponents as any}
-                      >
-                        {skillInfo.description}
-                      </ReactMarkdown>
-                    </div>
-                  </div>
-                )}
                 {(() => {
                   const refs = plugin.sourceUrl ? getSkillRefs(plugin.sourceUrl) : null;
                   const skillName = skillInfo?.name ?? refs?.name;
                   const repo = refs?.repo;
-                  if (!skillName || !repo) return null;
-                  const installMd = [
-                    '```sh',
-                    `npx skills add ${repo} --skill ${skillName} --global`,
-                    '```',
-                  ].join('\n');
-                  return (
-                    <div className={styles.contentCard}>
+                  const canRenderInstall = Boolean(skillName && repo);
+                  const installCard = canRenderInstall ? (
+                    <div key="install" className={styles.contentCard}>
                       <h2 className={styles.singleSectionTitle}>Installation</h2>
                       <div className={styles.markdownContent}>
                         <ReactMarkdown
                           remarkPlugins={[remarkGfm]}
                           components={mdComponents as any}
                         >
-                          {installMd}
+                          {[
+                            '```sh',
+                            `npx skills add ${repo} --skill ${skillName}`,
+                            '```',
+                          ].join('\n')}
                         </ReactMarkdown>
                       </div>
                     </div>
+                  ) : null;
+
+                  const renderSection = (section: MarketplaceSection, idx: number) => {
+                    const isSamples =
+                      section.title.trim().toLowerCase() === 'samples';
+                    const samples = isSamples
+                      ? parseMarketplaceSamples(section.body)
+                      : [];
+                    return (
+                      <div key={`mp-${idx}`} className={styles.contentCard}>
+                        <h2 className={styles.singleSectionTitle}>
+                          {section.title}
+                        </h2>
+                        <div className={styles.markdownContent}>
+                          {isSamples ? (
+                            samples.map((s, i) => (
+                              <SampleBlock
+                                key={`s-${i}`}
+                                sample={s}
+                                components={marketplaceMdComponents}
+                              />
+                            ))
+                          ) : (
+                            <ReactMarkdown
+                              remarkPlugins={[remarkGfm]}
+                              components={marketplaceMdComponents as any}
+                            >
+                              {section.body}
+                            </ReactMarkdown>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  };
+
+                  const isPrereq = (s: MarketplaceSection) => {
+                    const t = s.title.trim().toLowerCase();
+                    return t === 'prerequisites' || t === 'prerequisite';
+                  };
+                  const prereqIdx = marketplaceSections.findIndex(isPrereq);
+                  const prereqSection =
+                    prereqIdx >= 0 ? marketplaceSections[prereqIdx] : null;
+                  const otherSections = marketplaceSections.filter(
+                    (_, i) => i !== prereqIdx,
+                  );
+                  return (
+                    <>
+                      {prereqSection && renderSection(prereqSection, -1)}
+                      {installCard}
+                      {otherSections.map((s, i) => renderSection(s, i))}
+                    </>
                   );
                 })()}
               </>


### PR DESCRIPTION
## Summary

- Skill ecosystem detail pages now fetch \`assets/_marketplace.md\` from the skill's repo and render each \`## Section\` as a content card.
- Auto-generated **About** and **Installation** stay; the file's first \`## Prerequisites\` section (if any) renders before Installation, everything else after.
- The \`## Samples\` section gets a special renderer: each \`### Sample\` is a toggleable row (title visible, body collapsed) — clicking reveals the explanation and any copyable prompt code blocks. A sample can have multiple prompt blocks for stepwise flows.
- Prompt code blocks wrap long lines instead of horizontal-scrolling, and reuse the existing CopyButton.
- Adding a new section to a skill page is a markdown-only change in the skill repo — no code change here.

Companion PR in [openchoreo/skills](https://github.com/openchoreo/skills/pull/2) ships the actual \`_marketplace.md\` files for both skills. The sections render once that PR merges into \`openchoreo/skills:main\`; until then the fetch silently 404s and only About + Installation render (existing behaviour).

## Test plan

- [ ] After companion skills PR merges, visit \`/ecosystem/item/?id=skill-openchoreo-developer\` — Prerequisites, Installation, Use cases, Samples render in that order
- [ ] Same for \`?id=skill-openchoreo-platform-engineer\`
- [ ] Sample toggles open and close; multi-prompt samples render each prompt as a separate copyable block
- [ ] Long prompts wrap inside the code box
- [ ] Other ecosystem groups (modules / integrations / agents / component-types / workflows) still render their READMEs unchanged
- [ ] Skill items without a \`_marketplace.md\` still render (just About + Installation)