### PR TITLE
docs: document per-session MCP tool filtering and link reference from AI overview

### DIFF
--- a/docs/ai/overview.mdx
+++ b/docs/ai/overview.mdx
@@ -19,7 +19,7 @@ OpenChoreo exposes [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 This turns your AI assistant into an active participant in your platform operations — not just a code suggester, but a collaborator that understands your infrastructure.
 
-See [Configuring MCP Servers with AI Assistants](./mcp-servers.mdx) to connect your AI assistant to OpenChoreo.
+See the [MCP Servers Reference](../reference/mcp-servers.mdx) for the full list of available tools and server configuration options, and follow [Configuring MCP Servers with AI Assistants](./mcp-servers.mdx) to connect your AI assistant to OpenChoreo.
 
 ## Built-in Agents
 

--- a/docs/reference/mcp-servers.mdx
+++ b/docs/reference/mcp-servers.mdx
@@ -282,6 +282,25 @@ The Control Plane MCP server exposes six toolsets: `namespace`, `project`, `comp
 The `namespace` and `project` toolsets are useful companions for the PE toolset — they let platform engineers discover resources without enabling all developer toolsets.
 :::
 
+## Per-Session Tool Filtering
+
+By default, the Control Plane MCP server filters `tools/list` and `tools/call` results by the authenticated user's permissions. Tools the user lacks permission for are hidden, and unauthorized calls are rejected. MCP clients can additionally narrow what a session sees, or opt out of authorization-based filtering, by passing optional query parameters when establishing the session.
+
+| Query Parameter | Required | Default                 | Description                                                                                                                                              |
+| --------------- | -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toolsets`      | `false`  | All configured toolsets | Comma-separated list of toolsets to expose via `tools/list` for the session (e.g. `namespace,component,pe`). Unknown toolset names are silently ignored. |
+| `filterByAuthz` | `false`  | `true`                  | When `true`, hides tools the user cannot call and rejects unauthorized invocations. Set to `false` to disable MCP-layer authorization filtering.         |
+
+**Example:**
+
+```
+http://api.openchoreo.localhost:8080/mcp?toolsets=namespace,component,pe&filterByAuthz=false
+```
+
+:::note
+Both query parameters are HTTP-only and read once when the session is established. The `toolsets` parameter only filters `tools/list` results; it does not gate `tools/call`. The control plane API enforces authorization independently of `filterByAuthz`, so disabling MCP-layer filtering does not grant additional access. It just exposes tools the user cannot successfully invoke.
+:::
+
 ## Finding MCP Server URLs
 
 MCP server URLs follow a simple pattern based on the respective service's hostname:


### PR DESCRIPTION
## Purpose
Documents the two new per-session tool filtering capabilities of the Control Plane MCP server:
- Authorization-based filtering of `tools/list` and `tools/call` (default-on).
- Optional `?toolsets=` and `?filterByAuthz=` query parameters for narrowing session visibility.

Also adds a link to the MCP Servers reference from the **Working with AI** overview page so the tool catalog and configuration options are easier to discover.

## Related Issues
Addresses the feature detail documenting of: https://github.com/openchoreo/openchoreo/issues/3395

> Note: The tool updates will be sent in a separate PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
