### PR TITLE
docs: update MCP tool reference for new control-plane tools

### DIFF
--- a/docs/reference/mcp-servers.mdx
+++ b/docs/reference/mcp-servers.mdx
@@ -36,46 +36,53 @@ For the best experience, configure **both** the Control Plane and Observability 
 
 ### Control Plane MCP Server
 
-The Control Plane MCP server provides **90 unique tools** organized into six toolsets.
+The Control Plane MCP server provides **104 unique tools** organized into six toolsets.
 
 :::info Tools in multiple toolsets
-Some read-only tools (marked with †) appear in both the default developer toolsets and the PE toolset. This allows platform engineers to use the PE toolset alongside Namespace and Project toolsets without needing to enable all developer toolsets. When all six toolsets are enabled, the total remains 90 unique tools.
+Some read-only tools (marked with †) appear in both the default developer toolsets and the PE toolset. This allows platform engineers to use the PE toolset alongside Namespace and Project toolsets without needing to enable all developer toolsets. The per-toolset counts below sum to 117 (7 + 3 + 22 + 9 + 12 + 64); subtracting the 13 †-marked cross-toolset duplicates leaves 104 unique tools.
 :::
 
 <details>
-<summary><strong>Namespace Toolset (3 tools)</strong></summary>
+<summary><strong>Namespace Toolset (7 tools)</strong></summary>
 
 - `list_namespaces` — List all namespaces (top-level containers for organizing projects, components, and resources)
 - `create_namespace` — Create a new namespace
 - `list_secret_references` — List all secret references (credentials and sensitive configuration) for a namespace
+- `get_secret_reference` — Get a single secret reference's full spec (template, data sources, refresh interval, target plane). For sync status, query `get_resource_events` (PE toolset; enable PE alongside Namespace) against the rendered ExternalSecret on the data plane
+- `create_secret_reference` — Create a new secret reference; spec must include `template` (Kubernetes Secret type) and `data[]` (mapping of secret keys to external store references)
+- `update_secret_reference` — Update an existing secret reference; annotations are merged, spec is replaced wholesale when provided
+- `delete_secret_reference` — Delete a secret reference (the underlying Kubernetes Secret is removed by the controller)
 
 </details>
 
 <details>
-<summary><strong>Project Toolset (2 tools)</strong></summary>
+<summary><strong>Project Toolset (3 tools)</strong></summary>
 
 - `list_projects` — List all projects in a namespace (logical groupings of related components sharing deployment pipelines)
 - `create_project` — Create a new project in a namespace
+- `delete_project` — Delete a project; cascades via finalizer to remove all components, workloads, releases, and bindings owned by the project
 
 </details>
 
 <details>
-<summary><strong>Component Toolset (20 tools)</strong></summary>
+<summary><strong>Component Toolset (22 tools)</strong></summary>
 
 **Component Management**
 
 - `create_component` — Create a new component in a project
 - `list_components` — List all components in a project (deployable units with independent build and deployment lifecycles)
 - `get_component` — Get detailed component info including configuration, deployment status, and builds
-- `patch_component` — Partially update a component's configuration (autoDeploy, parameters)
+- `patch_component` — Partially update a component's configuration (display_name, description, autoDeploy, parameters, traits, workflow); pass an empty array for traits to clear all traits
+- `delete_component` — Delete a component; cascades via finalizer to its workloads, releases, and release bindings
 - `get_component_schema` — Get the JSON schema for a component's configuration options
 
 **Workload Management**
 
 - `list_workloads` — List workloads for a component (names, images, endpoint names)
-- `get_workload` — Get detailed workload info including container configuration, endpoints, and dependencies
+- `get_workload` — Get detailed workload info; returns the full Spec (round-trip-safe with `update_workload`)
 - `create_workload` — Create a new workload for a component (runtime spec: containers, resources, env vars)
 - `update_workload` — Update an existing workload's specification (container config, env vars, port mappings, resource limits)
+- `delete_workload` — Delete a workload; for reversible removal of just the deployment, use `update_release_binding` with `release_state: Undeploy`
 - `get_workload_schema` — Get the JSON schema for the workload specification
 
 **Platform Standards — Read-Only, Namespace-Scoped**
@@ -97,13 +104,14 @@ Some read-only tools (marked with †) appear in both the default developer tool
 </details>
 
 <details>
-<summary><strong>Deployment Toolset (8 tools)</strong></summary>
+<summary><strong>Deployment Toolset (9 tools)</strong></summary>
 
 - `create_release_binding` — Create a new release binding to deploy a component to a specific environment
 - `list_release_bindings` — List release bindings associating releases with environments for a component
 - `get_release_binding` — Get detailed info for a specific release binding including state, overrides, and endpoints
-- `update_release_binding` — Update a release binding's configuration (release, overrides, traits, workload settings)
-- `update_release_binding_state` — Update a release binding's state (Active or Undeploy) for a component in an environment
+- `update_release_binding` — Update a release binding's configuration (release, release_state, overrides, traits, workload settings); set `release_state: Active` to deploy or `Undeploy` to remove from the data plane while keeping the binding
+- `delete_release_binding` — Delete a release binding entirely; for reversible removal that keeps the binding, use `update_release_binding` with `release_state: Undeploy` instead
+- `delete_component_release` — Delete a component release (immutable; useful for pruning old releases)
 - `list_deployment_pipelines` — List all deployment pipelines defining environment promotion order in a namespace
 - `get_deployment_pipeline` — Get detailed deployment pipeline info including stages, promotion order, and environments
 - `list_environments` † — List all environments (deployment targets like dev, staging, production) in a namespace
@@ -111,12 +119,15 @@ Some read-only tools (marked with †) appear in both the default developer tool
 </details>
 
 <details>
-<summary><strong>Build Toolset (9 tools)</strong></summary>
+<summary><strong>Build Toolset (12 tools)</strong></summary>
 
 - `trigger_workflow_run` — Trigger a workflow run for a component using the component's configured workflow and parameters
 - `create_workflow_run` — Create a new workflow run by specifying a workflow name and optional parameters
 - `list_workflow_runs` — List workflow run executions in a namespace; optionally filter by project and component
 - `get_workflow_run` — Get detailed info for a workflow run including status, tasks, and timestamps
+- `get_workflow_run_status` — Get the live status of a workflow run (phase, task progress)
+- `get_workflow_run_logs` — Stream live logs for a workflow run (live-only — does not return archived logs for completed runs); optional `task` filter
+- `get_workflow_run_events` — Get Kubernetes events for a workflow run (scheduling, pod-startup failures); optional `task` filter
 - `list_workflows` † — List all workflow templates in a namespace (CI/CD pipelines executed on the workflow plane)
 - `get_workflow_schema` † — Get the parameter schema for a workflow template
 - `list_cluster_workflows` — List cluster-scoped workflow definitions shared across namespaces
@@ -126,7 +137,7 @@ Some read-only tools (marked with †) appear in both the default developer tool
 </details>
 
 <details>
-<summary><strong>Platform Engineering (PE) Toolset (61 tools)</strong></summary>
+<summary><strong>Platform Engineering (PE) Toolset (64 tools)</strong></summary>
 
 :::note
 The PE toolset is enabled by default. These tools are intended for platform administrators who manage infrastructure, environments, platform standards, and deployment pipelines. If you need to disable the PE toolset, see [Configuring MCP Toolsets](#configuring-mcp-toolsets).
@@ -182,11 +193,14 @@ The PE toolset is enabled by default. These tools are intended for platform admi
 - `get_workflow` — Get the full definition of a workflow including its complete spec
 - `get_workflow_schema` † — Get the parameter schema for a workflow template
 
-**Platform Standards — Creation Schemas (3)**
+**Platform Standards — Creation Schemas (6)**
 
 - `get_component_type_creation_schema` — Get the spec schema for creating a namespace-scoped component type
 - `get_cluster_component_type_creation_schema` — Get the spec schema for creating a cluster-scoped component type
 - `get_trait_creation_schema` — Get the spec schema for creating a namespace-scoped trait
+- `get_cluster_trait_creation_schema` — Get the spec schema for creating a cluster-scoped trait
+- `get_workflow_creation_schema` — Get the spec schema for creating a namespace-scoped workflow
+- `get_cluster_workflow_creation_schema` — Get the spec schema for creating a cluster-scoped workflow
 
 **Platform Standards — Write, Namespace-Scoped (9)**
 


### PR DESCRIPTION
## Purpose

Brings `docs/reference/mcp-servers.mdx` in sync with the MCP tool surface changes from openchoreo/openchoreo#3389. Total moves from 90 → 104 unique tools.

Per-toolset breakdown:

- **Namespace toolset (3 → 7)** — adds `get_secret_reference`, `create_secret_reference`, `update_secret_reference`, `delete_secret_reference`. \`get_secret_reference\` description points agents at \`get_resource_events\` against the rendered ExternalSecret on the data plane for actual sync status.
- **Project toolset (2 → 3)** — adds `delete_project`; description notes the finalizer-driven cascade to all components/workloads/releases/bindings.
- **Component toolset (20 → 22)** — adds `delete_component`, `delete_workload`. Updates \`patch_component\` description to reflect the extended fields (display_name, description, traits, workflow). Updates \`get_workload\` to mention round-trip safety with \`update_workload\`.
- **Deployment toolset (8 → 9)** — adds `delete_release_binding`, `delete_component_release`. Removes \`update_release_binding_state\` (folded into \`update_release_binding\` as a \`release_state\` field). Updates \`update_release_binding\` description.
- **PE toolset (61 → 64)** — adds three creation-schema tools: \`get_cluster_trait_creation_schema\`, \`get_workflow_creation_schema\`, \`get_cluster_workflow_creation_schema\`. Updates the \"Platform Standards — Creation Schemas\" sub-section count (3 → 6).

## Related Issues

https://github.com/openchoreo/openchoreo/issues/3395

## Checklist
- [x] Updated \`sidebars.ts\` if adding a new documentation page _(no new pages — only edits to existing reference doc)_
- [ ] Run \`npm run start\` to preview the changes locally
- [ ] Run \`npm run build\` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)