### PR TITLE
feat: generate versioned llms.txt on build

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -52,6 +52,7 @@ const config: Config = {
     '@docsearch/docusaurus-adapter',
     './plugins/docusaurus-plugin-swagger-dark-mode',
     './plugins/docusaurus-plugin-markdown-export',
+    './plugins/docusaurus-plugin-llms-txt',
     './plugins/docusaurus-plugin-docs-scripts',
     function webpackPolyfillsPlugin() {
       const webpack = require('webpack');

--- a/plugins/docusaurus-plugin-llms-txt/index.js
+++ b/plugins/docusaurus-plugin-llms-txt/index.js
@@ -1,0 +1,221 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function pluginLlmsTxt(context, options = {}) {
+  const { siteConfig } = context;
+  const sidebarName = options.sidebarName || 'docsSidebar';
+
+  let loadedVersions = null;
+
+  function fileNameForVersion(version) {
+    if (version.versionName === 'current') return 'llms-next.txt';
+    return `llms-${version.versionName}.txt`;
+  }
+
+  function absoluteUrl(permalink) {
+    if (!permalink) return '';
+    if (/^https?:\/\//.test(permalink)) return permalink;
+    const host = (siteConfig.url || '').replace(/\/$/, '');
+    return host + permalink;
+  }
+
+  // Mirror the URL convention from docusaurus-plugin-markdown-export:
+  //   /docs/<prefix>/<slug>          → /docs/<prefix>/<slug>.md
+  //   /docs/<prefix>/  (root slug)   → /docs/<prefix>.md
+  //   /docs/                         → /docs.md
+  function markdownUrl(permalink) {
+    if (!permalink) return '';
+    const trimmed = permalink.replace(/\/+$/, '');
+    return absoluteUrl(trimmed + '.md');
+  }
+
+  function escapeInline(s) {
+    if (!s) return '';
+    return String(s).replace(/\s+/g, ' ').trim();
+  }
+
+  function formatBullet(doc, overrideLabel) {
+    const title = escapeInline(overrideLabel || doc.title || doc.id);
+    const url = markdownUrl(doc.permalink);
+    return `- [${title}](${url})`;
+  }
+
+  function getDocByRef(ref, docsById) {
+    return docsById.get(ref) || null;
+  }
+
+  // Render a category's body: direct doc/link bullets first, then nested
+  // categories as deeper headings. `depth` is the heading level for nested
+  // categories (e.g. 3 → "###").
+  function renderCategoryBody(items, depth, lines, docsById) {
+    const directBullets = [];
+    const subcategories = [];
+
+    for (const item of items) {
+      if (typeof item === 'string') {
+        const doc = getDocByRef(item, docsById);
+        if (doc) directBullets.push(formatBullet(doc));
+      } else if (!item || typeof item !== 'object') {
+        continue;
+      } else if (item.type === 'doc' || item.type === 'ref') {
+        const doc = getDocByRef(item.id, docsById);
+        if (doc) directBullets.push(formatBullet(doc, item.label));
+      } else if (item.type === 'category') {
+        subcategories.push(item);
+      } else if (item.type === 'link' && item.href) {
+        directBullets.push(
+          `- [${escapeInline(item.label || item.href)}](${item.href})`
+        );
+      }
+    }
+
+    for (const b of directBullets) lines.push(b);
+    if (directBullets.length) lines.push('');
+
+    const heading = '#'.repeat(Math.min(depth, 6));
+    for (const sub of subcategories) {
+      lines.push(`${heading} ${escapeInline(sub.label)}`);
+      lines.push('');
+      if (sub.link?.type === 'doc') {
+        const doc = getDocByRef(sub.link.id, docsById);
+        if (doc) {
+          lines.push(formatBullet(doc, sub.label));
+          lines.push('');
+        }
+      }
+      renderCategoryBody(sub.items || [], depth + 1, lines, docsById);
+    }
+  }
+
+  function siteRootUrl() {
+    const host = (siteConfig.url || '').replace(/\/$/, '');
+    const base = siteConfig.baseUrl || '/';
+    return host + (base.startsWith('/') ? base : '/' + base);
+  }
+
+  function appendVersionsFooter(lines, allVersions) {
+    if (!allVersions || allVersions.length === 0) return;
+    const root = siteRootUrl();
+    lines.push('## Other versions');
+    lines.push('');
+    const lastVersion = allVersions.find((v) => v.isLast);
+    if (lastVersion) {
+      lines.push(
+        `- [Latest stable (${lastVersion.label || lastVersion.versionName})](${root}llms.txt)`
+      );
+    }
+    for (const v of allVersions) {
+      if (v.versionName === 'current') {
+        lines.push(`- [Bleeding edge (next)](${root}llms-next.txt)`);
+      } else {
+        lines.push(`- [${v.label || v.versionName}](${root}llms-${v.versionName}.txt)`);
+      }
+    }
+    lines.push('');
+  }
+
+  function buildContent(version, allVersions) {
+    const sidebar = version.sidebars?.[sidebarName];
+    const docsById = new Map();
+    for (const d of version.docs || []) {
+      docsById.set(d.id, d);
+      if (d.unversionedId && !docsById.has(d.unversionedId)) {
+        docsById.set(d.unversionedId, d);
+      }
+    }
+
+    const versionLabel = version.label || version.versionName;
+    const lines = [];
+    lines.push(`# ${siteConfig.title} Documentation (${versionLabel})`);
+    lines.push('');
+    if (siteConfig.tagline) {
+      lines.push(`> ${siteConfig.tagline}`);
+      lines.push('');
+    }
+
+    if (!sidebar) {
+      lines.push(`_No sidebar named "${sidebarName}" found for this version._`);
+      return lines.join('\n') + '\n';
+    }
+
+    for (const item of sidebar) {
+      if (typeof item === 'string') {
+        const doc = getDocByRef(item, docsById);
+        if (!doc) continue;
+        lines.push(`## ${escapeInline(doc.title || doc.id)}`);
+        lines.push('');
+        lines.push(formatBullet(doc));
+        lines.push('');
+      } else if (item.type === 'doc' || item.type === 'ref') {
+        const doc = getDocByRef(item.id, docsById);
+        if (!doc) continue;
+        lines.push(`## ${escapeInline(item.label || doc.title || doc.id)}`);
+        lines.push('');
+        lines.push(formatBullet(doc, item.label));
+        lines.push('');
+      } else if (item.type === 'category') {
+        lines.push(`## ${escapeInline(item.label)}`);
+        lines.push('');
+        if (item.link?.type === 'doc') {
+          const doc = getDocByRef(item.link.id, docsById);
+          if (doc) {
+            lines.push(formatBullet(doc, item.label));
+            lines.push('');
+          }
+        }
+        renderCategoryBody(item.items || [], 3, lines, docsById);
+      } else if (item.type === 'link' && item.href) {
+        lines.push(`## ${escapeInline(item.label || item.href)}`);
+        lines.push('');
+        lines.push(`- [${escapeInline(item.label || item.href)}](${item.href})`);
+        lines.push('');
+      }
+    }
+
+    appendVersionsFooter(lines, allVersions);
+
+    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+  }
+
+  return {
+    name: 'docusaurus-plugin-llms-txt',
+
+    async allContentLoaded({ allContent }) {
+      const docsPlugin = allContent?.['docusaurus-plugin-content-docs'];
+      const docsContent = docsPlugin?.default;
+      if (!docsContent?.loadedVersions) {
+        console.warn('[llms-txt] docs plugin content not found; skipping');
+        return;
+      }
+      loadedVersions = docsContent.loadedVersions;
+    },
+
+    async postBuild({ outDir }) {
+      if (!loadedVersions) {
+        console.warn('[llms-txt] no loaded versions; skipping');
+        return;
+      }
+
+      let written = 0;
+      let lastVersionContent = null;
+
+      for (const version of loadedVersions) {
+        const content = buildContent(version, loadedVersions);
+        const fileName = fileNameForVersion(version);
+        const outPath = path.join(outDir, fileName);
+        fs.writeFileSync(outPath, content);
+        written++;
+        if (version.isLast) lastVersionContent = content;
+      }
+
+      if (lastVersionContent) {
+        fs.writeFileSync(path.join(outDir, 'llms.txt'), lastVersionContent);
+        written++;
+      } else {
+        console.warn('[llms-txt] no version flagged isLast; llms.txt not written');
+      }
+
+      console.log(`[llms-txt] Wrote ${written} llms*.txt files to build/`);
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Adds a local `docusaurus-plugin-llms-txt` that emits one `llms-<version>.txt` per docs version (and `llms-next.txt` for the unreleased branch) at build time.
- Adds an unversioned `llms.txt` that mirrors the version flagged `lastVersion` in the docs config — so when a new minor is cut and `lastVersion` is bumped, `llms.txt` auto-tracks it.
- Each file ends with an "Other versions" footer listing every available variant inline, so a tool that fetches one llms.txt can immediately discover the rest.

## Why a local plugin (and not a community llms-txt plugin)
This site already has `docusaurus-plugin-markdown-export` (sibling plugin in this repo) producing clean Markdown for every doc page across every version. Existing community llms-txt plugins re-implement their own MDX-to-Markdown stripping pipeline and don't surface the *list* of available versions inside each generated file.

This plugin doesn't process Markdown at all. It hooks `allContentLoaded`, reads `loadedVersions` from the docs plugin (which already has each version's sidebar, doc titles, and resolved permalinks), and assembles those into a per-version index whose bullets point at the `.md` URLs the markdown-export plugin already writes (`/docs/<prefix>/<slug>.md`). The novel piece is the in-file "Other versions" footer — a reader of any single llms*.txt sees the full set of versioned files at once.

## Output structure
- Top-level sidebar categories → `## H2`
- Nested categories → `### H3` (and `####` for deeper levels)
- Doc items → bulleted `[Title](markdown-url)`
- "Other versions" footer at the bottom of every file

## Sample (excerpt of `llms-v1.0.x.txt`)

~~~markdown
# OpenChoreo Documentation (v1.0.x)

> A complete, open-source developer platform for Kubernetes, ready to use from day one, built to integrate with your stack.

## Overview

- [What is OpenChoreo](https://openchoreo.dev/docs.md)
- [Architecture](https://openchoreo.dev/docs/overview/architecture.md)

## Platform Engineer Guide

### Platform Setup

- [Deployment Topology](https://openchoreo.dev/docs/platform-engineer-guide/deployment-topology.md)
- [Multi-Cluster Connectivity](https://openchoreo.dev/docs/platform-engineer-guide/multi-cluster-connectivity.md)
- [Controlplane Namespace Management](https://openchoreo.dev/docs/platform-engineer-guide/namespace-management.md)

### Component Types & Traits

- [Overview](https://openchoreo.dev/docs/platform-engineer-guide/component-types/overview.md)
- [Templating Syntax](https://openchoreo.dev/docs/platform-engineer-guide/component-types/templating-syntax.md)

## Other versions

- [Latest stable (v1.0.x)](https://openchoreo.dev/llms.txt)
- [Bleeding edge (next)](https://openchoreo.dev/llms-next.txt)
- [v1.0.x](https://openchoreo.dev/llms-v1.0.x.txt)
- [v0.17.x](https://openchoreo.dev/llms-v0.17.x.txt)
- [v0.16.x](https://openchoreo.dev/llms-v0.16.x.txt)
- [v0.15.x](https://openchoreo.dev/llms-v0.15.x.txt)
- [v0.14.x](https://openchoreo.dev/llms-v0.14.x.txt)
~~~

## Refs
- openchoreo/openchoreo#3399

## Test plan
- [ ] `npm run build` produces `build/llms.txt`, `build/llms-next.txt`, and `build/llms-v<version>.txt` for every entry in `versions.json`.
- [ ] `build/llms.txt` matches `build/llms-v<lastVersion>.txt` byte-for-byte.
- [ ] Bullet URLs end in `.md` and resolve to a file generated by `docusaurus-plugin-markdown-export`.
- [ ] Top-level sidebar categories render as H2; nested categories render as H3 (and deeper).
- [ ] "Other versions" footer lists every version including `next` and the lastVersion mirror.