### PR TITLE
fix: issues with padding in homepage feature card images

### DIFF
--- a/src/components/common/ExpandableImage/styles.module.css
+++ b/src/components/common/ExpandableImage/styles.module.css
@@ -60,8 +60,7 @@
 .fillImage {
   width: 100%;
   height: 100%;
-  padding: 0.75rem;
-  box-sizing: border-box;
+  padding: 0;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## Purpose

Fixes a padding issue that's only visible when built/deployed (missed it in the previous PR)

Before:
<img width="744" height="571" alt="image" src="https://github.com/user-attachments/assets/56f20196-097a-4c9e-91d5-fab447a185f3" />

After:
<img width="711" height="551" alt="image" src="https://github.com/user-attachments/assets/5e27d5a1-90d3-45a7-b76f-a75386f6cee7" />


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
