### PR TITLE
chore: update metrics module version in installation guide

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -623,7 +623,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2
+  --version 0.5.1
 ```
 
 #### Enable logs collection in the configured logs module

--- a/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
+++ b/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
@@ -38,7 +38,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2
+  --version 0.5.1
 
 step "Enabling logs collection in the configured logs module..."
 helm upgrade observability-logs-opensearch \

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -968,7 +968,7 @@ helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2
+  --version 0.5.1
 ```
 
 #### Install the traces module (OpenSearch)


### PR DESCRIPTION
## Purpose
Update the Observability metrics module version to 0.5.1 in installation guides

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
