### PR TITLE
docs: enable expandable images in explore pages

### DIFF
--- a/src/components/WhatIsOpenChoreo/index.tsx
+++ b/src/components/WhatIsOpenChoreo/index.tsx
@@ -408,7 +408,6 @@ function FeatureVisual({
               src={imageSrc}
               alt={imageAlt}
               className={clsx(styles.expandableMedia, styles.plainMedia)}
-              hintText="Expand"
               fillContainer
               gutterBottom={false}
             />
@@ -451,7 +450,6 @@ function FeatureVisual({
               src={imageSrc}
               alt={imageAlt}
               className={styles.expandableMedia}
-              hintText="Expand"
               fillContainer
               fullBleed={fullBleedMedia}
               wrapToImage={fullBleedMedia}

--- a/src/components/common/ExpandableImage/MaximizeIcon.tsx
+++ b/src/components/common/ExpandableImage/MaximizeIcon.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+type MaximizeIconProps = {
+  size?: number;
+  className?: string;
+};
+
+export default function MaximizeIcon({
+  size = 16,
+  className,
+}: MaximizeIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline points="15 3 21 3 21 9" />
+      <polyline points="9 21 3 21 3 15" />
+      <line x1="21" y1="3" x2="14" y2="10" />
+      <line x1="3" y1="21" x2="10" y2="14" />
+    </svg>
+  );
+}

--- a/src/components/common/ExpandableImage/index.tsx
+++ b/src/components/common/ExpandableImage/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import styles from "./styles.module.css";
 import clsx from "clsx";
+import MaximizeIcon from "./MaximizeIcon";
 
 type SvgrComponent = React.ComponentType<React.SVGProps<SVGSVGElement>>;
 
@@ -9,7 +10,6 @@ type ExpandableImageProps = {
   src: string | SvgrComponent;
   alt: string;
   className?: string;
-  hintText?: string;
   /** makes the trigger behave like a fill media surface instead of a standalone content block */
   fillContainer?: boolean;
   /** removes the component's built-in padded frame so the image can fill edge-to-edge */
@@ -27,7 +27,6 @@ export default function ExpandableImage({
   src,
   alt,
   className = "",
-  hintText = "Click to expand",
   fillContainer = false,
   fullBleed = false,
   wrapToImage = false,
@@ -174,21 +173,7 @@ export default function ExpandableImage({
         >
           <ImageContent imgClassName={imageClassName} />
           <span className={hintClassName} aria-hidden="true">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="15 3 21 3 21 9" />
-              <polyline points="9 21 3 21 3 15" />
-              <line x1="21" y1="3" x2="14" y2="10" />
-              <line x1="3" y1="21" x2="10" y2="14" />
-            </svg>
+            <MaximizeIcon />
           </span>
         </button>
       </div>

--- a/src/components/common/ExpandableImage/index.tsx
+++ b/src/components/common/ExpandableImage/index.tsx
@@ -173,7 +173,23 @@ export default function ExpandableImage({
           aria-label={`Open ${alt} in full screen`}
         >
           <ImageContent imgClassName={imageClassName} />
-          <span className={hintClassName}>{hintText}</span>
+          <span className={hintClassName} aria-hidden="true">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="15 3 21 3 21 9" />
+              <polyline points="9 21 3 21 3 15" />
+              <line x1="21" y1="3" x2="14" y2="10" />
+              <line x1="3" y1="21" x2="10" y2="14" />
+            </svg>
+          </span>
         </button>
       </div>
 

--- a/src/components/common/ExpandableImage/styles.module.css
+++ b/src/components/common/ExpandableImage/styles.module.css
@@ -228,8 +228,8 @@
   }
 
   .expandHint {
-    padding: 0.3rem 0.55rem;
-    font-size: 0.7rem;
+    width: 1.75rem;
+    height: 1.75rem;
   }
 
   .lightboxSvgFrame {

--- a/src/components/common/ExpandableImage/styles.module.css
+++ b/src/components/common/ExpandableImage/styles.module.css
@@ -89,12 +89,15 @@
 }
 
 .expandHint {
-  padding: 0.45rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
   border-radius: 999px;
   background: rgba(12, 20, 33, 0.8);
   color: #fff;
-  font-size: 0.85rem;
-  font-weight: 600;
   flex-shrink: 0;
 }
 

--- a/src/pages/explore/backstage-powered-developer-portal.tsx
+++ b/src/pages/explore/backstage-powered-developer-portal.tsx
@@ -4,6 +4,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 import Layout from "@theme/Layout";
 import Button from "@site/src/components/common/Button";
 import BrowserShell from "@site/src/components/common/BrowserShell";
+import ExpandableImage from "@site/src/components/common/ExpandableImage";
 
 import portalPlatformView from "@site/blog/assets/joining-cncf-blog/portal_platform_view.png";
 
@@ -187,12 +188,14 @@ export default function BackstagePoweredDeveloperPortal(): ReactNode {
               </div>
 
               <BrowserShell className={styles.heroVisualFrame}>
-                <img
+                <ExpandableImage
                   src={useBaseUrl(
                     "/img/explore/backstage-powered-developer-portal/hero-home.png",
                   )}
                   alt="OpenChoreo portal home view powered by Backstage."
                   className={styles.heroVisual}
+                  fillContainer
+                  gutterBottom={false}
                 />
               </BrowserShell>
             </div>
@@ -235,7 +238,7 @@ export default function BackstagePoweredDeveloperPortal(): ReactNode {
 
                   <div className={styles.storyMedia}>
                     <BrowserShell className={styles.mediaFrame}>
-                      <img
+                      <ExpandableImage
                         src={
                           section.image.startsWith("/img/")
                             ? useBaseUrl(section.image)
@@ -243,6 +246,8 @@ export default function BackstagePoweredDeveloperPortal(): ReactNode {
                         }
                         alt={section.alt}
                         className={styles.sectionImage}
+                        fillContainer
+                        gutterBottom={false}
                       />
                     </BrowserShell>
                   </div>

--- a/src/pages/explore/observability.tsx
+++ b/src/pages/explore/observability.tsx
@@ -5,6 +5,7 @@ import Layout from "@theme/Layout";
 import Button from "@site/src/components/common/Button";
 import BrowserShell from "@site/src/components/common/BrowserShell";
 import TerminalShell from "@site/src/components/common/TerminalShell";
+import ExpandableImage from "@site/src/components/common/ExpandableImage";
 
 import styles from "./observability.module.css";
 
@@ -168,12 +169,14 @@ export default function Observability(): ReactNode {
               </div>
 
               <BrowserShell className={styles.heroVisualFrame}>
-                <img
+                <ExpandableImage
                   src={useBaseUrl(
                     "/img/explore/observability/observability-with-ai.gif",
                   )}
                   alt="Observability with AI in OpenChoreo"
                   className={styles.heroVisual}
+                  fillContainer
+                  gutterBottom={false}
                 />
               </BrowserShell>
             </div>
@@ -276,10 +279,12 @@ export default function Observability(): ReactNode {
                       />
                     ) : (
                       <BrowserShell className={styles.mediaFrame}>
-                        <img
+                        <ExpandableImage
                           src={useBaseUrl(section.image)}
                           alt={section.alt}
                           className={styles.sectionImage}
+                          fillContainer
+                          gutterBottom={false}
                         />
                       </BrowserShell>
                     )}


### PR DESCRIPTION
## Purpose

Enables image expansion for the screenshots in the explore pages.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
