### PR TITLE
fix: align breadcrumb chevrons with text on ecosystem item page

### DIFF
--- a/src/pages/ecosystem/item.module.css
+++ b/src/pages/ecosystem/item.module.css
@@ -27,6 +27,11 @@
   color: var(--ifm-color-emphasis-600);
 }
 
+.breadcrumbList li {
+  display: flex;
+  align-items: center;
+}
+
 .breadcrumbLink {
   color: var(--ifm-color-emphasis-600);
   text-decoration: none;


### PR DESCRIPTION
## Purpose
- Fixed vertical misalignment between breadcrumb text and chevron icons on the ecosystem item view page                                                                                
- Added flex alignment to breadcrumb list items to ensure consistent vertical centering 


## Screenshot

Before:
<img width="995" height="307" alt="image" src="https://github.com/user-attachments/assets/320b7641-018f-4598-9b26-b8caf36d2411" />

After:
<img width="1000" height="255" alt="image" src="https://github.com/user-attachments/assets/686c4de1-fd10-4dc3-97e7-d8bc4cc91730" />
