### PR TITLE
feat: add openchoreo-setup skill to marketplace plugins

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -584,5 +584,23 @@
     "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-platform-engineer",
     "default": false,
     "released": true
+  },
+  {
+    "id": "skill-openchoreo-setup",
+    "group": "skill",
+    "name": "OpenChoreo Setup",
+    "description": "Skill for fresh OpenChoreo installs. Bootstraps OpenChoreo onto local k3d or an existing Kubernetes cluster (k3s, GKE, EKS, AKS, DOKS, Rancher Desktop, or self-managed), walks the official install guide for the chosen target, applies provider-specific workarounds, and provisions the default platform resources.",
+    "category": "AI",
+    "tags": [
+      "install",
+      "bootstrap",
+      "kubernetes",
+      "k3d"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-setup",
+    "default": false,
+    "released": true
   }
 ]


### PR DESCRIPTION
## Summary

Adds the third OpenChoreo skill — `openchoreo-setup` — to the ecosystem marketplace alongside the existing developer and platform-engineer skill entries.

The skill bootstraps a fresh OpenChoreo install onto local k3d or an existing Kubernetes cluster (k3s, GKE, EKS, AKS, DOKS, Rancher Desktop, or self-managed).

Skill source PR: https://github.com/openchoreo/skills/pull/4

## Test plan

- [ ] `npm run build` succeeds (JSON parses, no schema regression).
- [ ] The ecosystem page renders the new card with its title, description, `install` / `bootstrap` / `kubernetes` / `k3d` tags, and source URL pointing at `openchoreo/skills`.
- [ ] Search and category filters include the new entry.