### PR TITLE
refactor: generalize _constants.mdx parsing

### DIFF
--- a/plugins/docusaurus-plugin-markdown-export/mdxProcessor.js
+++ b/plugins/docusaurus-plugin-markdown-export/mdxProcessor.js
@@ -4,31 +4,39 @@ const fs = require('fs');
  * Load constants from _constants.mdx file
  */
 async function loadConstants(constantsPath) {
-  if (!fs.existsSync(constantsPath)) {
-    return {};
-  }
+  if (!fs.existsSync(constantsPath)) return {};
 
   const content = fs.readFileSync(constantsPath, 'utf-8');
-
-  // Parse the exported versions object
-  const match = content.match(/export\s+const\s+versions\s*=\s*\{([^}]+)\}/s);
-  if (!match) return {};
-
-  const versionsBlock = match[1];
   const constants = {};
 
-  // Extract key-value pairs
-  const dockerTag = versionsBlock.match(/dockerTag:\s*['"]([^'"]+)['"]/);
-  const githubRef = versionsBlock.match(/githubRef:\s*['"]([^'"]+)['"]/);
-  const helmChart = versionsBlock.match(/helmChart:\s*['"]([^'"]+)['"]/);
-  const helmSource = versionsBlock.match(/helmSource:\s*['"]([^'"]+)['"]/);
-
-  if (dockerTag) constants.dockerTag = dockerTag[1];
-  if (githubRef) constants.githubRef = githubRef[1];
-  if (helmChart) constants.helmChart = helmChart[1];
-  if (helmSource) constants.helmSource = helmSource[1];
+  const blockRegex = /export\s+const\s+(\w+)\s*=\s*\{([^}]+)\}/gs;
+  let block;
+  while ((block = blockRegex.exec(content)) !== null) {
+    const [, name, body] = block;
+    const obj = {};
+    const propRegex = /(\w+):\s*['"]([^'"]+)['"]/g;
+    let prop;
+    while ((prop = propRegex.exec(body)) !== null) {
+      obj[prop[1]] = prop[2];
+    }
+    if (Object.keys(obj).length > 0) constants[name] = obj;
+  }
 
   return constants;
+}
+
+function replaceConstantInterpolations(content, constants) {
+  let result = content;
+  for (const [name, obj] of Object.entries(constants)) {
+    if (!obj || typeof obj !== 'object') continue;
+    for (const [key, value] of Object.entries(obj)) {
+      const pattern = new RegExp(`\\$?\\{${name}\\.${key}\\}`, 'g');
+      // Function replacer avoids `$&` / `$1` / etc. being treated as
+      // backreferences if a constant value happens to contain `$`.
+      result = result.replace(pattern, () => String(value));
+    }
+  }
+  return result;
 }
 
 /**
@@ -128,11 +136,7 @@ function processCodeBlocks(content, constants) {
     // Handle template literals with version interpolation
     code = code.replace(/\{`([\s\S]*?)`\}/g, '$1');
 
-    // Replace version placeholders in template literal syntax
-    code = code.replace(/\$\{versions\.dockerTag\}/g, constants.dockerTag || 'latest');
-    code = code.replace(/\$\{versions\.githubRef\}/g, constants.githubRef || 'main');
-    code = code.replace(/\$\{versions\.helmChart\}/g, constants.helmChart || '');
-    code = code.replace(/\$\{versions\.helmSource\}/g, constants.helmSource || '');
+    code = replaceConstantInterpolations(code, constants);
 
     // Clean up the code
     code = code.trim();
@@ -187,17 +191,7 @@ function processContentSections(content) {
 }
 
 function replaceVersionInterpolations(content, constants) {
-  let result = content;
-
-  // Match both `{versions.x}` (JSX interpolation in body text) and
-  // `${versions.x}` (template-literal interpolation inside JSX attributes).
-  // Without `\$?`, the `$` from `${...}` is left orphaned in the output.
-  result = result.replace(/\$?\{versions\.dockerTag\}/g, constants.dockerTag || 'latest');
-  result = result.replace(/\$?\{versions\.githubRef\}/g, constants.githubRef || 'main');
-  result = result.replace(/\$?\{versions\.helmChart\}/g, constants.helmChart || '');
-  result = result.replace(/\$?\{versions\.helmSource\}/g, constants.helmSource || '');
-
-  return result;
+  return replaceConstantInterpolations(content, constants);
 }
 
 function processImageTags(content) {
@@ -233,12 +227,7 @@ function processLinks(content, constants) {
   // Convert <Link to={`...`}>text</Link> to markdown links (template literals)
   result = result.replace(
     /<Link\s+to=\{`([^`]+)`\}>([^<]+)<\/Link>/g,
-    (match, url, text) => {
-      let resolvedUrl = url;
-      resolvedUrl = resolvedUrl.replace(/\$\{versions\.githubRef\}/g, constants.githubRef || 'main');
-      resolvedUrl = resolvedUrl.replace(/\$\{versions\.dockerTag\}/g, constants.dockerTag || 'latest');
-      return `[${text}](${resolvedUrl})`;
-    }
+    (match, url, text) => `[${text}](${replaceConstantInterpolations(url, constants)})`
   );
 
   // Convert <Link to="...">text</Link> to markdown links (static strings)


### PR DESCRIPTION
## Summary
`loadConstants` only knew the four `versions.*` keys, so other `export const` blocks in `_constants.mdx` (e.g. `defaultCredentials`) leaked into the exported `.md` as `<code>{defaultCredentials.username}</code>`. The parser now walks every `export const X = { ... }` block and a single `replaceConstantInterpolations` helper covers `{X.key}` and `${X.key}` uniformly across `processCodeBlocks`, `replaceVersionInterpolations`, and `processLinks`. Adding a new constant to `_constants.mdx` no longer requires plugin changes.

## Before / After
~~~markdown
# before
| <code>{defaultCredentials.username}</code> | <code>{defaultCredentials.password}</code> |

# after
| <code>admin@openchoreo.dev</code> | <code>Admin@123</code> |
~~~

## Test plan
- [x] `npm run build` succeeds with no errors.
- [x] `{defaultCredentials.username}` and `{defaultCredentials.password}` are replaced in `build/docs/getting-started/cli-installation.md` and `build/docs/ai/mcp-servers.md`.
- [x] `${versions.githubRef}` still resolves correctly inside `<Link to={...}>` (samples link shows `release-v1.1`, no orphan `$`).
- [x] Relative doc link absolutization and llms*.txt generation continue to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced constant parsing to dynamically process configuration values from documentation files
  * Generalized placeholder interpolation system for consistent substitution across code blocks, links, and markdown content
  * Streamlined documentation export pipeline logic for improved maintainability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openchoreo/openchoreo.github.io/pull/605)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->