### PR TITLE
feat: add runtime topology endpoint to metrics adapter API spec

### DIFF
--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -509,19 +509,19 @@ components:
         requestCount:
           type: number
           format: double
-        errorCount:
+        unsuccessfulRequestCount:
           type: number
           format: double
-        avgLatency:
+        meanLatency:
           type: number
           format: double
-        p50Latency:
+        latencyP50:
           type: number
           format: double
-        p90Latency:
+        latencyP90:
           type: number
           format: double
-        p99Latency:
+        latencyP99:
           type: number
           format: double
 
@@ -532,6 +532,10 @@ components:
         - $ref: "#/components/schemas/RuntimeTopologyNodeRefExternal"
       discriminator:
         propertyName: kind
+        mapping:
+          component: "#/components/schemas/RuntimeTopologyNodeRefComponent"
+          gateway: "#/components/schemas/RuntimeTopologyNodeRefGateway"
+          external: "#/components/schemas/RuntimeTopologyNodeRefExternal"
 
     RuntimeTopologyNodeRefComponent:
       type: object
@@ -599,6 +603,10 @@ components:
         - $ref: "#/components/schemas/RuntimeTopologyNodeExternal"
       discriminator:
         propertyName: kind
+        mapping:
+          component: "#/components/schemas/RuntimeTopologyNodeComponent"
+          gateway: "#/components/schemas/RuntimeTopologyNodeGateway"
+          external: "#/components/schemas/RuntimeTopologyNodeExternal"
 
     RuntimeTopologyNodeComponent:
       type: object

--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -531,19 +531,21 @@ components:
           format: double
 
     RuntimeTopologyNodeRef:
+      oneOf:
+        - $ref: "#/components/schemas/RuntimeTopologyNodeRefComponent"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeRefGateway"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeRefExternal"
+      discriminator:
+        propertyName: kind
+
+    RuntimeTopologyNodeRefComponent:
       type: object
       description: |
-        Reference to a node in the runtime topology. Identifier shape depends
-        on `kind`:
-          - kind=component: `componentUid` is required.
-          - kind=gateway:   `gatewayName` is required (e.g. internet, intranet).
-          - kind=external:  at least one of `externalHost` or `componentUid`
-            should be set; `projectUid` is included when the source is in a
-            different project.
+        Reference to a component node in the runtime topology.
       properties:
         kind:
           type: string
-          enum: [component, gateway, external]
+          enum: [component]
         componentUid:
           type: string
           format: uuid
@@ -553,22 +555,64 @@ components:
         namespace:
           type: string
           description: |
-            Namespace the node lives in. May differ from the request scope when
-            kind=external.
+            Namespace the node lives in.
+      required: [kind, componentUid]
+
+    RuntimeTopologyNodeRefGateway:
+      type: object
+      description: |
+        Reference to a gateway node in the runtime topology.
+      properties:
+        kind:
+          type: string
+          enum: [gateway]
         gatewayName:
           type: string
+          description: Gateway name (e.g., internet, intranet)
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+      required: [kind, gatewayName]
+
+    RuntimeTopologyNodeRefExternal:
+      type: object
+      description: |
+        Reference to an external node in the runtime topology.
+      properties:
+        kind:
+          type: string
+          enum: [external]
         externalHost:
+          type: string
+        componentUid:
+          type: string
+          format: uuid
+        projectUid:
+          type: string
+          format: uuid
+          description: Included when the source is in a different project
+        namespace:
           type: string
       required: [kind]
 
     RuntimeTopologyNode:
+      oneOf:
+        - $ref: "#/components/schemas/RuntimeTopologyNodeComponent"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeGateway"
+        - $ref: "#/components/schemas/RuntimeTopologyNodeExternal"
+      discriminator:
+        propertyName: kind
+
+    RuntimeTopologyNodeComponent:
       type: object
       description: |
-        A node observed in the runtime topology with its aggregated metrics.
+        A component node observed in the runtime topology with its aggregated metrics.
       properties:
         kind:
           type: string
-          enum: [component, gateway, external]
+          enum: [component]
         componentUid:
           type: string
           format: uuid
@@ -577,9 +621,46 @@ components:
           format: uuid
         namespace:
           type: string
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [kind, componentUid]
+
+    RuntimeTopologyNodeGateway:
+      type: object
+      description: |
+        A gateway node observed in the runtime topology with its aggregated metrics.
+      properties:
+        kind:
+          type: string
+          enum: [gateway]
         gatewayName:
           type: string
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [kind, gatewayName]
+
+    RuntimeTopologyNodeExternal:
+      type: object
+      description: |
+        An external node observed in the runtime topology with its aggregated metrics.
+      properties:
+        kind:
+          type: string
+          enum: [external]
         externalHost:
+          type: string
+        componentUid:
+          type: string
+          format: uuid
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
           type: string
         metrics:
           $ref: "#/components/schemas/RuntimeTopologyMetrics"
@@ -605,7 +686,7 @@ components:
           enum: [http]
         metrics:
           $ref: "#/components/schemas/RuntimeTopologyMetrics"
-      required: [id, source, target]
+      required: [id, source, target, protocol]
 
     RuntimeTopologySummary:
       type: object

--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -102,6 +102,58 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  # Runtime topology endpoint (for cell diagram with runtime observability)
+  /api/v1alpha1/metrics/runtime-topology:
+    post:
+      tags:
+        - Metrics
+      summary: Query runtime topology
+      description: |
+        Returns the live HTTP traffic topology for a project in a given environment:
+        a list of nodes (components, gateways, external endpoints) and a list of edges
+        (observed source -> target traffic flows), each with aggregated metrics
+        (request count, error count, latency percentiles) computed over the requested
+        time window. Identifiers are returned as OpenChoreo UIDs — the caller is
+        expected to map UIDs back to human-readable names.
+      operationId: queryRuntimeTopology
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RuntimeTopologyRequest"
+      responses:
+        "200":
+          description: Runtime topology queried successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RuntimeTopologyResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/v1alpha1/alerts/rules:
     post:
       tags:
@@ -414,6 +466,182 @@ components:
       oneOf:
         - $ref: "#/components/schemas/ResourceMetricsTimeSeries"
         - $ref: "#/components/schemas/HttpMetricsTimeSeries"
+
+    # Runtime topology schemas
+    RuntimeTopologyRequest:
+      type: object
+      description: |
+        Request body for POST /api/v1alpha1/metrics/runtime-topology.
+        searchScope must include namespace, projectUid, and environmentUid —
+        runtime topology is project- and environment-scoped. The optional
+        componentUid, if set, restricts results to edges that touch that
+        component.
+      properties:
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+        startTime:
+          type: string
+          description: The start time of the query window
+          format: date-time
+        endTime:
+          type: string
+          description: The end time of the query window
+          format: date-time
+        step:
+          type: string
+          description: |
+            Step hint used for sub-queries when computing aggregates
+            (e.g. 1m, 5m, 1h).
+        includeGateways:
+          type: boolean
+          description: |
+            Whether to include gateway -> component edges. Defaults to true.
+          default: true
+        includeExternal:
+          type: boolean
+          description: |
+            Whether to include edges to/from components outside the requested
+            project. Defaults to true.
+          default: true
+      required: [searchScope, startTime, endTime]
+
+    RuntimeTopologyMetrics:
+      type: object
+      description: |
+        Aggregate HTTP metrics over the requested window. Latency values are
+        in seconds, matching /api/v1/metrics/query.
+      properties:
+        requestCount:
+          type: number
+          format: double
+        errorCount:
+          type: number
+          format: double
+        avgLatency:
+          type: number
+          format: double
+        p50Latency:
+          type: number
+          format: double
+        p90Latency:
+          type: number
+          format: double
+        p99Latency:
+          type: number
+          format: double
+
+    RuntimeTopologyNodeRef:
+      type: object
+      description: |
+        Reference to a node in the runtime topology. Identifier shape depends
+        on `kind`:
+          - kind=component: `componentUid` is required.
+          - kind=gateway:   `gatewayName` is required (e.g. internet, intranet).
+          - kind=external:  at least one of `externalHost` or `componentUid`
+            should be set; `projectUid` is included when the source is in a
+            different project.
+      properties:
+        kind:
+          type: string
+          enum: [component, gateway, external]
+        componentUid:
+          type: string
+          format: uuid
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+          description: |
+            Namespace the node lives in. May differ from the request scope when
+            kind=external.
+        gatewayName:
+          type: string
+        externalHost:
+          type: string
+      required: [kind]
+
+    RuntimeTopologyNode:
+      type: object
+      description: |
+        A node observed in the runtime topology with its aggregated metrics.
+      properties:
+        kind:
+          type: string
+          enum: [component, gateway, external]
+        componentUid:
+          type: string
+          format: uuid
+        projectUid:
+          type: string
+          format: uuid
+        namespace:
+          type: string
+        gatewayName:
+          type: string
+        externalHost:
+          type: string
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [kind]
+
+    RuntimeTopologyEdge:
+      type: object
+      description: An observed traffic flow from a source node to a target node.
+      properties:
+        id:
+          type: string
+          description: |
+            Stable identifier for the edge. Convention:
+              - component->component: `${srcComponentUid}->${dstComponentUid}`
+              - gateway->component:   `gateway:${gatewayName}->${dstComponentUid}`
+              - component->external:  `${srcComponentUid}->external:${externalHost}`
+        source:
+          $ref: "#/components/schemas/RuntimeTopologyNodeRef"
+        target:
+          $ref: "#/components/schemas/RuntimeTopologyNodeRef"
+        protocol:
+          type: string
+          enum: [http]
+        metrics:
+          $ref: "#/components/schemas/RuntimeTopologyMetrics"
+      required: [id, source, target]
+
+    RuntimeTopologySummary:
+      type: object
+      description: Metadata describing the query window.
+      properties:
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        step:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+      required: [startTime, endTime, generatedAt]
+
+    RuntimeTopologyResponse:
+      type: object
+      description: |
+        Runtime topology response. Nodes and edges only include entities for
+        which traffic was observed in the window — static topology comes from
+        a separate source.
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/RuntimeTopologyNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/RuntimeTopologyEdge"
+        summary:
+          $ref: "#/components/schemas/RuntimeTopologySummary"
+      required: [summary]
 
     # Request schemas for alert rules
     AlertRuleRequest:

--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -545,17 +545,22 @@ components:
         kind:
           type: string
           enum: [component]
+        component:
+          type: string
+          description: The component name (from pod label).
         componentUid:
           type: string
-          format: uuid
+          description: The component UID (from pod label).
+        project:
+          type: string
+          description: The project name (from pod label).
         projectUid:
           type: string
-          format: uuid
+          description: The project UID.
         namespace:
           type: string
-          description: |
-            Namespace the node lives in.
-      required: [kind, componentUid]
+          description: The namespace name (from pod label).
+      required: [kind, component, componentUid]
 
     RuntimeTopologyNodeRefGateway:
       type: object
@@ -584,6 +589,8 @@ components:
           type: string
           enum: [external]
         externalHost:
+          type: string
+        component:
           type: string
         componentUid:
           type: string
@@ -616,17 +623,25 @@ components:
         kind:
           type: string
           enum: [component]
+        component:
+          type: string
+          description: The component name (from pod label).
         componentUid:
           type: string
+          description: The component UID (from pod label).
           format: uuid
+        project:
+          type: string
+          description: The project name (from pod label).
         projectUid:
           type: string
+          description: The project UID.
           format: uuid
         namespace:
           type: string
         metrics:
           $ref: "#/components/schemas/RuntimeTopologyMetrics"
-      required: [kind, componentUid]
+      required: [kind, component, componentUid]
 
     RuntimeTopologyNodeGateway:
       type: object
@@ -656,6 +671,8 @@ components:
           type: string
           enum: [external]
         externalHost:
+          type: string
+        component:
           type: string
         componentUid:
           type: string

--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -487,11 +487,6 @@ components:
           type: string
           description: The end time of the query window
           format: date-time
-        step:
-          type: string
-          description: |
-            Step hint used for sub-queries when computing aggregates
-            (e.g. 1m, 5m, 1h).
         includeGateways:
           type: boolean
           description: |
@@ -698,8 +693,6 @@ components:
         endTime:
           type: string
           format: date-time
-        step:
-          type: string
         generatedAt:
           type: string
           format: date-time


### PR DESCRIPTION
## Purpose
This pull request adds a new runtime topology query API to the observability metrics adapter OpenAPI specification. The main addition is a new `POST /api/v1alpha1/metrics/runtime-topology` endpoint, which allows clients to retrieve live HTTP traffic topology (nodes and edges with aggregated metrics) for a project and environment. Several new schema definitions are introduced to support the request and response structure for this endpoint.

**New API endpoint:**

* Added the `POST /api/v1alpha1/metrics/runtime-topology` endpoint to allow querying of live HTTP traffic topology, including nodes (components, gateways, external endpoints) and edges (traffic flows) with aggregated HTTP metrics.

**New schema definitions for runtime topology:**

* Introduced `RuntimeTopologyRequest` schema for specifying the query scope, time window, and filtering options in the request body.
* Added `RuntimeTopologyNode`, `RuntimeTopologyEdge`, and `RuntimeTopologyNodeRef` schemas to represent nodes and traffic flows in the topology graph.
* Defined `RuntimeTopologyMetrics` schema to capture aggregate HTTP metrics (request count, error count, latency percentiles) for nodes and edges.
* Created `RuntimeTopologyResponse` and `RuntimeTopologySummary` schemas to structure the API response, including the list of observed nodes, edges, and query metadata.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3111

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
