### PR TITLE
chore: list the two new gitops skills in the marketplace

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -602,5 +602,39 @@
     "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-setup",
     "default": false,
     "released": true
+  },
+  {
+    "id": "skill-openchoreo-platform-engineer-gitops",
+    "group": "skill",
+    "name": "OpenChoreo Platform Engineer GitOps",
+    "description": "Skill for platform engineers running OpenChoreo via GitOps. Scaffolds a GitOps repo (pristine, platform-only, or active cluster), wires Flux CD, and authors platform CRDs (ComponentTypes, Traits, Workflows, Environments, DeploymentPipelines, SecretReferences, AuthzRoles, alert rules, notification channels) via Git.",
+    "category": "AI",
+    "tags": [
+      "platform-engineer",
+      "gitops",
+      "flux"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-platform-engineer-gitops",
+    "default": false,
+    "released": true
+  },
+  {
+    "id": "skill-openchoreo-developer-gitops",
+    "group": "skill",
+    "name": "OpenChoreo Developer GitOps",
+    "description": "Skill for application developers working in an OpenChoreo GitOps repo. Onboards Components (BYO image or source-build), configures workloads, attaches platform-authored traits, connects components, promotes releases across environments, applies per-environment overrides, and verifies Flux reconciliation.",
+    "category": "AI",
+    "tags": [
+      "developer",
+      "gitops",
+      "flux"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-developer-gitops",
+    "default": false,
+    "released": true
   }
 ]


### PR DESCRIPTION
## Summary

Adds two new entries to \`src/data/marketplace-plugins.json\` so the new gitops skills land on the ecosystem page:

- **OpenChoreo Platform Engineer GitOps** — scaffolds a GitOps repo, wires Flux CD, authors platform CRDs (ComponentTypes, Traits, Workflows, Environments, DeploymentPipelines, SecretReferences, AuthzRoles, alert rules, notification channels) via Git.
- **OpenChoreo Developer GitOps** — onboards Components (BYO or source-build), configures workloads, attaches PE-authored traits, connects components, promotes releases, applies per-env overrides, verifies Flux reconciliation.

Both skills live in [openchoreo/skills#3](https://github.com/openchoreo/skills/pull/3). Merge that first; this PR makes them discoverable on the docs site.

## Test plan

- [ ] \`npm run build\` succeeds with the new entries (JSON validates).
- [ ] Marketplace page renders both new skill cards next to the existing developer / platform-engineer / setup ones.
- [ ] \`sourceUrl\` links resolve once openchoreo/skills#3 lands.