### PR TITLE
docs: clarify OTLP HTTP traces endpoint

### DIFF
--- a/docs/platform-engineer-guide/observability-alerting.mdx
+++ b/docs/platform-engineer-guide/observability-alerting.mdx
@@ -176,10 +176,14 @@ The traces are enriched with Kubernetes metadata to support querying by OpenChor
 
 Applications must be instrumented to send traces to the OpenTelemetry Collector. Configure your application to send OTLP traces to one of the following endpoints when using single-cluster mode:
 
-| Protocol | Endpoint                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------ |
-| HTTP     | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318/v1/traces` |
-| gRPC     | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317`                  |
+| Protocol | Endpoint                                                                               |
+| -------- | -------------------------------------------------------------------------------------- |
+| HTTP     | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318` |
+| gRPC     | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317`        |
+
+:::note
+OpenTelemetry SDKs append `/v1/traces` to the HTTP endpoint automatically, so configure your application with the base URL above rather than including the path explicitly.
+:::
 
 When using multi-cluster mode, the traces are published to the observability plane through the gateway ingress of the observability plane. Configure the applications accordingly.
 

--- a/versioned_docs/version-v0.16.x/operations/observability-alerting.mdx
+++ b/versioned_docs/version-v0.16.x/operations/observability-alerting.mdx
@@ -227,8 +227,12 @@ Applications must be instrumented to send traces to the OpenTelemetry Collector.
 
 | Protocol | Endpoint |
 |----------|----------|
-| HTTP | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318/v1/traces` |
+| HTTP | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318` |
 | gRPC | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317` |
+
+:::note
+OpenTelemetry SDKs append `/v1/traces` to the HTTP endpoint automatically, so configure your application with the base URL above rather than including the path explicitly.
+:::
 
 **Example: OpenTelemetry SDK Configuration (Go)**
 

--- a/versioned_docs/version-v0.17.x/operations/observability-alerting.mdx
+++ b/versioned_docs/version-v0.17.x/operations/observability-alerting.mdx
@@ -227,8 +227,12 @@ Applications must be instrumented to send traces to the OpenTelemetry Collector.
 
 | Protocol | Endpoint |
 |----------|----------|
-| HTTP | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318/v1/traces` |
+| HTTP | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318` |
 | gRPC | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317` |
+
+:::note
+OpenTelemetry SDKs append `/v1/traces` to the HTTP endpoint automatically, so configure your application with the base URL above rather than including the path explicitly.
+:::
 
 **Example: OpenTelemetry SDK Configuration (Go)**
 

--- a/versioned_docs/version-v1.0.x/platform-engineer-guide/observability-alerting.mdx
+++ b/versioned_docs/version-v1.0.x/platform-engineer-guide/observability-alerting.mdx
@@ -176,10 +176,14 @@ The traces are enriched with Kubernetes metadata to support querying by OpenChor
 
 Applications must be instrumented to send traces to the OpenTelemetry Collector. Configure your application to send OTLP traces to one of the following endpoints when using single-cluster mode:
 
-| Protocol | Endpoint                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------ |
-| HTTP     | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318/v1/traces` |
-| gRPC     | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317`                  |
+| Protocol | Endpoint                                                                                 |
+| -------- | ---------------------------------------------------------------------------------------- |
+| HTTP     | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318`   |
+| gRPC     | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317`          |
+
+:::note
+OpenTelemetry SDKs append `/v1/traces` to the HTTP endpoint automatically, so configure your application with the base URL above rather than including the path explicitly.
+:::
 
 When using multi-cluster mode, the traces are published to the observability plane through the gateway ingress of the observability plane. Configure the applications accordingly.
 

--- a/versioned_docs/version-v1.1.0-alpha-1/platform-engineer-guide/observability-alerting.mdx
+++ b/versioned_docs/version-v1.1.0-alpha-1/platform-engineer-guide/observability-alerting.mdx
@@ -176,10 +176,14 @@ The traces are enriched with Kubernetes metadata to support querying by OpenChor
 
 Applications must be instrumented to send traces to the OpenTelemetry Collector. Configure your application to send OTLP traces to one of the following endpoints when using single-cluster mode:
 
-| Protocol | Endpoint                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------ |
-| HTTP     | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318/v1/traces` |
-| gRPC     | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317`                  |
+| Protocol | Endpoint                                                                                 |
+| -------- | ---------------------------------------------------------------------------------------- |
+| HTTP     | `http://opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4318`   |
+| gRPC     | `opentelemetry-collector.openchoreo-observability-plane.svc.cluster.local:4317`          |
+
+:::note
+OpenTelemetry SDKs append `/v1/traces` to the HTTP endpoint automatically, so configure your application with the base URL above rather than including the path explicitly.
+:::
 
 When using multi-cluster mode, the traces are published to the observability plane through the gateway ingress of the observability plane. Configure the applications accordingly.
 


### PR DESCRIPTION
## Purpose

Fix a misleading entry in the **Instrumenting Applications** table on the Observability & Alerting page. The HTTP row previously listed the OTLP collector endpoint as `http://…:4318/v1/traces`. Per the [OTLP/HTTP spec](https://opentelemetry.io/docs/specs/otlp/#otlphttp-request), SDKs append `/v1/traces` to the configured base URL automatically when the OTLP/HTTP exporter is used. Users who copy-pasted the documented URL into the standard `OTEL_EXPORTER_OTLP_ENDPOINT` variable ended up with the path appended twice (or with a per-signal-only URL), causing exports to silently fail.

This PR drops the `/v1/traces` suffix from the HTTP row and adds a short note clarifying the SDK behavior, so the documented URL works as-is regardless of which OTLP/HTTP SDK is in use.

## Related Issues

_None._

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page _(N/A — no new page)_
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)

## Files touched

The same edit is applied across the live docs and all versioned copies to keep them consistent:

- `docs/platform-engineer-guide/observability-alerting.mdx`
- `versioned_docs/version-v1.1.0-alpha-1/platform-engineer-guide/observability-alerting.mdx`
- `versioned_docs/version-v1.0.x/platform-engineer-guide/observability-alerting.mdx`
- `versioned_docs/version-v0.17.x/operations/observability-alerting.mdx`
- `versioned_docs/version-v0.16.x/operations/observability-alerting.mdx`