### PR TITLE
feat: generate per-type ecosystem catalogs and link them from llms.txt

### DIFF
--- a/plugins/docusaurus-plugin-llms-txt/index.js
+++ b/plugins/docusaurus-plugin-llms-txt/index.js
@@ -2,8 +2,19 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = function pluginLlmsTxt(context, options = {}) {
-  const { siteConfig } = context;
+  const { siteConfig, siteDir } = context;
   const sidebarName = options.sidebarName || 'docsSidebar';
+
+  const ECOSYSTEM_GROUPS = [
+    { group: 'module', heading: 'Modules', slug: 'modules' },
+    { group: 'integration', heading: 'Integrations', slug: 'integrations' },
+    { group: 'component-type', heading: 'Component Types', slug: 'component-types' },
+    { group: 'workflow', heading: 'Workflows', slug: 'workflows' },
+    { group: 'skill', heading: 'Skills', slug: 'skills' },
+    { group: 'agent', heading: 'Agents', slug: 'agents' },
+  ];
+  const ECOSYSTEM_BLURB =
+    'Catalogs of components that extend OpenChoreo, split by type. Each entry links to its source (GitHub) or its documentation page.';
 
   let loadedVersions = null;
 
@@ -93,6 +104,73 @@ module.exports = function pluginLlmsTxt(context, options = {}) {
     return host + (base.startsWith('/') ? base : '/' + base);
   }
 
+  function ecosystemUrl(slug) {
+    const host = (siteConfig.url || '').replace(/\/$/, '');
+    return host + '/ecosystem/' + slug + '.md';
+  }
+
+  // Resolve an ecosystem entry's sourceUrl into the link we want to render.
+  // - empty → null (renders as "Coming soon")
+  // - https://openchoreo.dev/docs/<path>[/] → https://openchoreo.dev/docs/<path>.md
+  // - anything else (GitHub, external) → unchanged
+  function ecosystemLinkForEntry(sourceUrl) {
+    if (!sourceUrl) return null;
+    const m = sourceUrl.match(
+      /^(https?:\/\/openchoreo\.dev\/docs(?:\/[^?#]*?)?)\/?(\?[^#]*)?(#.*)?$/
+    );
+    if (!m) return sourceUrl;
+    return m[1] + '.md' + (m[2] || '') + (m[3] || '');
+  }
+
+  // One markdown file per ecosystem type, so an agent after (say) workflows
+  // doesn't pay tokens for modules and skills. Returns [{ slug, content }].
+  function buildEcosystemFiles() {
+    const jsonPath = path.join(siteDir, 'src', 'data', 'marketplace-plugins.json');
+    let entries;
+    try {
+      entries = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    } catch (e) {
+      console.warn(`[llms-txt] could not read ${jsonPath}: ${e.message}`);
+      return [];
+    }
+
+    const files = [];
+    for (const { group, heading, slug } of ECOSYSTEM_GROUPS) {
+      const groupEntries = entries
+        .filter((e) => e.group === group)
+        .sort((a, b) => {
+          const releasedDiff = (b.released ? 1 : 0) - (a.released ? 1 : 0);
+          if (releasedDiff !== 0) return releasedDiff;
+          return (a.name || '').localeCompare(b.name || '');
+        });
+
+      if (groupEntries.length === 0) continue;
+
+      const lines = [];
+      lines.push(`# ${siteConfig.title} Ecosystem — ${heading}`);
+      lines.push('');
+      lines.push(`> ${ECOSYSTEM_BLURB}`);
+      lines.push('');
+
+      for (const entry of groupEntries) {
+        const name = escapeInline(entry.name || entry.id);
+        const desc = escapeInline(entry.description || '');
+        const defaultTag = entry.default ? ' *(default)*' : '';
+        const link = ecosystemLinkForEntry(entry.sourceUrl);
+        const tail = link ? link : '_Coming soon_';
+        const descPart = desc ? ` — ${desc}` : '';
+        lines.push(`- **${name}**${defaultTag}${descPart} — ${tail}`);
+      }
+      lines.push('');
+
+      files.push({
+        slug,
+        content: lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n',
+      });
+    }
+    return files;
+  }
+
   function appendVersionsFooter(lines, allVersions) {
     if (!allVersions || allVersions.length === 0) return;
     const root = siteRootUrl();
@@ -132,6 +210,13 @@ module.exports = function pluginLlmsTxt(context, options = {}) {
       lines.push(`> ${siteConfig.tagline}`);
       lines.push('');
     }
+
+    lines.push('## Ecosystem');
+    lines.push('');
+    for (const { heading, slug } of ECOSYSTEM_GROUPS) {
+      lines.push(`- [${heading}](${ecosystemUrl(slug)})`);
+    }
+    lines.push('');
 
     if (!sidebar) {
       lines.push(`_No sidebar named "${sidebarName}" found for this version._`);
@@ -215,7 +300,19 @@ module.exports = function pluginLlmsTxt(context, options = {}) {
         console.warn('[llms-txt] no version flagged isLast; llms.txt not written');
       }
 
-      console.log(`[llms-txt] Wrote ${written} llms*.txt files to build/`);
+      const ecosystemFiles = buildEcosystemFiles();
+      if (ecosystemFiles.length) {
+        const ecoDir = path.join(outDir, 'ecosystem');
+        fs.mkdirSync(ecoDir, { recursive: true });
+        for (const { slug, content } of ecosystemFiles) {
+          fs.writeFileSync(path.join(ecoDir, `${slug}.md`), content);
+        }
+        console.log(
+          `[llms-txt] Wrote ${written} llms*.txt files and ${ecosystemFiles.length} ecosystem/*.md files to build/`
+        );
+      } else {
+        console.log(`[llms-txt] Wrote ${written} llms*.txt files to build/ (ecosystem skipped)`);
+      }
     },
   };
 };


### PR DESCRIPTION
## Summary

- Extends the `docusaurus-plugin-llms-txt` plugin to emit `build/ecosystem/<type>.md` — one agent-readable catalog per ecosystem type (`modules`, `integrations`, `component-types`, `workflows`, `skills`, `agents`), generated from `src/data/marketplace-plugins.json`.
- Adds an `## Ecosystem` section to every `llms*.txt` linking to those six files, so agents discovering docs via `llms.txt` also discover installable extensions.
- Each entry links to its source: GitHub URLs as-is, `openchoreo.dev/docs/...` URLs rewritten to their `.md` sibling, empty `sourceUrl` rendered as "Coming soon". Released entries sort first, `*(default)*` tagged.

The React `/ecosystem/` page is untouched — it keeps rendering from the same JSON.

## Test plan

- [ ] `npm run build` succeeds and logs `Wrote N llms*.txt files and 6 ecosystem/*.md files`
- [ ] `build/ecosystem/{modules,integrations,component-types,workflows,skills,agents}.md` exist and group entries correctly
- [ ] Every `build/llms*.txt` has an `## Ecosystem` section with six links
- [ ] Doc-page `sourceUrl`s are rewritten to `.md`; GitHub URLs unchanged; empty `sourceUrl` shows "Coming soon"