### PR TITLE
feat: add Networking - Cilium module to ecosystem page

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -408,6 +408,25 @@
     "released": true
   },
   {
+    "id": "networking-cilium",
+    "group": "module",
+    "name": "Networking - Cilium",
+    "description": "Networking module for configuring CiliumNetworkPolicies and Hubble-based network observability in OpenChoreo.",
+    "category": "Networking",
+    "tags": [
+      "networking",
+      "observability",
+      "cilium",
+      "hubble",
+      "ebpf"
+    ],
+    "logoUrl": "https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/cilium/icon/color/cilium_icon-color.svg",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/networking-cilium",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "workflow-aws-rds-postgres",
     "group": "workflow",
     "name": "AWS RDS PostgreSQL",


### PR DESCRIPTION
## Purpose
This pull request adds a new networking module to the marketplace plugins configuration. The main change is the introduction of a Cilium-based networking module to support advanced network policies and observability in OpenChoreo.

New module addition:

* Added a new entry for the `networking-cilium` module in `marketplace-plugins.json`, which provides CiliumNetworkPolicies and Hubble-based network observability features, along with relevant metadata and links.

> TODO: merge this after merging https://github.com/openchoreo/community-modules/pull/103

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3452

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
