### PR TITLE
fix: set v1.0.x as the latest docs version

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -85,7 +85,7 @@ const config: Config = {
       'classic',
       {
         docs: {
-          lastVersion: 'v1.1.0-alpha-1',
+          lastVersion: 'v1.0.x',
           versions: {
             'v1.1.0-alpha-1': {
               label: 'v1.1.0-alpha-1',


### PR DESCRIPTION
## Summary

- `lastVersion` in `docusaurus.config.ts` was set to `v1.1.0-alpha-1`, which made Docusaurus render an "unmaintained — see the latest version" banner on the stable `v1.0.x` docs pointing users at the alpha release.
- Switch `lastVersion` to `v1.0.x` so the stable release is served at `/docs/` and the misleading banner on 1.0.x goes away.

## Checklist

- [x] `npm run start` — confirm `/docs/` serves `v1.0.x` content and shows no "unmaintained" banner.
- [x] Navigate into `v1.1.0-alpha-1` docs via the version dropdown and verify those pages still load.
- [x] `npm run build` succeeds.