### PR TITLE
docs: add default component types and gitops workflows to ecosystem

### DIFF
--- a/src/components/PluginCard/PluginCard.tsx
+++ b/src/components/PluginCard/PluginCard.tsx
@@ -8,7 +8,7 @@ interface Plugin {
   group: string;
   name: string;
   description: string;
-  category: string;
+  category?: string;
   tags: string[];
   logoUrl?: string;
   author: string;

--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -641,8 +641,7 @@
     "id": "componenttype-service",
     "group": "component-type",
     "name": "Service",
-    "description": "A long-running request-serving component with one or more endpoints.",
-    "category": "Default",
+    "description": "A request-serving workload like a backend API or microservice. Listens on one or more endpoints and stays running to handle incoming traffic. Runs as a Kubernetes Deployment.",
     "tags": [
       "component-type",
       "default",
@@ -658,8 +657,7 @@
     "id": "componenttype-web-application",
     "group": "component-type",
     "name": "Web Application",
-    "description": "A long-running component that serves web requests and exposes at least one HTTP endpoint.",
-    "category": "Default",
+    "description": "An HTTP-serving frontend or full-stack web app, such as a single-page app, server-rendered app, or static site with a build step. Exposes at least one HTTP endpoint that end users hit in the browser. Runs as a Kubernetes Deployment.",
     "tags": [
       "component-type",
       "default",
@@ -675,8 +673,7 @@
     "id": "componenttype-worker",
     "group": "component-type",
     "name": "Worker",
-    "description": "A long-running background or event-driven component with no endpoints.",
-    "category": "Default",
+    "description": "A background or event-driven workload that doesn't accept inbound requests, such as a queue consumer, stream processor, event handler, or long-running agent. Stays running and pulls work or reacts to events. Runs as a Kubernetes Deployment.",
     "tags": [
       "component-type",
       "default",
@@ -692,8 +689,7 @@
     "id": "componenttype-scheduled-task",
     "group": "component-type",
     "name": "Scheduled Task",
-    "description": "A component that runs to completion on a schedule.",
-    "category": "Default",
+    "description": "A batch job that runs to completion on a recurring schedule, such as a report, cleanup, or periodic data sync. Starts, does its work, and exits until the next scheduled time. Runs as a Kubernetes CronJob.",
     "tags": [
       "component-type",
       "default",

--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -636,5 +636,144 @@
     "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-developer-gitops",
     "default": false,
     "released": true
+  },
+  {
+    "id": "componenttype-service",
+    "group": "component-type",
+    "name": "Service",
+    "description": "A long-running request-serving component with one or more endpoints.",
+    "category": "Default",
+    "tags": [
+      "component-type",
+      "default",
+      "service"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/openchoreo/blob/main/samples/getting-started/component-types/service.yaml",
+    "default": true,
+    "released": true
+  },
+  {
+    "id": "componenttype-web-application",
+    "group": "component-type",
+    "name": "Web Application",
+    "description": "A long-running component that serves web requests and exposes at least one HTTP endpoint.",
+    "category": "Default",
+    "tags": [
+      "component-type",
+      "default",
+      "web-application"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/openchoreo/blob/main/samples/getting-started/component-types/webapp.yaml",
+    "default": true,
+    "released": true
+  },
+  {
+    "id": "componenttype-worker",
+    "group": "component-type",
+    "name": "Worker",
+    "description": "A long-running background or event-driven component with no endpoints.",
+    "category": "Default",
+    "tags": [
+      "component-type",
+      "default",
+      "worker"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/openchoreo/blob/main/samples/getting-started/component-types/worker.yaml",
+    "default": true,
+    "released": true
+  },
+  {
+    "id": "componenttype-scheduled-task",
+    "group": "component-type",
+    "name": "Scheduled Task",
+    "description": "A component that runs to completion on a schedule.",
+    "category": "Default",
+    "tags": [
+      "component-type",
+      "default",
+      "scheduled-task"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/openchoreo/blob/main/samples/getting-started/component-types/scheduled-task.yaml",
+    "default": true,
+    "released": true
+  },
+  {
+    "id": "workflow-docker-gitops-release",
+    "group": "workflow",
+    "name": "Docker GitOps Release",
+    "description": "Docker workflow that builds a container image from a Dockerfile and performs a GitOps release in a single workflow.",
+    "category": "GitOps",
+    "tags": [
+      "workflow",
+      "gitops",
+      "build",
+      "docker"
+    ],
+    "logoUrl": "https://www.docker.com/app/uploads/2022/03/Moby-logo.png",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/sample-gitops/blob/main/namespaces/default/platform/workflows/docker-with-gitops-release.yaml",
+    "default": false,
+    "released": true
+  },
+  {
+    "id": "workflow-google-cloud-buildpacks-gitops-release",
+    "group": "workflow",
+    "name": "Google Cloud Buildpacks GitOps Release",
+    "description": "Google Cloud Buildpacks workflow that builds a container image without a Dockerfile and performs a GitOps release in a single workflow.",
+    "category": "GitOps",
+    "tags": [
+      "workflow",
+      "gitops",
+      "build",
+      "buildpacks"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/sample-gitops/blob/main/namespaces/default/platform/workflows/google-cloud-buildpacks-gitops-release.yaml",
+    "default": false,
+    "released": true
+  },
+  {
+    "id": "workflow-react-gitops-release",
+    "group": "workflow",
+    "name": "React GitOps Release",
+    "description": "React workflow that builds a web application container image and performs a GitOps release in a single workflow.",
+    "category": "GitOps",
+    "tags": [
+      "workflow",
+      "gitops",
+      "build",
+      "react"
+    ],
+    "logoUrl": "https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original.svg",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/sample-gitops/blob/main/namespaces/default/platform/workflows/react-gitops-release.yaml",
+    "default": false,
+    "released": true
+  },
+  {
+    "id": "workflow-bulk-gitops-release",
+    "group": "workflow",
+    "name": "Bulk GitOps Release",
+    "description": "Promotion workflow that generates ReleaseBindings to promote existing releases for all components or a specific project to a target environment.",
+    "category": "GitOps",
+    "tags": [
+      "workflow",
+      "gitops",
+      "promotion"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/sample-gitops/blob/main/namespaces/default/platform/workflows/bulk-gitops-release.yaml",
+    "default": false,
+    "released": true
   }
 ]

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -12,7 +12,7 @@ interface Plugin {
   group: string;
   name: string;
   description: string;
-  category: string;
+  category?: string;
   tags: string[];
   logoUrl?: string;
   author: string;
@@ -75,7 +75,8 @@ export default function Ecosystem(): ReactNode {
     selectedGroup === 'all' || p.group === selectedGroup;
 
   const matchesCategory = (p: Plugin) =>
-    selectedCategories.size === 0 || selectedCategories.has(p.category);
+    selectedCategories.size === 0 ||
+    (p.category !== undefined && selectedCategories.has(p.category));
 
   const filteredPlugins = useMemo(() => {
     const result = plugins
@@ -99,6 +100,7 @@ export default function Ecosystem(): ReactNode {
       .filter((p) => matchesSearch(p, searchQuery))
       .filter(matchesGroup)
       .forEach((p) => {
+        if (!p.category) return;
         counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
       });
     return Array.from(counts.entries())

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -14,7 +14,7 @@ interface Plugin {
   group: string;
   name: string;
   description: string;
-  category: string;
+  category?: string;
   tags: string[];
   logoUrl?: string;
   author: string;
@@ -602,7 +602,9 @@ export default function EcosystemItem(): ReactNode {
                     <span className={`${styles.groupBadge} ${groupBadgeClass}`}>
                       {groupLabel}
                     </span>
-                    <span className={styles.categoryBadge}>{plugin.category}</span>
+                    {plugin.category && (
+                      <span className={styles.categoryBadge}>{plugin.category}</span>
+                    )}
                   </div>
                   <div className={styles.tagRow}>
                     {plugin.tags.map((tag) => (


### PR DESCRIPTION
Adds 8 entries to `src/data/marketplace-plugins.json` so the ecosystem page surfaces resources that previously had no listing.

### Default ComponentTypes (group: `component-type`, category: `Default`, `default: true`)
Sourced from [`openchoreo/samples/getting-started/component-types/`](https://github.com/openchoreo/openchoreo/tree/main/samples/getting-started/component-types):

- Service
- Web Application
- Worker
- Scheduled Task

### GitOps workflows (group: `workflow`, category: `GitOps`, `gitops` tag)
Sourced from [`openchoreo/sample-gitops`](https://github.com/openchoreo/sample-gitops/tree/main/namespaces/default/platform/workflows):

- Docker GitOps Release
- Google Cloud Buildpacks GitOps Release
- React GitOps Release
- Bulk GitOps Release

### Notes
- `sourceUrl`s point at the upstream samples repos (matching the precedent set by the existing `default: true` CI build workflows, which also point into `openchoreo/samples/` rather than `community-modules/`).
- ComponentType ids use a `componenttype-` prefix to avoid collision with generic names like `service`.