### PR TITLE
docs: label default namespace before applying base resources

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -314,8 +314,8 @@ You can browse and modify the bootstrapped identity configuration (users, groups
 OpenChoreo needs some base resources before you can deploy anything: a project, environments, component types, and a deployment pipeline. These define what kinds of things you can build and where they run.
 
 <CodeBlock language="bash">
-  {`kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/samples/getting-started/all.yaml && \\
-kubectl label namespace default openchoreo.dev/control-plane=true --overwrite`}
+  {`kubectl label namespace default openchoreo.dev/control-plane=true --overwrite && \\
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/samples/getting-started/all.yaml`}
 </CodeBlock>
 
 **What was created:**

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -466,15 +466,15 @@ curl -sk -o /dev/null -w "%{http_code}" https://console.${CP_BASE_DOMAIN}/
 
 OpenChoreo needs some base resources before you can deploy anything: a project, environments, component types, and a deployment pipeline.
 
-<CodeBlock language="bash">
-  {`kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/samples/getting-started/all.yaml`}
-</CodeBlock>
-
-Label the default namespace as a control plane namespace:
+Label the default namespace as a control plane namespace first, then apply the resources:
 
 ```bash
 kubectl label namespace default openchoreo.dev/control-plane=true --overwrite
 ```
+
+<CodeBlock language="bash">
+  {`kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/samples/getting-started/all.yaml`}
+</CodeBlock>
 
 ## Step 5: Setup Data Plane
 


### PR DESCRIPTION
## Purpose

In the "Install Default Resources" step of both getting-started guides, the namespace label was applied after `kubectl apply -f all.yaml`. Reordering these commands — labeling the namespace first — fixes some intermittent Backstage sync failures seen when the resources are applied before the namespace is marked as a control plane.

## Approach

- `on-k3d-locally.mdx`: flip the chained command so `kubectl label namespace` runs before `kubectl apply -f all.yaml`
- `on-your-environment.mdx`: move the label step above the apply step and update the surrounding sentence

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)