### PR TITLE
docs(platform-engineer-guide): add Backstage Plugins section

### DIFF
--- a/docs/platform-engineer-guide/backstage-plugins/catalog-sync.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/catalog-sync.mdx
@@ -1,0 +1,101 @@
+---
+title: Catalog sync
+description: How OpenChoreo entities are mirrored into the Backstage software catalog.
+sidebar_position: 3
+---
+
+# Catalog sync
+
+Once installed, the **`@openchoreo/backstage-plugin-catalog-backend-module`** registers an entity provider that polls the OpenChoreo Platform API on a schedule and writes the result into your Backstage catalog.
+
+## What gets synced
+
+| OpenChoreo resource                                   | Backstage entity            | Notes                                                                                                                  |
+| ----------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Namespace                                             | `Domain`                    | One per OpenChoreo namespace.                                                                                          |
+| Project                                               | `System`                    | `spec.domain` references the parent namespace.                                                                         |
+| Component                                             | `Component`                 | `spec.system` references the parent project. `spec.type` is the OpenChoreo component type (e.g. `deployment/service`). |
+| API definition                                        | `API`                       | Linked to its owning component.                                                                                        |
+| Environment                                           | custom kind `environment`   | Listed under each namespace.                                                                                           |
+| ComponentType / Trait / Workflow                      | custom kinds                | Used by the scaffolder templates.                                                                                      |
+| ClusterComponentType / ClusterTrait / ClusterWorkflow | cluster-scoped custom kinds |                                                                                                                        |
+| DataPlane / WorkflowPlane / ObservabilityPlane        | infrastructure entities     | Visible in the platform overview.                                                                                      |
+
+The full set of relations is defined in `@openchoreo/backstage-plugin-common` — `RELATION_DEPLOYS_TO`, `RELATION_USES_PIPELINE`, `RELATION_HOSTED_ON`, etc. The catalog graph picks them up automatically once the entity provider is active.
+
+## Tuning the sync schedule
+
+```yaml title="app-config.yaml"
+openchoreo:
+  schedule:
+    frequency: 30 # seconds between catalog provider runs (default: 30)
+    timeout: 120 # seconds before a single run is considered hung (default: 120)
+```
+
+Both fields are plain integers (seconds). They are _not_ the Backstage `HumanDuration` shape — passing `{ minutes: 1 }` produces a startup error.
+
+## Catalog rules
+
+Backstage's catalog rejects entity kinds that are not in `catalog.rules.allow`. Add `Domain` (and `Group`, `User` if you sync identities later) to the allow list:
+
+```yaml title="app-config.yaml"
+catalog:
+  rules:
+    - allow: [Component, System, Domain, API, Resource, Location, Group, User]
+```
+
+## Default ownership
+
+Each synced entity gets `spec.owner = group:default/${openchoreo.defaultOwner}`. The default value is `openchoreo-users`. Override it if you sync your own users/groups separately:
+
+```yaml
+openchoreo:
+  defaultOwner: platform-team
+```
+
+## Inspecting synced entities
+
+```bash
+# All Domain entities
+curl http://localhost:7007/api/catalog/entities?filter=kind=domain \
+  -H "Authorization: Bearer ${BACKSTAGE_TOKEN}" | jq
+
+# Components in a given system
+curl 'http://localhost:7007/api/catalog/entities?filter=kind=component,spec.system=url-shortener' \
+  -H "Authorization: Bearer ${BACKSTAGE_TOKEN}" | jq
+```
+
+## How the sync authenticates to OpenChoreo
+
+The entity provider runs as a background task — there's no end-user request to attach a token to. It uses an OAuth2 **client credentials** flow against the OpenChoreo identity provider:
+
+```yaml
+openchoreo:
+  auth:
+    clientId: openchoreo-backstage-client
+    clientSecret: backstage-portal-secret
+    tokenUrl: http://thunder.openchoreo.localhost:8080/oauth2/token
+```
+
+The catalog provider only fetches a token when **`openchoreo.features.auth.enabled: true`**. If that flag is `false`, the provider skips authentication and the OpenChoreo API rejects the calls with `MISSING_TOKEN`. As the install guide explains in its [cluster-mirroring callout](./installing-into-existing-backstage.mdx#configure-app-config), this flag must match how your OpenChoreo cluster was deployed — if the cluster runs in auth-off mode the API itself accepts unauthenticated calls and the provider works without credentials.
+
+## Common issues
+
+**`Failed to fetch namespaces: 401 Unauthorized - missing or invalid authentication token`**
+
+Either `openchoreo.features.auth.enabled` is `false`, or the `clientId` / `clientSecret` / `tokenUrl` are wrong, or the IDP is not reachable. Check the token endpoint with:
+
+```bash
+curl -X POST -d 'grant_type=client_credentials' \
+  -d "client_id=${OPENCHOREO_CLIENT_ID}" \
+  -d "client_secret=${OPENCHOREO_CLIENT_SECRET}" \
+  ${OPENCHOREO_TOKEN_URL}
+```
+
+**Entities fail to appear despite a successful run**
+
+Check `catalog.rules`. If `Domain` is not in the allow list, the catalog drops every namespace silently.
+
+**Sync runs every 30s and floods logs**
+
+Tune `openchoreo.schedule.frequency` upward for production. The default 30s is fine on `k3d`.

--- a/docs/platform-engineer-guide/backstage-plugins/compatibility-matrix.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/compatibility-matrix.mdx
@@ -1,0 +1,155 @@
+---
+title: Compatibility matrix
+description: Tested combinations of OpenChoreo plugins with Backstage releases.
+sidebar_position: 7
+---
+
+# Compatibility matrix
+
+The OpenChoreo plugin set is tested against a specific Backstage release line. Installing into a Backstage app on a different line typically requires pinning every `@backstage/*` package; see [Troubleshooting](./troubleshooting.mdx).
+
+## Tested combination
+
+| Component              | Version           |
+| ---------------------- | ----------------- |
+| Backstage release line | **1.43.3**        |
+| Node.js                | 22.x              |
+| Yarn                   | 4.4.1             |
+| `@backstage/cli`       | 0.34.3            |
+| OpenChoreo plugin set  | `0.1.x` / `0.2.x` |
+
+## Required `resolutions`
+
+Add the following to your workspace root `package.json`. These pins keep transitive `@backstage/*` ranges from drifting to newer minors that the plugins have not been validated against.
+
+```json
+{
+  "resolutions": {
+    "@types/react": "18.3.26",
+    "@types/react-dom": "18.3.7",
+    "csstype": "3.1.3",
+
+    "@backstage/app-defaults": "1.7.0",
+    "@backstage/backend-app-api": "1.2.7",
+    "@backstage/backend-defaults": "0.12.1",
+    "@backstage/backend-plugin-api": "1.4.3",
+    "@backstage/catalog-client": "1.12.0",
+    "@backstage/catalog-model": "1.7.5",
+    "@backstage/cli": "0.34.3",
+    "@backstage/cli-common": "0.1.15",
+    "@backstage/cli-node": "0.2.14",
+    "@backstage/config": "1.3.4",
+    "@backstage/config-loader": "1.10.4",
+    "@backstage/core-app-api": "1.19.0",
+    "@backstage/core-components": "0.18.1",
+    "@backstage/core-plugin-api": "1.11.0",
+    "@backstage/errors": "1.2.7",
+    "@backstage/integration": "1.18.0",
+    "@backstage/integration-react": "1.2.10",
+    "@backstage/plugin-api-docs": "0.12.11",
+    "@backstage/plugin-app-backend": "0.5.6",
+    "@backstage/plugin-auth-backend": "0.25.4",
+    "@backstage/plugin-auth-backend-module-github-provider": "0.3.7",
+    "@backstage/plugin-auth-backend-module-guest-provider": "0.2.12",
+    "@backstage/plugin-auth-node": "0.6.7",
+    "@backstage/plugin-catalog": "1.31.3",
+    "@backstage/plugin-catalog-backend": "3.1.1",
+    "@backstage/plugin-catalog-backend-module-logs": "0.1.14",
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "0.2.12",
+    "@backstage/plugin-catalog-common": "1.1.5",
+    "@backstage/plugin-catalog-graph": "0.5.1",
+    "@backstage/plugin-catalog-import": "0.13.5",
+    "@backstage/plugin-catalog-node": "1.19.0",
+    "@backstage/plugin-catalog-react": "1.21.1",
+    "@backstage/plugin-events-node": "0.4.15",
+    "@backstage/plugin-kubernetes": "0.12.11",
+    "@backstage/plugin-kubernetes-backend": "0.20.2",
+    "@backstage/plugin-kubernetes-node": "0.3.4",
+    "@backstage/plugin-org": "0.6.44",
+    "@backstage/plugin-permission-backend": "0.7.4",
+    "@backstage/plugin-permission-common": "0.9.1",
+    "@backstage/plugin-permission-node": "0.10.4",
+    "@backstage/plugin-permission-react": "0.4.36",
+    "@backstage/plugin-proxy-backend": "0.6.6",
+    "@backstage/plugin-scaffolder": "1.34.1",
+    "@backstage/plugin-scaffolder-backend": "2.2.1",
+    "@backstage/plugin-scaffolder-backend-module-github": "0.9.0",
+    "@backstage/plugin-scaffolder-common": "1.7.1",
+    "@backstage/plugin-scaffolder-node": "0.11.1",
+    "@backstage/plugin-scaffolder-react": "1.19.1",
+    "@backstage/plugin-search": "1.4.30",
+    "@backstage/plugin-search-backend": "2.0.6",
+    "@backstage/plugin-search-backend-module-catalog": "0.3.8",
+    "@backstage/plugin-search-backend-module-pg": "0.5.48",
+    "@backstage/plugin-search-backend-node": "1.3.15",
+    "@backstage/plugin-search-react": "1.9.4",
+    "@backstage/plugin-techdocs": "1.15.0",
+    "@backstage/plugin-techdocs-backend": "2.1.0",
+    "@backstage/plugin-techdocs-module-addons-contrib": "1.1.28",
+    "@backstage/plugin-techdocs-react": "1.3.3",
+    "@backstage/plugin-user-settings": "0.8.28",
+    "@backstage/test-utils": "1.7.11",
+    "@backstage/theme": "0.6.8",
+    "@backstage/types": "1.2.2"
+  }
+}
+```
+
+## Aligning your existing app
+
+If your Backstage app is on a different release line, run:
+
+```bash
+yarn backstage-cli versions:bump --release 1.43.3
+```
+
+…before adding the OpenChoreo packages. Note: `versions:bump` writes caret ranges (`^x.y.z`), which still allow yarn to resolve to newer minors via transitive deps. The `resolutions` block above is what actually pins.
+
+## Plugin packages
+
+### Core (required)
+
+Installed and wired by [section 4 of the install guide](./installing-into-existing-backstage.mdx#core).
+
+| Package                                                                    | Role                    | Notes                                        |
+| -------------------------------------------------------------------------- | ----------------------- | -------------------------------------------- |
+| `@openchoreo/backstage-plugin`                                             | `frontend-plugin`       | Cell, Deploy, Definition tabs.               |
+| `@openchoreo/backstage-plugin-react`                                       | `web-library`           | Shared React hooks (permission hooks, etc.). |
+| `@openchoreo/backstage-design-system`                                      | `web-library`           | MUI v4 theme + form widgets.                 |
+| `@openchoreo/backstage-plugin-common`                                      | `common-library`        | Constants, types, relation refs.             |
+| `@openchoreo/backstage-plugin-backend`                                     | `backend-plugin`        | Powers `/api/openchoreo/*`.                  |
+| `@openchoreo/backstage-plugin-catalog-backend-module`                      | `backend-plugin-module` | Catalog entity provider + service factories. |
+| `@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy` | `backend-plugin-module` | Permission policy.                           |
+| `@openchoreo/backstage-plugin-scaffolder-backend-module`                   | `backend-plugin-module` | Scaffolder actions.                          |
+| `@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth`         | `backend-plugin-module` | OpenChoreo OIDC sign-in.                     |
+| `@openchoreo/openchoreo-client-node`                                       | `node-library`          | Generated typed API client.                  |
+| `@openchoreo/openchoreo-auth`                                              | `node-library`          | Token service + IDP middleware.              |
+
+### Optional tab packs
+
+Installed and wired by [sections 5–7 of the install guide](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional). Each frontend/backend pair is installed together.
+
+| Package                                                         | Role              | Tabs delivered                                                            |
+| --------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------- |
+| `@openchoreo/backstage-plugin-openchoreo-observability`         | `frontend-plugin` | Component → Logs/Metrics/Alerts, System → Logs/Traces/Incidents/RCA/Cost. |
+| `@openchoreo/backstage-plugin-openchoreo-observability-backend` | `backend-plugin`  | Backend + `/resolve-urls` for the observability tabs.                     |
+| `@openchoreo/backstage-plugin-openchoreo-ci`                    | `frontend-plugin` | Component → Build.                                                        |
+| `@openchoreo/backstage-plugin-openchoreo-ci-backend`            | `backend-plugin`  | Backend for the Build tab.                                                |
+| `@openchoreo/backstage-plugin-openchoreo-workflows`             | `frontend-plugin` | Standalone org-level workflows page.                                      |
+| `@openchoreo/backstage-plugin-openchoreo-workflows-backend`     | `backend-plugin`  | Backend for the workflows page.                                           |
+
+### Also published
+
+These packages live in the `@openchoreo` scope and ship on the same release cadence as the rest, but the canonical install guide does not wire them. They exist for downstream tools and special-case installs.
+
+| Package                                                                | Use                                                                                                                                                                   |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@openchoreo/openapi-client-generator-node`                            | Build-time generator for the typed OpenChoreo API clients. Consumed by plugin authors, not Backstage runtime.                                                         |
+| `@openchoreo/backstage-plugin-platform-engineer-core`                  | Platform-engineer home/dashboard surface used by the in-tree portal. Not part of the canonical install.                                                               |
+| `@openchoreo/backstage-plugin-platform-engineer-core-backend`          | Backend for the above.                                                                                                                                                |
+| `@openchoreo/backstage-plugin-thunder-idp-client-node`                 | TypeScript client for the Thunder IDP user/group API. Used by `catalog-backend-module-openchoreo-users` below.                                                        |
+| `@openchoreo/backstage-plugin-catalog-backend-module-openchoreo-users` | Syncs Thunder users/groups into the Backstage catalog. Install only if your OpenChoreo cluster uses Thunder as its IDP and you want user/group entities in Backstage. |
+
+## Reporting compatibility issues
+
+If you successfully install on a different Backstage release line, file an issue at [openchoreo/backstage-plugins](https://github.com/openchoreo/backstage-plugins/issues) — we will add the combination to this matrix.

--- a/docs/platform-engineer-guide/backstage-plugins/entity-views.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/entity-views.mdx
@@ -1,0 +1,112 @@
+---
+title: Entity views
+description: Wiring OpenChoreo cards and tabs onto your catalog entity pages.
+sidebar_position: 4
+---
+
+# Entity views
+
+OpenChoreo ships entity-page tabs for **Domain**, **System**, and **Component** entities. They mirror what the in-tree OpenChoreo portal shows, so a user navigating from the OpenChoreo UI into your Backstage instance sees the same tabs they're used to.
+
+## Tab catalog
+
+Every tab below ships in one of three "tab packs". Install only the packs whose tabs you want; tabs whose pack is not installed simply won't appear in the layout (you control which `<EntityLayout.Route>` blocks to include in your `EntityPage.tsx`).
+
+| Kind      | Tab           | Component                         | Package                                                 | Notes                                                        |
+| --------- | ------------- | --------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
+| Domain    | Overview      | (built-in)                        | `@openchoreo/backstage-plugin`                          | Cards: `NamespaceProjectsCard`, `NamespaceResourcesCard`.    |
+| Domain    | Definition    | `ResourceDefinitionTab`           | `@openchoreo/backstage-plugin`                          | Raw OpenChoreo resource manifest.                            |
+| System    | Overview      | (built-in)                        | `@openchoreo/backstage-plugin`                          | Cards: `ProjectComponentsCard`, `DeploymentPipelineCard`.    |
+| System    | Definition    | `ResourceDefinitionTab`           | `@openchoreo/backstage-plugin`                          |                                                              |
+| System    | Cell          | `CellDiagram`                     | `@openchoreo/backstage-plugin`                          | Project-level architecture view.                             |
+| System    | Diagram       | `EntityCatalogGraphCard`          | `@backstage/plugin-catalog-graph`                       | Standard catalog-graph card; no OpenChoreo package required. |
+| System    | Logs          | `ObservabilityProjectRuntimeLogs` | `@openchoreo/backstage-plugin-openchoreo-observability` | Project-scoped runtime logs.                                 |
+| System    | Traces        | `ObservabilityTraces`             | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| System    | Incidents     | `ObservabilityProjectIncidents`   | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| System    | RCA Reports   | `ObservabilityRCA`                | `@openchoreo/backstage-plugin-openchoreo-observability` | Root-cause analysis agent reports.                           |
+| System    | Cost Analysis | `ObservabilityCostAnalysis`       | `@openchoreo/backstage-plugin-openchoreo-observability` | FinOps agent reports.                                        |
+| Component | Overview      | (built-in)                        | `@openchoreo/backstage-plugin`                          | Cards: `DeploymentStatusCard`, `RuntimeHealthCard`.          |
+| Component | Definition    | `ResourceDefinitionTab`           | `@openchoreo/backstage-plugin`                          |                                                              |
+| Component | Build         | `Workflows`                       | `@openchoreo/backstage-plugin-openchoreo-ci`            | Workflow runs / triggers.                                    |
+| Component | Deploy        | `Environments`                    | `@openchoreo/backstage-plugin`                          | Per-environment runtime status.                              |
+| Component | Logs          | `ObservabilityRuntimeLogs`        | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime logs.                               |
+| Component | Metrics       | `ObservabilityMetrics`            | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| Component | Alerts        | `ObservabilityAlerts`             | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+
+Each `openchoreo-observability` / `openchoreo-ci` frontend package has a matching backend package (`-backend` suffix) — install both. The frontend talks to the backend at a Backstage discovery endpoint; the backend talks to OpenChoreo at `${openchoreo.baseUrl}` and `/resolve-urls` for observability.
+
+## Wiring example
+
+A minimal example showing all tabs wired across all three entity kinds:
+
+```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
+import {
+  Environments,
+  CellDiagram,
+  ResourceDefinitionTab,
+} from "@openchoreo/backstage-plugin";
+import { Workflows } from "@openchoreo/backstage-plugin-openchoreo-ci";
+import {
+  ObservabilityMetrics,
+  ObservabilityAlerts,
+  ObservabilityRuntimeLogs,
+  ObservabilityProjectRuntimeLogs,
+  ObservabilityTraces,
+  ObservabilityProjectIncidents,
+  ObservabilityRCA,
+  ObservabilityCostAnalysis,
+} from "@openchoreo/backstage-plugin-openchoreo-observability";
+```
+
+See the full snippet in [Core install → Add the entity-page routes](./installing-into-existing-backstage.mdx#core-routes), plus the opt-in sections for [Observability](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional) and [CI/Build](./installing-into-existing-backstage.mdx#6-add-cibuild-tab-optional).
+
+## What the views actually render
+
+`<Environments />` issues authenticated calls to `${openchoreo.baseUrl}` via the Backstage backend proxy at `/api/openchoreo/*`. It reads the entity's annotations to determine which OpenChoreo project and component to query. Components synced by the catalog provider already have these annotations — for components imported from your own `catalog-info.yaml`, the tab renders an "OpenChoreo metadata not found" empty state.
+
+`<CellDiagram />` does the same against `${openchoreo.baseUrl}/projects/{name}/cell-diagram` for the project the system corresponds to.
+
+Observability tabs first call the observability backend's `/resolve-urls` endpoint to discover the per-environment Observer/RCA/FinOps URLs, then call those services directly with the IDP token attached (header `x-openchoreo-direct: true` to bypass any intermediate proxies).
+
+The Build tab (`Workflows`) calls the CI backend, which proxies to OpenChoreo's workflow API.
+
+## Other extensions you can opt into
+
+The `@openchoreo/backstage-plugin` package re-exports more components than the install guide wires. These are not part of the canonical install but are available for hosts that want richer overview cards or standalone pages:
+
+| Export                         | Use                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------- |
+| `RuntimeHealthCard`            | Smaller component-level health card for the **Overview** tab.               |
+| `DeploymentStatusCard`         | Per-environment deployment status, for the Overview tab.                    |
+| `DeploymentPipelineCard`       | Deployment pipeline summary on a `Component` overview.                      |
+| `EnvironmentStatusSummaryCard` | Aggregated environment status on an Environment entity page.                |
+| `AccessControlContent`         | Standalone Access Control page (only useful when authz is enabled).         |
+| `GitSecretsContent`            | Git secret management page (only useful when secret-management is enabled). |
+
+These ship in the same `@openchoreo/backstage-plugin` package — no extra installation step.
+
+## Hiding tabs when annotations are missing
+
+If you want the tabs to only appear on entities that the OpenChoreo provider synced, gate them on the `openchoreo.io/component-name` annotation:
+
+```tsx
+import { isOpenChoreoComponent } from "@openchoreo/backstage-plugin-common";
+
+<EntityLayout.Route
+  path="/environments"
+  title="Deploy"
+  if={isOpenChoreoComponent}
+>
+  <Environments />
+</EntityLayout.Route>;
+```
+
+(`isOpenChoreoComponent` checks for the standard OpenChoreo annotations; see `@openchoreo/backstage-plugin-common` for the full list.)
+
+## Frontend dependencies
+
+The plugin uses **MUI v4** (`@material-ui/core@4.12.x`), matching Backstage's current default. If your host app has migrated to MUI v5, you must keep both: do not remove `@material-ui/core@4.x` from your dependencies.
+
+`@material-ui/lab@4.0.0-alpha.61` is required for some sub-components — add it to your app workspace if you do not already depend on it.
+
+The observability pack pulls `recharts`, `@material-ui/pickers`, and `@date-io/date-fns` transitively; the CI pack pulls `@rjsf/*` for dynamic workflow-parameter forms. Both are pinned by the packages themselves.

--- a/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
@@ -1,0 +1,907 @@
+---
+title: Installing into an existing Backstage app
+description: Step-by-step installation of OpenChoreo plugins into your Backstage workspace.
+sidebar_position: 2
+---
+
+# Installing into an existing Backstage app
+
+This guide walks through installing the OpenChoreo plugin set into a Backstage app you already own. It assumes a standard Backstage workspace produced by `npx @backstage/create-app` with the [New Backend System](https://backstage.io/docs/backend-system/) (the default since Backstage 1.32).
+
+The guide is **organized by feature**. Sections 1–3 are setup. Section 4 (**Core**) is the only mandatory install — after finishing it you have a working OpenChoreo-aware Backstage with Domain/System/Component pages and the Cell, Deploy, and Definition tabs rendering real data. Sections 5–7 each add one optional capability on top of Core; you can install any subset independently.
+
+:::info
+
+OpenChoreo plugins are published to **GitHub Packages** under the [`@openchoreo`](https://github.com/orgs/openchoreo/packages?repo_name=backstage-plugins) scope. You install them with `yarn add` once your package manager is authenticated against `https://npm.pkg.github.com` — see [Authenticate to GitHub Packages](#authenticate-to-github-packages) below.
+
+:::
+
+## 1. Prerequisites
+
+- A Backstage workspace on the [supported Backstage version](./compatibility-matrix.mdx). This guide pins to **Backstage `1.43.3`**.
+- Node.js **22**, Yarn **4.4.1**.
+- Access to a running OpenChoreo control plane (local `k3d` or a deployed cluster).
+- OAuth client credentials for the OpenChoreo Identity Provider (used by the catalog sync and user sign-in). On `k3d` the helm chart pre-seeds these; for a deployed cluster see [Identity configuration](../identity-configuration.mdx).
+
+## 2. Pin Backstage versions
+
+Add the following resolutions to your workspace `package.json`. They lock every `@backstage/*` package to the version line that the OpenChoreo plugins are tested against. **Without these pins, transitive `@backstage/*` deps drift to newer minor versions and you will hit missing `serviceRef{alpha.core.metrics}` and similar errors at startup.**
+
+```json
+{
+  "resolutions": {
+    "@types/react": "18.3.26",
+    "@types/react-dom": "18.3.7",
+    "csstype": "3.1.3",
+    "@backstage/backend-defaults": "0.12.1",
+    "@backstage/backend-plugin-api": "1.4.3",
+    "@backstage/catalog-model": "1.7.5",
+    "@backstage/cli": "0.34.3",
+    "@backstage/config": "1.3.4",
+    "@backstage/core-plugin-api": "1.11.0",
+    "@backstage/plugin-catalog-backend": "3.1.1",
+    "@backstage/plugin-catalog-backend-module-logs": "0.1.14",
+    "@backstage/plugin-catalog-node": "1.19.0",
+    "@backstage/plugin-permission-backend": "0.7.4",
+    "@backstage/plugin-permission-node": "0.10.4",
+    "@backstage/plugin-scaffolder-backend": "2.2.1",
+    "@backstage/plugin-scaffolder-node": "0.11.1"
+  }
+}
+```
+
+For the full pinned set see the [compatibility matrix](./compatibility-matrix.mdx).
+
+If your existing app is at a different Backstage release line, run:
+
+```bash
+yarn backstage-cli versions:bump --release 1.43.3
+```
+
+…to align before adding the OpenChoreo packages.
+
+## 3. Authenticate to GitHub Packages {#authenticate-to-github-packages}
+
+GitHub Packages requires authentication even for `read:packages`-only operations. Create a [classic Personal Access Token](https://github.com/settings/tokens/new) with the `read:packages` scope, then wire it into your package manager.
+
+**Yarn 4 (Berry):** add to your workspace `.yarnrc.yml`:
+
+```yaml
+npmScopes:
+  openchoreo:
+    npmRegistryServer: "https://npm.pkg.github.com"
+    npmAlwaysAuth: true
+    npmAuthToken: "${GITHUB_PACKAGES_TOKEN}"
+```
+
+…then `export GITHUB_PACKAGES_TOKEN=<your-pat>` before running `yarn install`. Berry expands the `${...}` placeholder from the environment so the token never lands in the repo.
+
+**npm / Yarn Classic:** add to your workspace `.npmrc`:
+
+```
+@openchoreo:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}
+```
+
+In **CI**, GitHub Actions can use the auto-issued `GITHUB_TOKEN` instead of a PAT, provided the workflow has `permissions: { packages: read }` and the running repo is in (or a fork of) an org the package is published from.
+
+---
+
+## 4. Core install {#core}
+
+Required. Delivers OpenChoreo sign-in, catalog sync (Domain/System/Component entities), and the **Cell**, **Deploy**, and **Definition** tabs on every entity page.
+
+After this section, a user signs in via the OpenChoreo IDP, lands in the catalog, and clicks into an entity to see live Cell/Deploy/Definition data. Sections 5–7 build on this foundation; do them in any order.
+
+:::tip Why sign-in is part of Core
+
+The Deploy and Cell tabs read from OpenChoreo APIs that require a **user IDP token** (not the Backstage identity token). That token only exists after the user signs in via the OpenChoreo IDP. The catalog _provider_ uses client-credentials and doesn't need user sign-in, but the _tabs_ on those entities do. So sign-in lives in Core, not in an opt-in section.
+
+If your OpenChoreo cluster runs with `features.auth.enabled: false` (no IDP), the same wiring still works — `DynamicSignInPage` (below) falls through to guest sign-in. See the [cluster-mirroring warning](#configure-app-config) in section 4.4.
+
+:::
+
+### 4.1 Install packages
+
+In your **app** workspace (`packages/app`):
+
+```bash
+yarn workspace app add \
+  @openchoreo/backstage-design-system@^0.1.0 \
+  @openchoreo/backstage-plugin-common@^0.1.0 \
+  @openchoreo/backstage-plugin-react@^0.1.0 \
+  @openchoreo/backstage-plugin@^0.1.0 \
+  @material-ui/lab@4.0.0-alpha.61
+```
+
+In your **backend** workspace (`packages/backend`):
+
+```bash
+yarn workspace backend add \
+  @openchoreo/openchoreo-client-node@^0.1.0 \
+  @openchoreo/openchoreo-auth@^0.1.0 \
+  @openchoreo/backstage-plugin-common@^0.1.0 \
+  @openchoreo/backstage-plugin-catalog-backend-module@^0.1.0 \
+  @openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy@^0.1.0 \
+  @openchoreo/backstage-plugin-scaffolder-backend-module@^0.1.0 \
+  @openchoreo/backstage-plugin-backend@^0.1.0 \
+  @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth@^0.1.0
+```
+
+:::tip Pinning all `@openchoreo/*` to the same minor
+
+The packages above are linked together by the OpenChoreo release process — they always release with matching versions. Pinning them all to the same `^x.y.0` caret keeps your install on one consistent release line. If you want to track the cutting edge, swap `^0.1.0` for the `next` dist-tag: `yarn workspace app add @openchoreo/backstage-plugin@next` (etc.). Prereleases are published under `next`; stable releases are under `latest`.
+
+:::
+
+### 4.2 Wire the backend
+
+Edit `packages/backend/src/index.ts`:
+
+```ts title="packages/backend/src/index.ts"
+import { createBackend } from "@backstage/backend-defaults";
+import { rootHttpRouterServiceFactory } from "@backstage/backend-defaults/rootHttpRouter";
+import {
+  immediateCatalogServiceFactory,
+  annotationStoreFactory,
+} from "@openchoreo/backstage-plugin-catalog-backend-module";
+import { createIdpTokenHeaderMiddleware } from "@openchoreo/openchoreo-auth";
+import { OpenChoreoAuthModule } from "@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth";
+
+const backend = createBackend();
+
+// Service factories required by the OpenChoreo plugins.
+// AnnotationStore is shared between the catalog module and openchoreo-backend.
+// ImmediateCatalogService lets scaffolder actions register entities synchronously.
+backend.add(immediateCatalogServiceFactory);
+backend.add(annotationStoreFactory);
+
+// IDP token middleware: reads x-openchoreo-token from frontend requests and
+// stashes it in AsyncLocalStorage. The permission policy and tab backends
+// pull from that context to authorize the signed-in user against OpenChoreo.
+// MUST be added before applyDefaults() so the context exists when downstream
+// handlers run.
+backend.add(
+  rootHttpRouterServiceFactory({
+    configure: ({ app, applyDefaults, middleware }) => {
+      app.use(middleware.helmet());
+      app.use(middleware.cors());
+      app.use(middleware.compression());
+      app.use(createIdpTokenHeaderMiddleware());
+      applyDefaults();
+    },
+  }),
+);
+
+// ... your existing backend.add(...) lines ...
+
+// Sign-in: register OpenChoreo as an OIDC provider.
+backend.add(import("@backstage/plugin-auth-backend"));
+backend.add(OpenChoreoAuthModule);
+backend.add(import("@backstage/plugin-auth-backend-module-guest-provider"));
+
+// Replace `@backstage/plugin-permission-backend-module-allow-all-policy`
+// with the OpenChoreo permission policy. The OpenChoreo policy delegates
+// `openchoreo.*` permissions to the OpenChoreo authorization service and
+// falls back to ALLOW for everything else, so it is composable with
+// other host-app policies.
+backend.add(import("@backstage/plugin-permission-backend"));
+backend.add(
+  import("@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy"),
+);
+
+// IMPORTANT: register catalog-backend-module BEFORE openchoreo-backend.
+// openchoreo-backend depends on the AnnotationStore initialized by the catalog module.
+backend.add(import("@openchoreo/backstage-plugin-catalog-backend-module"));
+backend.add(import("@openchoreo/backstage-plugin-backend"));
+backend.add(import("@openchoreo/backstage-plugin-scaffolder-backend-module"));
+
+backend.start();
+```
+
+If your existing `index.ts` registers `@backstage/plugin-permission-backend-module-allow-all-policy`, remove that line — only one permission policy can be active at a time.
+
+### 4.3 Wire the frontend
+
+Five sub-steps, all in `packages/app/src/`. Steps 4.3.1, 4.3.3, and 4.3.4 are also prerequisites for the opt-in sections that follow.
+
+#### 4.3.1 Register the plugin {#register-plugin}
+
+Backstage's plugin auto-discovery walks the JSX tree of the rendered app to find plugins. Plugins whose only mount points are `EntityLayout.Route` tabs inside `EntitySwitch.Case` branches are **not discovered** at boot (those branches only render once an entity is loaded), so their API factories are never registered. Register `choreoPlugin` explicitly in `packages/app/src/App.tsx`:
+
+```tsx title="packages/app/src/App.tsx"
+import { choreoPlugin } from '@openchoreo/backstage-plugin';
+
+const app = createApp({
+  apis,
+  plugins: [choreoPlugin], // <-- add this; opt-in sections will append more
+  bindRoutes({ bind }) { ... },
+});
+```
+
+#### 4.3.2 Wire OpenChoreo sign-in {#wire-signin}
+
+Create `packages/app/src/apis/authRefs.ts`:
+
+```ts title="packages/app/src/apis/authRefs.ts"
+import {
+  ApiRef,
+  BackstageIdentityApi,
+  createApiRef,
+  OAuthApi,
+  ProfileInfoApi,
+  SessionApi,
+} from "@backstage/core-plugin-api";
+
+export const openChoreoAuthApiRef: ApiRef<
+  OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
+> = createApiRef({
+  id: "auth.openchoreo-auth",
+});
+```
+
+Register the OAuth2 factory in `packages/app/src/apis.ts`:
+
+```tsx title="packages/app/src/apis.ts"
+import {
+  AnyApiFactory,
+  configApiRef,
+  createApiFactory,
+  discoveryApiRef,
+  oauthRequestApiRef,
+} from "@backstage/core-plugin-api";
+import { OAuth2 } from "@backstage/core-app-api";
+import { openChoreoAuthApiRef } from "./apis/authRefs";
+
+export { openChoreoAuthApiRef };
+
+export const apis: AnyApiFactory[] = [
+  // ... your existing factories ...
+  createApiFactory({
+    api: openChoreoAuthApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      oauthRequestApi: oauthRequestApiRef,
+      configApi: configApiRef,
+    },
+    factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
+      OAuth2.create({
+        discoveryApi,
+        oauthRequestApi,
+        configApi,
+        provider: {
+          id: "openchoreo-auth",
+          title: "OpenChoreo",
+          icon: () => null,
+        },
+        environment: configApi.getOptionalString("auth.environment"),
+        defaultScopes: ["openid", "profile", "email"],
+      }),
+  }),
+];
+```
+
+Swap the `SignInPage` component in `packages/app/src/App.tsx` for a feature-gated wrapper. This lets you toggle sign-in via `openchoreo.features.auth.enabled` without changing code — when your cluster runs with auth off, it falls through to guest sign-in:
+
+```tsx title="packages/app/src/App.tsx"
+import { SignInPage } from '@backstage/core-components';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { openChoreoAuthApiRef } from './apis/authRefs';
+
+function DynamicSignInPage(props: any) {
+  const configApi = useApi(configApiRef);
+  const authEnabled =
+    configApi.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
+
+  if (!authEnabled) {
+    return <SignInPage {...props} auto providers={['guest']} />;
+  }
+
+  return (
+    <SignInPage
+      {...props}
+      provider={{
+        id: 'openchoreo-auth',
+        title: 'OpenChoreo',
+        message: 'Sign in using OpenChoreo',
+        apiRef: openChoreoAuthApiRef,
+      }}
+    />
+  );
+}
+
+const app = createApp({
+  apis,
+  plugins: [...],
+  components: { SignInPage: DynamicSignInPage }, // <-- here
+  // ...
+});
+```
+
+:::warning Backend and frontend gates must agree
+
+`openchoreo.features.auth.enabled` is read in both places. If the backend module sees it as `true` but the SignInPage falls through to guest, the OpenChoreo authz API will reject the guest token. Set it once in `app-config` and let both sides read it.
+
+:::
+
+#### 4.3.3 Override `fetchApi` to inject the IDP token {#fetch-api}
+
+The OpenChoreo backend modules read an `x-openchoreo-token` header from incoming requests, populated by `createIdpTokenHeaderMiddleware()` you wired in [4.2 Wire the backend](#42-wire-the-backend). Backstage's default `fetchApi` does not know about that header — it only injects the Backstage identity token in `Authorization`. Without overriding `fetchApi`, **every tab data fetch goes out without the IDP token and the backend responds 401**.
+
+Create `packages/app/src/apis/OpenChoreoFetchApi.ts`:
+
+```ts title="packages/app/src/apis/OpenChoreoFetchApi.ts"
+import {
+  ConfigApi,
+  FetchApi,
+  IdentityApi,
+  OAuthApi,
+} from "@backstage/core-plugin-api";
+
+const OPENCHOREO_TOKEN_HEADER = "x-openchoreo-token";
+const DIRECT_MODE_HEADER = "x-openchoreo-direct";
+
+export class OpenChoreoFetchApi implements FetchApi {
+  private readonly authEnabled: boolean;
+
+  constructor(
+    private readonly identityApi: IdentityApi,
+    private readonly oauthApi: OAuthApi,
+    configApi: ConfigApi,
+  ) {
+    this.authEnabled =
+      configApi.getOptionalBoolean("openchoreo.features.auth.enabled") ?? true;
+    this.fetch = this.fetch.bind(this);
+  }
+
+  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const headers = new Headers(init?.headers);
+
+    // Direct mode: caller wants to bypass the Backstage backend and hit an
+    // external API directly. Strip the signal header; put IDP token in
+    // Authorization instead of x-openchoreo-token.
+    const isDirect = headers.has(DIRECT_MODE_HEADER);
+    if (isDirect) headers.delete(DIRECT_MODE_HEADER);
+
+    if (isDirect) {
+      if (this.authEnabled) {
+        try {
+          const idpToken = await this.oauthApi.getAccessToken();
+          if (idpToken) headers.set("Authorization", `Bearer ${idpToken}`);
+        } catch {
+          // No IDP token — proceed unauthenticated.
+        }
+      }
+    } else {
+      const { token: backstageToken } = await this.identityApi.getCredentials();
+      if (backstageToken)
+        headers.set("Authorization", `Bearer ${backstageToken}`);
+
+      if (this.authEnabled) {
+        try {
+          const idpToken = await this.oauthApi.getAccessToken();
+          if (idpToken) headers.set(OPENCHOREO_TOKEN_HEADER, idpToken);
+        } catch {
+          // No IDP token available — proceed with just the Backstage token.
+        }
+      }
+    }
+
+    return fetch(input, { ...init, headers });
+  }
+}
+```
+
+Register it against `fetchApiRef` in `packages/app/src/apis.ts`. The factory must come **after** the `openChoreoAuthApiRef` factory (it depends on it):
+
+```ts title="packages/app/src/apis.ts"
+import { fetchApiRef, identityApiRef } from "@backstage/core-plugin-api";
+import { OpenChoreoFetchApi } from "./apis/OpenChoreoFetchApi";
+
+export const apis: AnyApiFactory[] = [
+  // ... existing factories, including the openChoreoAuthApiRef one from 4.3.2 ...
+  createApiFactory({
+    api: fetchApiRef,
+    deps: {
+      identityApi: identityApiRef,
+      oauthApi: openChoreoAuthApiRef,
+      configApi: configApiRef,
+    },
+    factory: ({ identityApi, oauthApi, configApi }) =>
+      new OpenChoreoFetchApi(identityApi, oauthApi, configApi),
+  }),
+];
+```
+
+#### 4.3.4 Override `permissionApi` to inject the IDP token {#permission-api}
+
+Backstage's default `PermissionClient` uses `cross-fetch` directly and **bypasses `fetchApi` entirely** — so even with the `OpenChoreoFetchApi` step above, permission `/authorize` requests would still miss the `x-openchoreo-token` header. The Deploy tab's env-scoped permission hooks (and similar hooks in the opt-in tab packs) depend on this.
+
+Create `packages/app/src/apis/OpenChoreoPermissionApi.ts`:
+
+```ts title="packages/app/src/apis/OpenChoreoPermissionApi.ts"
+import { Config } from "@backstage/config";
+import {
+  DiscoveryApi,
+  IdentityApi,
+  OAuthApi,
+} from "@backstage/core-plugin-api";
+import { AuthorizeResult } from "@backstage/plugin-permission-common";
+
+const OPENCHOREO_TOKEN_HEADER = "x-openchoreo-token";
+
+export class OpenChoreoPermissionApi {
+  private readonly enabled: boolean;
+  private readonly authEnabled: boolean;
+  private readonly discovery: DiscoveryApi;
+  private readonly identityApi: IdentityApi;
+  private readonly oauthApi: OAuthApi;
+
+  constructor(options: {
+    config: Config;
+    discovery: DiscoveryApi;
+    identity: IdentityApi;
+    oauthApi: OAuthApi;
+  }) {
+    this.discovery = options.discovery;
+    this.identityApi = options.identity;
+    this.oauthApi = options.oauthApi;
+    this.enabled =
+      options.config.getOptionalBoolean("permission.enabled") ?? false;
+    this.authEnabled =
+      options.config.getOptionalBoolean("openchoreo.features.auth.enabled") ??
+      true;
+  }
+
+  async authorize(request: {
+    permission: { name: string };
+    resourceRef?: string;
+  }) {
+    if (!this.enabled) return { result: AuthorizeResult.ALLOW };
+
+    const permissionApiUrl = await this.discovery.getBaseUrl("permission");
+    const { token: backstageToken } = await this.identityApi.getCredentials();
+
+    let idpToken: string | undefined;
+    if (this.authEnabled) {
+      try {
+        idpToken = await this.oauthApi.getAccessToken();
+      } catch {
+        // No IDP token — proceed with just the Backstage token.
+      }
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (backstageToken) headers.Authorization = `Bearer ${backstageToken}`;
+    if (idpToken) headers[OPENCHOREO_TOKEN_HEADER] = idpToken;
+
+    const response = await fetch(`${permissionApiUrl}/authorize`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        items: [{ id: crypto.randomUUID(), ...request }],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Permission request failed: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.items[0];
+  }
+}
+```
+
+Register against `permissionApiRef` in `apis.ts`:
+
+```ts title="packages/app/src/apis.ts"
+import { permissionApiRef } from "@backstage/plugin-permission-react";
+import { OpenChoreoPermissionApi } from "./apis/OpenChoreoPermissionApi";
+
+export const apis: AnyApiFactory[] = [
+  // ... existing factories, including the fetchApiRef one from 4.3.3 ...
+  createApiFactory({
+    api: permissionApiRef,
+    deps: {
+      configApi: configApiRef,
+      discoveryApi: discoveryApiRef,
+      identityApi: identityApiRef,
+      oauthApi: openChoreoAuthApiRef,
+    },
+    factory: ({ configApi, discoveryApi, identityApi, oauthApi }) =>
+      new OpenChoreoPermissionApi({
+        config: configApi,
+        discovery: discoveryApi,
+        identity: identityApi,
+        oauthApi,
+      }),
+  }),
+];
+```
+
+This factory short-circuits to ALLOW when `permission.enabled: false`, so installing it before you turn on the permission framework is safe.
+
+#### 4.3.5 Add the entity-page routes {#core-routes}
+
+In `packages/app/src/components/catalog/EntityPage.tsx`, import the Core tab components and add them to the relevant entity layouts:
+
+```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
+import {
+  Environments,
+  CellDiagram,
+  ResourceDefinitionTab,
+} from '@openchoreo/backstage-plugin';
+
+// In your componentEntityPage / defaultEntityPage <EntityLayout> blocks:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+<EntityLayout.Route path="/environments" title="Deploy">
+  <Environments />
+</EntityLayout.Route>
+
+// In your systemPage <EntityLayout> block:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+<EntityLayout.Route path="/cell" title="Cell">
+  <CellDiagram />
+</EntityLayout.Route>
+
+// In your domainPage <EntityLayout> block:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+```
+
+OpenChoreo synced components have type strings like `deployment/web-application` and `deployment/service`. The default `componentPage` `EntitySwitch` only routes `service`/`website` to the page that includes Environments — add the Environments route to `defaultEntityPage` too if you want it on every component kind.
+
+### 4.4 Configure `app-config` {#configure-app-config}
+
+Add an `openchoreo` block to your `app-config.yaml` (or `app-config.local.yaml` for development).
+
+:::warning Feature flags must mirror the OpenChoreo cluster
+
+`openchoreo.features.auth.enabled` and `openchoreo.features.authz.enabled` are **not** independent installer defaults. They must match how the OpenChoreo cluster your Backstage instance is talking to was deployed:
+
+| Cluster runs with…                         | Set in Backstage                              |
+| ------------------------------------------ | --------------------------------------------- |
+| auth + authz both **off** (local dev mode) | `auth.enabled: false`, `authz.enabled: false` |
+| auth + authz both **on** (production mode) | `auth.enabled: true`, `authz.enabled: true`   |
+
+The in-tree OpenChoreo portal hides this knob because the Helm chart configures both halves in lockstep. External Backstage hosts installing the published `@openchoreo/*` plugins bypass the chart and must align by hand. Mismatch produces failure modes covered in [Troubleshooting](./troubleshooting.mdx): the catalog provider 401s if auth disagrees, and tabs render "No permissions" if authz disagrees.
+
+Check your cluster: look at the `features` block in the OpenChoreo helm values, or ask whoever deployed it.
+
+:::
+
+```yaml title="app-config.local.yaml"
+auth:
+  environment: development
+  providers:
+    openchoreo-auth:
+      development:
+        clientId: ${OPENCHOREO_AUTH_CLIENT_ID}
+        clientSecret: ${OPENCHOREO_AUTH_CLIENT_SECRET}
+        # Set the OAuth2 endpoints explicitly. `metadataUrl` (OIDC discovery)
+        # is *not* used because the default OpenChoreo IDP (Thunder) does not
+        # expose a reliable /.well-known/openid-configuration endpoint on k3d
+        # — uncomment it only if your IDP advertises one.
+        # metadataUrl: ${OPENCHOREO_AUTH_METADATA_URL}
+        authorizationUrl: ${OPENCHOREO_AUTH_AUTHORIZATION_URL}
+        tokenUrl: ${OPENCHOREO_AUTH_TOKEN_URL}
+        scope: "openid profile email"
+    guest:
+      dangerouslyAllowOutsideDevelopment: true
+
+openchoreo:
+  baseUrl: ${OPENCHOREO_API_URL} # e.g. http://api.openchoreo.localhost:8080/api/v1
+
+  # OAuth2 client credentials used by the catalog provider for
+  # service-to-service auth (client_credentials flow). Required even when
+  # features.auth.enabled is false, because the catalog provider still needs
+  # to fetch namespaces/projects/components from the OpenChoreo API.
+  auth:
+    clientId: ${OPENCHOREO_CLIENT_ID}
+    clientSecret: ${OPENCHOREO_CLIENT_SECRET}
+    tokenUrl: ${OPENCHOREO_TOKEN_URL}
+
+  features:
+    # MIRROR THE CLUSTER (see warning above). Backend and frontend both read
+    # these — they must agree across the whole stack.
+    auth:
+      enabled: true
+    authz:
+      enabled: true
+
+  defaultOwner: openchoreo-users
+  schedule:
+    frequency: 30 # seconds between catalog provider runs
+    timeout: 120 # seconds for catalog provider timeout
+
+permission:
+  enabled: true # required for the OpenChoreo permission policy to run
+
+# The catalog must accept Domain entities from the OpenChoreo provider.
+catalog:
+  rules:
+    - allow: [Component, System, Domain, API, Resource, Location, Group, User]
+```
+
+#### Local k3d quickstart {#k3d-quickstart}
+
+OpenChoreo's k3d helm install seeds known credentials. Skip the `${VAR}` placeholders and hardcode these values to get sign-in working without touching env vars:
+
+```yaml title="app-config.local.yaml (k3d-only)"
+auth:
+  environment: development
+  providers:
+    openchoreo-auth:
+      development:
+        clientId: openchoreo-backstage-client
+        clientSecret: backstage-portal-secret
+        authorizationUrl: http://thunder.openchoreo.localhost:8080/oauth2/authorize
+        tokenUrl: http://thunder.openchoreo.localhost:8080/oauth2/token
+        scope: "openid profile email"
+
+openchoreo:
+  baseUrl: http://api.openchoreo.localhost:8080/api/v1
+  auth:
+    clientId: openchoreo-backstage-client
+    clientSecret: backstage-portal-secret
+    tokenUrl: http://thunder.openchoreo.localhost:8080/oauth2/token
+```
+
+These are **k3d dev cluster seed values, not real secrets** — never use them against a production OpenChoreo install. For deployed clusters see [Identity configuration](../identity-configuration.mdx).
+
+### 4.5 Verify
+
+```bash
+yarn dev
+```
+
+Expected:
+
+1. Backend logs show `Plugin initialization complete` for `openchoreo`, `catalog`, `permission`, `auth`.
+2. After ~30s: `Successfully processed N entities (X domains, Y systems, Z components, ...)`.
+3. Browser → `http://localhost:3000` → sign-in page shows "Sign in using OpenChoreo." Click through and land in the catalog.
+4. `http://localhost:3000/catalog?filters[kind]=domain` → see your OpenChoreo namespaces.
+5. Click into any project (`kind=system`) → **Cell** and **Definition** tabs are present and render real data.
+6. Click into any component → **Deploy** and **Definition** tabs are present and render real data.
+
+If you get a 401 on tab data fetches, you skipped 4.3.3 (`OpenChoreoFetchApi`). If you get "No permissions" on Deploy, you skipped 4.3.4 (`OpenChoreoPermissionApi`). See [Troubleshooting](./troubleshooting.mdx) for the full failure-mode index.
+
+---
+
+## 5. Add Observability tabs (optional)
+
+Adds **Logs, Metrics, Alerts** to Component pages and **Logs, Traces, Incidents, RCA Reports, Cost Analysis** to System pages. Built on top of Core.
+
+**Prerequisites:** Section 4 (Core) complete and verified.
+
+### 5.1 Install packages
+
+```bash
+yarn workspace app add @openchoreo/backstage-plugin-openchoreo-observability@^0.1.0
+yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-observability-backend@^0.1.0
+```
+
+### 5.2 Wire the backend
+
+Append to `packages/backend/src/index.ts` (after the Core wiring):
+
+```ts
+backend.add(
+  import("@openchoreo/backstage-plugin-openchoreo-observability-backend"),
+);
+```
+
+### 5.3 Wire the frontend
+
+Register the plugin (append to the `plugins: [...]` array you set up in [4.3.1](#register-plugin)):
+
+```tsx title="packages/app/src/App.tsx"
+import { openchoreoObservabilityPlugin } from '@openchoreo/backstage-plugin-openchoreo-observability';
+
+plugins: [
+  choreoPlugin,
+  openchoreoObservabilityPlugin, // <-- add
+],
+```
+
+Add the observability routes to `packages/app/src/components/catalog/EntityPage.tsx`:
+
+```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
+import {
+  ObservabilityMetrics,
+  ObservabilityAlerts,
+  ObservabilityRuntimeLogs,
+  ObservabilityProjectRuntimeLogs,
+  ObservabilityTraces,
+  ObservabilityProjectIncidents,
+  ObservabilityRCA,
+  ObservabilityCostAnalysis,
+} from '@openchoreo/backstage-plugin-openchoreo-observability';
+
+// Component pages (componentEntityPage / defaultEntityPage):
+<EntityLayout.Route path="/runtime-logs" title="Logs">
+  <ObservabilityRuntimeLogs />
+</EntityLayout.Route>
+<EntityLayout.Route path="/metrics" title="Metrics">
+  <ObservabilityMetrics />
+</EntityLayout.Route>
+<EntityLayout.Route path="/alerts" title="Alerts">
+  <ObservabilityAlerts />
+</EntityLayout.Route>
+
+// System page (systemPage):
+<EntityLayout.Route path="/logs" title="Logs">
+  <ObservabilityProjectRuntimeLogs />
+</EntityLayout.Route>
+<EntityLayout.Route path="/traces" title="Traces">
+  <ObservabilityTraces />
+</EntityLayout.Route>
+<EntityLayout.Route path="/incidents" title="Incidents">
+  <ObservabilityProjectIncidents />
+</EntityLayout.Route>
+<EntityLayout.Route path="/rca-reports" title="RCA Reports">
+  <ObservabilityRCA />
+</EntityLayout.Route>
+<EntityLayout.Route path="/cost-analysis" title="Cost Analysis">
+  <ObservabilityCostAnalysis />
+</EntityLayout.Route>
+```
+
+### 5.4 Configure
+
+Append to the `openchoreo.features` block in `app-config.local.yaml`:
+
+```yaml
+openchoreo:
+  features:
+    observability:
+      enabled: true
+```
+
+### 5.5 Verify
+
+Restart `yarn dev`. Open any Component → the **Logs**, **Metrics**, **Alerts** tabs appear. Open any System → **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
+
+---
+
+## 6. Add CI/Build tab (optional)
+
+Adds a **Build** tab to Component pages, showing workflow runs and a parameter-form trigger. Built on top of Core.
+
+**Prerequisites:** Section 4 (Core) complete and verified.
+
+### 6.1 Install packages
+
+```bash
+yarn workspace app add @openchoreo/backstage-plugin-openchoreo-ci@^0.1.0
+yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-ci-backend@^0.1.0
+```
+
+### 6.2 Wire the backend
+
+Append to `packages/backend/src/index.ts`:
+
+```ts
+backend.add(import("@openchoreo/backstage-plugin-openchoreo-ci-backend"));
+```
+
+### 6.3 Wire the frontend
+
+Register the plugin (append to the `plugins: [...]` array):
+
+```tsx title="packages/app/src/App.tsx"
+import { openchoreoCiPlugin } from '@openchoreo/backstage-plugin-openchoreo-ci';
+
+plugins: [
+  choreoPlugin,
+  openchoreoCiPlugin, // <-- add
+],
+```
+
+Add the Build route to `EntityPage.tsx`:
+
+```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
+import { Workflows } from "@openchoreo/backstage-plugin-openchoreo-ci";
+
+// In your componentEntityPage / defaultEntityPage:
+<EntityLayout.Route path="/workflows" title="Build">
+  <Workflows />
+</EntityLayout.Route>;
+```
+
+### 6.4 Configure
+
+Append to the `openchoreo.features` block:
+
+```yaml
+openchoreo:
+  features:
+    workflows:
+      enabled: true
+```
+
+### 6.5 Verify
+
+Restart `yarn dev`. Open any Component → the **Build** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
+
+---
+
+## 7. Add standalone Workflows page (optional)
+
+Adds an org-level Workflows page for generic (non-component-scoped) workflow templates and runs. Built on top of Core.
+
+**Prerequisites:** Section 4 (Core) complete and verified.
+
+### 7.1 Install packages
+
+```bash
+yarn workspace app add @openchoreo/backstage-plugin-openchoreo-workflows@^0.1.0
+yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-workflows-backend@^0.1.0
+```
+
+### 7.2 Wire the backend
+
+Append to `packages/backend/src/index.ts`:
+
+```ts
+backend.add(
+  import("@openchoreo/backstage-plugin-openchoreo-workflows-backend"),
+);
+```
+
+### 7.3 Wire the frontend
+
+Register the plugin:
+
+```tsx title="packages/app/src/App.tsx"
+import { openchoreoWorkflowsPlugin } from '@openchoreo/backstage-plugin-openchoreo-workflows';
+
+plugins: [
+  choreoPlugin,
+  openchoreoWorkflowsPlugin, // <-- add
+],
+```
+
+The standalone Workflows page is mounted via a route — see the plugin's README for the route component to wire into your app's `FlatRoutes`.
+
+### 7.4 Verify
+
+Restart `yarn dev`. Navigate to the Workflows route → see the org-level workflow list.
+
+---
+
+## 8. Remove the notifications plugin (if present)
+
+The default `@backstage/create-app` template wires `@backstage/plugin-notifications` into both the sidebar (`NotificationsSidebarItem`) and routes (`<NotificationsPage />`). The version of that plugin published when this guide was tested expects `toastApiRef` and several components (`Tag`, `Dialog`, `DialogHeader`, ...) from `@backstage/ui` / `@backstage/frontend-plugin-api` that are **not present** in the 1.43.3 release line we pin. The sidebar item crashes the whole app shell with `Cannot read properties of undefined (reading 'id')`.
+
+Delete the import and JSX usage from `packages/app/src/components/Root/Root.tsx`:
+
+```tsx
+// Remove:
+// import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
+// <NotificationsSidebarItem />
+```
+
+…and from `packages/app/src/App.tsx`:
+
+```tsx
+// Remove:
+// import { NotificationsPage } from '@backstage/plugin-notifications';
+// <Route path="/notifications" element={<NotificationsPage />} />
+```
+
+You can leave the `@backstage/plugin-notifications` package installed; it just shouldn't be referenced from the rendered tree.
+
+---
+
+## Troubleshooting
+
+If anything misbehaves at any step, see [Troubleshooting](./troubleshooting.mdx) for the full failure-mode index, indexed by exact error message.

--- a/docs/platform-engineer-guide/backstage-plugins/overview.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/overview.mdx
@@ -1,0 +1,56 @@
+---
+title: Overview
+description: Install OpenChoreo plugins into your existing Backstage app.
+sidebar_position: 1
+---
+
+# Backstage Plugins for OpenChoreo
+
+OpenChoreo ships its own Backstage portal preconfigured for the platform. If you already run a Backstage instance and just want to add OpenChoreo capabilities, this guide is for you.
+
+This is an alternative to forking the [`openchoreo/backstage-plugins`](https://github.com/openchoreo/backstage-plugins) repository. You install a small set of npm packages into your own Backstage workspace and wire them up.
+
+## What you get
+
+**Core** (required) — delivered by a single install path:
+
+| Capability                 | Details                                                                                                                                                                               |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Catalog sync**           | OpenChoreo namespaces become `Domain` entities, projects become `System` entities, components become `Component` entities, with relations preserved.                                  |
+| **OpenChoreo sign-in**     | OIDC sign-in against the OpenChoreo IDP. The signed-in user's token flows into entity-page tab calls. Falls through to guest sign-in when your OpenChoreo cluster runs with auth off. |
+| **Domain entity views**    | **Overview**, **Definition**.                                                                                                                                                         |
+| **System entity views**    | **Overview**, **Definition**, **Cell** (architectural diagram), **Diagram** (catalog graph).                                                                                          |
+| **Component entity views** | **Overview**, **Definition**, **Deploy** (per-environment runtime state).                                                                                                             |
+| **Permission policy**      | Composable Backstage permission policy that delegates `openchoreo.*` permissions to the OpenChoreo authorization service and falls back to ALLOW for everything else.                 |
+| **Scaffolder actions**     | OpenChoreo-aware actions for use in your own scaffolder templates.                                                                                                                    |
+
+**Optional tab packs** — install only the ones you want:
+
+| Pack                                                    | Adds                                                                                                                                     |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `@openchoreo/backstage-plugin-openchoreo-observability` | System tabs: **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis**. Component tabs: **Logs**, **Metrics**, **Alerts**. |
+| `@openchoreo/backstage-plugin-openchoreo-ci`            | Component tab: **Build** (workflow runs + trigger form).                                                                                 |
+| `@openchoreo/backstage-plugin-openchoreo-workflows`     | Standalone org-level Workflows page.                                                                                                     |
+
+See the [compatibility matrix](./compatibility-matrix.mdx) for the full list of packages.
+
+## What is not in scope yet
+
+The following live in `openchoreo/backstage-plugins` but are not packaged for external installation:
+
+- **External CI integrations** (Jenkins, GitHub Actions, GitLab CI) — third-party plugin wiring that the in-tree portal ships preconfigured.
+- **Scaffolder _templates_** — the scaffolder _backend module_ (which ships actions) is part of Core; templates that consume those actions are still in the upstream repo.
+
+If you need any of these today, fork the upstream repo or file an issue at [openchoreo/backstage-plugins](https://github.com/openchoreo/backstage-plugins/issues).
+
+## Compatibility
+
+OpenChoreo plugins target a specific Backstage release line. See the [compatibility matrix](./compatibility-matrix.mdx) for the tested combinations. Installing into a Backstage app on a different release line may surface dependency-resolution issues; the [troubleshooting](./troubleshooting.mdx) guide lists the common ones and how to pin around them.
+
+## Where to start
+
+1. [Installing into an existing Backstage app](./installing-into-existing-backstage.mdx) — the canonical step-by-step. Core first; opt-in tab packs follow.
+2. [Catalog sync](./catalog-sync.mdx) — what gets synced and how to tune it.
+3. [Entity views](./entity-views.mdx) — the full tab matrix and per-tab package mapping.
+4. [Permission policy](./permission-policy.mdx) — composing OpenChoreo authorization with your existing policy.
+5. [Troubleshooting](./troubleshooting.mdx) — failure-mode index keyed by exact error message.

--- a/docs/platform-engineer-guide/backstage-plugins/permission-policy.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/permission-policy.mdx
@@ -1,0 +1,97 @@
+---
+title: Permission policy
+description: Compose the OpenChoreo permission policy with your existing host policy.
+sidebar_position: 5
+---
+
+# Permission policy
+
+The **`@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy`** module installs a Backstage [permission policy](https://backstage.io/docs/permissions/concepts) that consults the OpenChoreo authorization service for `openchoreo.*` permissions. For everything else (catalog read, scaffolder execute, …) it returns ALLOW, so it is **composable** with your existing host policy as long as it is registered as the only top-level policy.
+
+## Wiring
+
+The Backstage backend can only have one permission policy active. If your existing `packages/backend/src/index.ts` registers the default allow-all policy:
+
+```ts
+backend.add(
+  import("@backstage/plugin-permission-backend-module-allow-all-policy"),
+);
+```
+
+Replace it with the OpenChoreo policy:
+
+```ts
+backend.add(import("@backstage/plugin-permission-backend"));
+backend.add(
+  import("@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy"),
+);
+```
+
+If you have a custom policy already, you can call into the OpenChoreo policy from yours — see the policy's exported helpers in [`plugins/permission-backend-module-openchoreo-policy/src/index.ts`](https://github.com/openchoreo/backstage-plugins/blob/main/plugins/permission-backend-module-openchoreo-policy/src/index.ts).
+
+## Two operating modes
+
+Behaviour switches on `openchoreo.features.authz.enabled`. **This flag must mirror the OpenChoreo cluster's deployment state** — it is not an independent installer default:
+
+| Cluster state         | Set in Backstage       | Policy behaviour                                                                                                                                                                                   |
+| --------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| authz off (local dev) | `authz.enabled: false` | Policy short-circuits to ALLOW for every permission. Logs `OpenChoreo permission policy disabled via openchoreo.features.authz.enabled=false. Using allow-all policy.` at startup.                 |
+| authz on (production) | `authz.enabled: true`  | Policy queries `${openchoreo.baseUrl}/authz/profile` for the user's capabilities, evaluates `openchoreo.*` permissions against the result, and falls back to ALLOW for non-OpenChoreo permissions. |
+
+The in-tree OpenChoreo portal hides this knob because the Helm chart configures both halves in lockstep. External Backstage hosts must align by hand.
+
+## Enabling authz: extra wiring required
+
+When the cluster runs with authz on, the policy needs the user's IDP token to reach `/authz/profile`. Install the **IDP token middleware** on the root HTTP router. Edit `packages/backend/src/index.ts`:
+
+```ts
+import { rootHttpRouterServiceFactory } from "@backstage/backend-defaults/rootHttpRouter";
+import { createIdpTokenHeaderMiddleware } from "@openchoreo/openchoreo-auth";
+
+backend.add(
+  rootHttpRouterServiceFactory({
+    configure: ({ app, applyDefaults, middleware }) => {
+      app.use(middleware.helmet());
+      app.use(middleware.cors());
+      app.use(middleware.compression());
+      app.use(middleware.logging());
+
+      // Reads the IDP token from the request and exposes it via
+      // AsyncLocalStorage so the policy can use it for /authz/profile calls.
+      app.use(createIdpTokenHeaderMiddleware());
+
+      applyDefaults();
+    },
+  }),
+);
+```
+
+You also need the frontend OIDC sign-in provider so the policy receives the user's IDP token. That wiring is part of [Core install § 4.3.2](./installing-into-existing-backstage.mdx#wire-signin) — `OpenChoreoAuthModule` on the backend, the `OAuth2` factory and `DynamicSignInPage` on the frontend. Plus the [`OpenChoreoPermissionApi`](./installing-into-existing-backstage.mdx#permission-api) override, without which the IDP token doesn't reach the authorize call at all.
+
+## Composability semantics
+
+The policy decision tree:
+
+1. If the permission name starts with `openchoreo.`:
+   - If `authz.enabled = false`: **ALLOW**.
+   - If `authz.enabled = true`: query `/authz/profile`, evaluate, return ALLOW or DENY.
+2. If the permission name is one of the OpenChoreo-managed catalog permissions (e.g. `catalog.entity.read` for an OpenChoreo-synced entity): same rules as above.
+3. Otherwise (e.g. `scaffolder.task.execute`, `catalog.entity.create`, your-org's custom permissions): **ALLOW**.
+
+This means your existing Backstage permissions UX (scaffolder gating, catalog write rules, …) is unchanged.
+
+## Verification
+
+The simplest end-to-end smoke test runs the policy in AllowAll mode (matching a cluster deployed with `authz: false`). With the backend running:
+
+```bash
+# Acquire a guest token (development only).
+TOKEN=$(curl -sS -X POST http://localhost:7007/api/auth/guest/refresh \
+  | jq -r '.backstageIdentity.token')
+
+# Authorize a no-op OpenChoreo permission. Expect "ALLOW".
+curl -sS -X POST http://localhost:7007/api/permission/authorize \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"items":[{"id":"x","permission":{"type":"basic","name":"openchoreo.foo.read"}}]}' | jq
+```

--- a/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
@@ -1,0 +1,254 @@
+---
+title: Troubleshooting
+description: Common installation issues and how to diagnose them.
+sidebar_position: 6
+---
+
+# Troubleshooting
+
+Issues you will most likely run into when installing the OpenChoreo plugins into an existing Backstage app, drawn from observed failures.
+
+## Missing `alpha.core.metrics` service ref
+
+```
+Service or extension point dependencies of plugin 'catalog' are missing
+for the following ref(s): serviceRef{alpha.core.metrics}
+```
+
+**Cause:** your host app resolved a newer minor of `@backstage/plugin-catalog-backend` than the OpenChoreo plugins were tested against. Newer versions depend on alpha services (`alpha.core.metrics`, `catalogPermissionExtensionPoint`) that the older `backend-defaults` does not provide.
+
+**Fix:** pin every `@backstage/*` package to the version line tested by OpenChoreo. The full set is in the [compatibility matrix](./compatibility-matrix.mdx). Add the listed `resolutions` to your workspace root `package.json`, then:
+
+```bash
+rm -rf node_modules yarn.lock
+yarn install
+```
+
+## Missing `catalog.permission` extension point
+
+```
+Service or extension point dependencies of module 'openchoreo' for plugin
+'catalog' are missing for the following ref(s): extensionPoint{catalog.permission}
+```
+
+Same root cause as above. The `catalogPermissionExtensionPoint` is registered by `@backstage/plugin-catalog-backend@3.1.x`; in `3.6.x+` it moved out of the main package. Pin to `3.1.1`.
+
+## `AnnotationStore is not available`
+
+```
+Failed to instantiate service 'openchoreo.annotation-store' because the
+default factory loader threw an error, Error: AnnotationStore is not
+available. Make sure the catalog-backend-module-openchoreo is installed.
+```
+
+**Cause:** the catalog-backend-module is installed but the **service factories** are not registered. The factories are required by both `catalog-backend-module-openchoreo` (for processors) and `openchoreo-backend` (for the API surface).
+
+**Fix:** add the explicit `backend.add(...)` lines in `packages/backend/src/index.ts`:
+
+```ts
+import {
+  immediateCatalogServiceFactory,
+  annotationStoreFactory,
+} from "@openchoreo/backstage-plugin-catalog-backend-module";
+
+backend.add(immediateCatalogServiceFactory);
+backend.add(annotationStoreFactory);
+```
+
+These must be added **before** `backend.start()`.
+
+## `openchoreo.schedule.frequency` config rejected as object
+
+```
+Invalid type in config for key 'openchoreo.schedule.frequency' in
+'app-config.local.yaml', got object, wanted number
+```
+
+**Cause:** the catalog provider expects `frequency` and `timeout` to be plain integers (seconds), not the Backstage `HumanDuration` shape.
+
+**Fix:**
+
+```yaml
+openchoreo:
+  schedule:
+    frequency: 30 # ✅ correct
+    timeout: 120 # ✅ correct
+    # frequency: { seconds: 30 }   ❌ wrong — produces this error
+```
+
+## Catalog sync fails with 401 from OpenChoreo
+
+```
+Failed to fetch namespaces: 401 Unauthorized - missing or invalid
+authentication token
+```
+
+**Cause:** the catalog provider tried to call the OpenChoreo API without a token. This happens when **either** `openchoreo.features.auth.enabled` is `false` **or** the OAuth `clientId` / `clientSecret` / `tokenUrl` are missing or wrong.
+
+**Fix:** keep `auth.enabled: true` and confirm the credentials work:
+
+```bash
+curl -X POST -d 'grant_type=client_credentials' \
+  -d "client_id=${OPENCHOREO_CLIENT_ID}" \
+  -d "client_secret=${OPENCHOREO_CLIENT_SECRET}" \
+  ${OPENCHOREO_TOKEN_URL}
+```
+
+A successful response returns a JSON object with `access_token`. If you see `invalid_client`, the credentials are wrong; if the request times out, the IDP is not reachable.
+
+## Yarn `portal:` link conflicts on `@backstage/*`
+
+```
+Cannot link @openchoreo/backstage-plugin-react ... dependency
+@backstage/catalog-model conflicts with parent dependency
+```
+
+**Cause:** you tried to use Yarn `portal:` to point at a sibling `openchoreo/backstage-plugins` checkout. Portal preserves each portal'd workspace's own `node_modules`, which produces duplicate `@backstage/*` package instances and broken service-ref identity.
+
+**Fix:** install from GitHub Packages instead of using `portal:`. See the [installation guide](./installing-into-existing-backstage.mdx#core) — `yarn add` against the published `@openchoreo/*` packages lets yarn dedupe `@backstage/*` against your host app's tree.
+
+## React duplicate-instance error / "Invalid hook call"
+
+**Cause:** two copies of `react` in the dependency tree, usually because a portal'd or `link:`-ed plugin pulled its own `react` instead of using the host's.
+
+**Fix:** add to your workspace root `resolutions`:
+
+```json
+"resolutions": {
+  "react": "18.3.1",
+  "react-dom": "18.3.1",
+  "@types/react": "18.3.26",
+  "@types/react-dom": "18.3.7"
+}
+```
+
+## `csstype` type errors during `yarn tsc`
+
+```
+Property.AlignmentBaseline ... is not assignable
+```
+
+**Cause:** version drift on `csstype` between the OpenChoreo plugin tree and your app's tree.
+
+**Fix:**
+
+```json
+"resolutions": {
+  "csstype": "3.1.3"
+}
+```
+
+## Backend module startup fails with `Cannot read properties of undefined (reading 'id')`
+
+```
+Module 'openchoreo' for plugin 'catalog' startup failed;
+caused by TypeError: Cannot read properties of undefined (reading 'id')
+```
+
+**Cause:** one of the modules registered with `backend.add(...)` declares a dependency on a service ref that resolved to `undefined`. Usually a version skew where one of `@backstage/plugin-scaffolder-backend-module-notifications` or similar is pulled at a version newer than your Backstage release line.
+
+**Fix:** pin all transitive `@backstage/*` resolutions to the tested versions in the [compatibility matrix](./compatibility-matrix.mdx). If you do not need a specific module (e.g. `scaffolder-backend-module-notifications`), remove its `backend.add(...)` line and `yarn remove` it.
+
+## Port 7007 already in use
+
+```
+EADDRINUSE: address already in use :::7007
+```
+
+A previous failed boot left a node process on port 7007. Kill it:
+
+```bash
+lsof -i :7007 -i :3000
+kill <pid>
+```
+
+## Catalog provider runs but no entities show up
+
+Check `catalog.rules.allow` includes `Domain` and any other custom kinds the OpenChoreo provider produces. The catalog silently drops disallowed kinds.
+
+```yaml
+catalog:
+  rules:
+    - allow: [Component, System, Domain, API, Resource, Location, Group, User]
+```
+
+## `NotificationsSidebarItem` crashes the app at boot
+
+```
+Uncaught TypeError: Cannot read properties of undefined (reading 'id')
+  in <NotificationsSidebarItem>
+```
+
+**Cause:** the create-app template installs `@backstage/plugin-notifications`, which in versions newer than the 1.43.3 release line expects exports (`toastApiRef`, `Tag`, `Dialog`, `DialogHeader`, ...) that the pinned `@backstage/ui` and `@backstage/frontend-plugin-api` do not provide.
+
+**Fix:** remove `NotificationsSidebarItem` from `packages/app/src/components/Root/Root.tsx` and `<NotificationsPage />` from `packages/app/src/App.tsx`. See the [installation guide](./installing-into-existing-backstage.mdx#8-remove-the-notifications-plugin-if-present) for details.
+
+## `choreoPlugin` API factories not registered on entity tabs
+
+```
+NotImplementedError: No implementation available for
+apiRef{plugin.openchoreo.client}
+```
+
+**Cause:** Backstage's plugin auto-discovery walks the JSX tree of the rendered app to find plugins. The `Environments` and `CellDiagram` components are mounted inside `EntitySwitch.Case` branches that only render once an entity is loaded, so they are not in the static tree at app boot. Backstage never adds `choreoPlugin` to its plugin set, and its `apis: [...]` factories are never registered.
+
+**Fix:** register `choreoPlugin` explicitly in `packages/app/src/App.tsx`:
+
+```tsx
+import { choreoPlugin } from "@openchoreo/backstage-plugin";
+
+const app = createApp({
+  apis,
+  plugins: [choreoPlugin],
+  // ...
+});
+```
+
+## Observability API factory missing on Environments tab
+
+```
+NotImplementedError: No implementation available for
+apiRef{plugin.openchoreo-observability.service}
+```
+
+**Cause:** the Environments tab consumes the observability API (`openchoreoObservabilityPlugin`) for incident counts. If you didn't install the observability tab pack, the plugin's API factory is never registered.
+
+**Fix:** install `@openchoreo/backstage-plugin-openchoreo-observability` + its backend counterpart and register `openchoreoObservabilityPlugin` in `createApp({ plugins: [...] })`. See the [installation guide → Observability tabs](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional).
+
+## `openchoreo-auth` provider misconfigured
+
+```
+NotFoundError: Auth provider registered for 'openchoreo-auth' is misconfigured.
+This could mean the configs under auth.providers.openchoreo-auth are missing
+or the environment variables used are not defined.
+```
+
+**Cause:** one or more of the `OPENCHOREO_AUTH_*` env vars referenced by `auth.providers.openchoreo-auth.development.*` in your `app-config.local.yaml` is undefined. Backstage's config loader expands `${VAR}` placeholders at startup; if a var is missing, the literal `${OPENCHOREO_AUTH_CLIENT_ID}` string ends up in the config, and the auth module rejects it.
+
+**Fix:** for local k3d, hardcode the seeded credentials instead of using env-var substitution — see the [Local k3d quickstart](./installing-into-existing-backstage.mdx#k3d-quickstart) section. For a real deployment, set the env vars in your shell or process manager before starting Backstage.
+
+## 401 on tab data fetches after signing in
+
+```
+HTTP 401: Unauthorized
+```
+
+**Cause:** you're signed in to Backstage but the OpenChoreo backend modules (`-observability-backend`, `-ci-backend`, `-workflows-backend`) reject your requests because they can't find the IDP token. Backstage's default `fetchApi` only injects the Backstage identity token in `Authorization`; it has no concept of the `x-openchoreo-token` header the backend modules read.
+
+**Fix:** install the custom `OpenChoreoFetchApi` and register it against `fetchApiRef`. See [Override `fetchApi`](./installing-into-existing-backstage.mdx#fetch-api). The same fix is needed for permission requests — see [Override `permissionApi`](./installing-into-existing-backstage.mdx#permission-api).
+
+## "No permissions to view this environment" on Deploy / Logs / Metrics tabs
+
+**Cause:** one of two things, in order of likelihood:
+
+1. **`OpenChoreoPermissionApi` not registered** in `packages/app/src/apis.ts`. The default `PermissionClient` bypasses `fetchApi` entirely and never gets the IDP token, so every authorize call fails. Fix: [Override `permissionApi`](./installing-into-existing-backstage.mdx#permission-api).
+2. **Your user genuinely has no capabilities** in OpenChoreo. The IDP token is valid but Thunder hasn't granted them `release-binding:read` / `environment:read`. Confirm with `LOG_LEVEL=debug yarn dev`, hit a Deploy tab, and grep backend logs for `[AUTHZ] Parsed capabilities` — that dumps what the OpenChoreo authz service returned. If the expected capabilities aren't there, fix the user's role bindings on the OpenChoreo control plane, not in Backstage.
+
+## `JWKSNoMatchingKey` warnings in permission backend logs
+
+```
+permission warn Failed to verify incoming user token no applicable key
+found in the JSON Web Key Set
+```
+
+Benign. It means the permission backend is trying to verify an incoming user token against the OpenChoreo IDP's JWKS but the token was issued by another provider (typically Backstage's guest provider when your cluster is in auth-off mode). Catalog sync still works because the catalog provider uses its own client-credentials flow, not the user token. The warning disappears once users sign in via OpenChoreo (i.e. when the cluster runs with `auth.enabled: true` and your Backstage config mirrors it).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -101,6 +101,24 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "category",
+          label: "Backstage Plugins",
+          description:
+            "Install OpenChoreo plugins into your existing Backstage app",
+          link: {
+            type: "doc",
+            id: "platform-engineer-guide/backstage-plugins/overview",
+          },
+          items: [
+            "platform-engineer-guide/backstage-plugins/installing-into-existing-backstage",
+            "platform-engineer-guide/backstage-plugins/catalog-sync",
+            "platform-engineer-guide/backstage-plugins/entity-views",
+            "platform-engineer-guide/backstage-plugins/permission-policy",
+            "platform-engineer-guide/backstage-plugins/troubleshooting",
+            "platform-engineer-guide/backstage-plugins/compatibility-matrix",
+          ],
+        },
+        {
+          type: "category",
           label: "Component Types & Traits",
           description:
             "Define and customize workload templates with schemas and CEL",


### PR DESCRIPTION
Adds a new Backstage Plugins section under the Platform Engineer Guide covering how to install the OpenChoreo plugins into an existing Backstage app. Six new docs (overview, install guide, catalog sync, entity views, permission policy, troubleshooting, compatibility matrix) plus a sidebar entry linking them.

The install guide is organized as per-feature self-contained bundles: Core (required) covers GitHub Packages auth, backend wiring, OpenChoreo sign-in, FetchApi/PermissionApi overrides, and the Cell/Deploy/Definition tabs; Observability, CI/Build, and Workflows are opt-in add-ons that each install end-to-end.

<img width="1728" height="872" alt="image" src="https://github.com/user-attachments/assets/1deddee3-ec59-4eaf-af01-dcd302d21e8e" />
