### PR TITLE
docs: add instructions to reindex old tracing data after upgrade

### DIFF
--- a/docs/platform-engineer-guide/upgrades.mdx
+++ b/docs/platform-engineer-guide/upgrades.mdx
@@ -167,6 +167,16 @@ helm upgrade --install observability-traces-opensearch \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
 
+:::warning Reindex old tracing data
+Observability Traces OpenSearch module v0.4.0 uses a new index template that indexes `resource.openchoreo.dev/namespace`
+and uses it for queries. Since the old template did not index this field, traces query endpoints may return empty results after the upgrade.
+To fix this, reindex your old tracing data to the new index template:
+
+<CodeBlock language="bash">
+  {`curl -fsSL https://raw.githubusercontent.com/openchoreo/community-modules/refs/heads/main/observability-tracing-opensearch/scripts/upgrade-to-0-4-1.sh | bash`}
+</CodeBlock>
+:::
+
 - Observability Metrics Prometheus module: v0.2.5 -> v0.6.1
 
 ```bash


### PR DESCRIPTION
## Purpose
This pull request adds an important upgrade note to the documentation for the Observability Traces OpenSearch module. It warns users about a breaking change in index templates and provides a script to reindex old tracing data, ensuring queries continue to return results after the upgrade.

Upgrade documentation update:

* Added a warning section to the upgrade guide for the Observability Traces OpenSearch module, explaining that v0.4.1 uses a new index template which could cause queries to return empty results unless old data is reindexed, and provided a script to automate the reindexing process.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
