### PR TITLE
fix(docs): update githubRef to release-v1.1.0-alpha-1

### DIFF
--- a/versioned_docs/version-v1.1.0-alpha-1/_constants.mdx
+++ b/versioned_docs/version-v1.1.0-alpha-1/_constants.mdx
@@ -2,7 +2,7 @@
 
 export const versions = {
   dockerTag: "v1.1.0-alpha-1",
-  githubRef: "release-v1.1", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
+  githubRef: "release-v1.1.0-alpha-1", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
   helmChart: "1.1.0-alpha-1",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };


### PR DESCRIPTION
## Purpose

The `githubRef` constant in the v1.1.0-alpha-1 versioned docs pointed to `release-v1.1`, which does not match the actual release tag. As a result, GitHub Raw URL references rendered from this constant could resolve to the wrong branch/tag. This PR corrects the reference to `release-v1.1.0-alpha-1`.

## Approach

- Update `githubRef` in `versioned_docs/version-v1.1.0-alpha-1/_constants.mdx` from `release-v1.1` to `release-v1.1.0-alpha-1` so all raw GitHub URL references in the v1.1.0-alpha-1 docs resolve to the matching release tag.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)