### PR TITLE
docs: add resource abstractions documentation

### DIFF
--- a/docs/concepts/developer-abstractions.md
+++ b/docs/concepts/developer-abstractions.md
@@ -90,15 +90,43 @@ This tells the platform what code to run and how to configure it.
 endpoint declares its type (HTTP, gRPC, GraphQL, Websocket, TCP, or UDP) and port number. These definitions tell the
 platform what network services the component provides, enabling automatic service creation and network policy generation.
 
-**Dependencies** declare the component's dependencies on other services, whether internal to the platform or external
-third-party services. Each dependency specifies how to inject service information into the component through environment
-variables. This enables the platform to manage service discovery, configure network policies, and track dependencies.
+**Dependencies** declare the component's dependencies on other services and managed infrastructure. Endpoint
+dependencies target endpoints exposed by other components: the platform resolves the
+target address, injects it through environment variables, and configures network policies for the traffic. Resource
+dependencies target a Resource in the same project: the outputs declared by the
+referenced ResourceType are injected as environment variables or file mounts in
+the consuming container.
 
 This declarative specification can be generated from configuration files in the source repository or applied directly
 to the cluster. The separation between workload (what the application needs) and ComponentType (how the platform provides it)
 enables platform teams to control infrastructure policies while developers focus on application requirements. Resource
 limits, scaling parameters, and operational policies come from the ComponentType and Traits, while the
 workload simply declares what the application needs to function.
+
+## Resource
+
+A **Resource** represents a managed-infrastructure dependency declared by a developer—a database, queue, cache, object
+store, or any other piece of stateful infrastructure the application needs. A Resource is project-bound: it belongs to
+exactly one Project, and the components in that project consume it through Workload dependencies.
+
+A Resource is a thin declaration. It references a **ResourceType** (or **ClusterResourceType**) by name, mirroring how
+Components reference ComponentTypes. The Resource provides parameter values that conform to the ResourceType's
+schema—such as database engine version, replica count, or storage size—and the platform handles provisioning through
+the resource templates defined on the ResourceType. Developers do not write the provisioning logic; that lives in the
+ResourceType authored by platform engineers.
+
+Each Resource is bound to environments through one **ResourceReleaseBinding** per environment. A binding selects a
+specific **ResourceRelease**—an immutable snapshot of the Resource and ResourceType spec taken at release time—and
+carries per-environment configuration overrides.
+
+Components consume Resource outputs through their Workload's dependencies. Each output declared by the ResourceType
+can be mapped to an environment variable or a file mount inside the consuming container. Sensitive values remain on
+the data plane: the consuming pod reads them from a Secret resolved at pod-start, and only the reference travels
+through the control plane.
+
+The Resource abstraction follows the same separation of concerns as Components. Developers express what
+infrastructure they need; platform engineers control how that infrastructure is provisioned, what defaults apply, and
+which resource templates are available.
 
 ## WorkflowRun
 

--- a/docs/concepts/platform-abstractions.md
+++ b/docs/concepts/platform-abstractions.md
@@ -116,6 +116,24 @@ Once a ReleaseBinding is created, the ReleaseBinding controller renders the Comp
 combined configuration, generates the necessary Kubernetes resources (Deployments, Services, ConfigMaps, etc.), and
 produces a **RenderedRelease** resource that is applied to the target plane.
 
+## ResourceReleaseBinding
+
+A **ResourceReleaseBinding** is the resource-side counterpart of ReleaseBinding. It pins a specific **ResourceRelease**
+to an Environment and carries per-environment configuration overrides for the referenced ResourceType. This is where
+settings like dev-vs-prod replica counts, storage sizes, or admin-UI enablement live—while the ResourceRelease
+snapshot itself remains unchanged across environments.
+
+ResourceReleaseBindings are authored by platform engineers or GitOps tooling, not by the Resource controller. The
+controller for the parent Resource never creates or modifies bindings on its own; this keeps developer-facing Resource
+spec edits from triggering automatic redeploys. Promoting a release into an environment is always an explicit step.
+
+A binding can also override the ResourceType's retention policy for its environment, allowing production environments
+to preserve underlying state (volumes, databases) on deletion while dev and staging defer to the type-level default.
+
+When a ResourceReleaseBinding is created, the binding controller renders the ResourceType template with the combined
+Resource parameters and environment overrides, produces a RenderedRelease that is applied to the target plane, and
+resolves the declared outputs so consuming workloads can read them.
+
 ## Component Types
 
 A **ComponentType** is a platform engineer-defined template that governs how components are deployed and managed in
@@ -202,6 +220,47 @@ to existing resources.
 This separation between ComponentTypes (base deployment patterns) and Traits (composable capabilities) enables platform
 engineers to define orthogonal concerns independently. Rather than creating separate ComponentTypes for every combination
 of features, platform engineers define focused Traits that developers can mix and match as needed.
+
+## Resource Types
+
+A **ResourceType** is a platform engineer-defined template that governs how managed infrastructure is provisioned in
+OpenChoreo. Where ComponentTypes describe how a code component is deployed, ResourceTypes describe how a Resource is
+provisioned: what Kubernetes manifests the platform emits on the data plane, what parameters the developer can set,
+what outputs (hostnames, credentials, connection URLs) the resulting infrastructure exposes to consumers, and what
+retention behavior applies on deletion.
+
+OpenChoreo also provides **ClusterResourceType**, a cluster-scoped variant that is available across all namespaces.
+Use ClusterResourceType for templates intended to be shared platform-wide and namespace-scoped ResourceType for
+templates that are only relevant to a single namespace.
+
+ResourceTypes use the same schema-driven approach as ComponentTypes, with two schemas:
+
+**Parameters** capture developer-supplied values that become part of the immutable ResourceRelease snapshot—engine
+version pin, schema name, replica count, anything that should stay identical across environments for a given release.
+The schema is `openAPIV3Schema` with support for defaults, enums, validation, and CEL-based rules.
+
+**EnvironmentConfigs** capture per-environment overrides applied through ResourceReleaseBinding's
+`resourceTypeEnvironmentConfigs`—storage size, request limits, dev-only admin UI toggles. The same ResourceRelease
+deployed to dev and prod uses different environment overrides while the snapshot itself is unchanged.
+
+A ResourceType defines two further sections:
+
+**Resources** are the Kubernetes manifest templates the provisioner emits on the data plane—StatefulSets, Services,
+Secrets, or third-party CRs like Crossplane claims. Each entry has a unique `id`, an optional `includeWhen` CEL
+expression for conditional rendering, the manifest template, and an optional `readyWhen` CEL expression for per-Kind
+health beyond the default heuristic. Templates have access to `metadata.*`, `parameters.*`, `environmentConfigs.*`,
+and `dataplane.*` through the same CEL surface ComponentTypes use.
+
+**Outputs** declare the named values that consuming workloads bind to environment variables and file mounts. Each
+output is one of three source kinds: a literal or CEL-rendered `value`, a `secretKeyRef` to a data-plane Secret, or a
+`configMapKeyRef` to a data-plane ConfigMap. Output CEL has access to the same context as the resource templates plus
+`applied.<id>.status.*` for reading fields populated by the provisioner. Sensitive material—passwords, tokens, private
+keys—is declared with `secretKeyRef`; only the `{name, key}` reference transits to the control plane while the
+underlying credential never leaves the data plane.
+
+The **`retainPolicy`** field on a ResourceType sets the default retention behavior for bindings of that type. The
+default is `Delete`. Platform engineers opt into `Retain` for templates that emit non-recoverable state (production
+databases, persistent volumes), and individual environments can still override the policy through the binding.
 
 ## Workflow and ClusterWorkflow
 

--- a/docs/concepts/resource-relationships.md
+++ b/docs/concepts/resource-relationships.md
@@ -22,13 +22,15 @@ OpenChoreo also supports cluster-scoped resources that exist at the cluster leve
 
 ### Project Ownership
 
-Within a namespace, **Projects** form the next level of ownership for application resources. Projects own
-Components, establishing team boundaries and application domains. This ownership relationship means that components
-cannot exist without a parent project, and deleting a project removes all its components.
+Within a namespace, **Projects** form the next level of ownership for application resources. Projects own both
+**Components** and **Resources**, establishing team boundaries and application domains. This ownership relationship
+means that components and resources cannot exist without a parent project, and deleting a project removes all its
+components and resources.
 
-The project ownership boundary also defines the scope for internal communication. Components within the same project
-can reference each other directly and communicate without crossing security boundaries. This locality enables teams to
-work efficiently within their domain while maintaining isolation from other projects.
+The project ownership boundary also defines the scope for internal communication and resource sharing. Components
+within the same project can reference each other's endpoints directly and consume the project's Resources through
+Workload dependencies. This locality enables teams to work efficiently within their domain while maintaining
+isolation from other projects.
 
 ### ComponentType
 
@@ -97,8 +99,40 @@ ReleaseBinding controller renders the final Kubernetes manifests and produces a 
 to the target plane.
 
 This relationship chain—Component → ComponentRelease → ReleaseBinding → RenderedRelease—ensures complete governance while
-enabling environment-specific customization. The immutable ComponentRelease supports a "create once, deploy many"
-workflow, where the same release can be safely promoted across environments (dev → staging → prod) without drift.
+enabling environment-specific customization. Because ComponentRelease is immutable, the same release can be promoted
+across environments (dev → staging → prod) without drift.
+
+### Resource and ResourceType
+
+**ResourceTypes** define platform-level templates for managed infrastructure—databases, caches, queues, object stores.
+Each ResourceType declares a parameter schema, the Kubernetes manifests the provisioner emits on the data plane, the
+named outputs that consumers bind to, and a default retention policy. The cluster-scoped variant
+**ClusterResourceType** is available across all namespaces.
+
+**Resources** reference a ResourceType (or ClusterResourceType) by name. The Resource provides parameter values that
+conform to the referenced template's schema; validation failures surface on the Resource itself. The reference is
+fixed at create time, so a Resource cannot be retargeted to a different template after it is created.
+
+The Resource-to-ResourceType relationship mirrors Component-to-ComponentType. Resources cannot be created without a
+valid ResourceType reference, ensuring every Resource is governed by a template the platform team has approved.
+
+### ResourceRelease and ResourceReleaseBinding
+
+A **ResourceRelease** is an immutable snapshot of a Resource and its referenced ResourceType at a specific point in
+time. When either input changes, a new ResourceRelease is cut; existing releases remain unchanged so the same
+snapshot can be promoted to multiple environments without re-rendering. This mirrors how ComponentRelease works for
+components.
+
+To deploy a ResourceRelease to an environment, a platform engineer or GitOps process creates a
+**ResourceReleaseBinding**. The binding pins a specific ResourceRelease, targets an Environment, and provides
+per-environment configuration overrides. The captured ResourceType template is rendered with the combined
+configuration, producing a **RenderedRelease** that is applied to the target data plane, and the declared outputs
+are resolved so consuming workloads can read them.
+
+The chain—Resource → ResourceRelease → ResourceReleaseBinding → RenderedRelease—is the resource-side parallel of the
+Component chain. The Resource controller never authors bindings on its own; promoting a release into an environment
+is always an explicit action by a platform engineer or GitOps tooling. This isolation keeps developer-facing Resource
+spec edits from triggering automatic redeploys against stateful infrastructure.
 
 ## Network Relationships
 
@@ -117,11 +151,21 @@ that communication follows the declared patterns.
 
 ### Dependencies
 
-**Dependencies** create explicit relationships between components. When a component declares a
-dependency on another service, it establishes a formal relationship that the platform can track, secure, and monitor.
+**Dependencies** create explicit relationships from a Component to the things it consumes. A Workload declares
+two kinds of dependency:
 
-Dependency relationships make the links between components explicit. This relationship model helps teams understand
-their application architecture and service dependencies.
+**Endpoint dependencies** (`dependencies.endpoints[]`) target endpoints exposed by other components. The platform
+resolves the target address, injects it into the consuming container through environment variables, and configures
+network policies for the resulting traffic.
+
+**Resource dependencies** (`dependencies.resources[]`) target a Resource in the same project. The named outputs
+declared by the referenced ResourceType—hostnames, ports, credentials, connection URLs—are bound to environment
+variables or file mounts on the consuming container. Sensitive outputs are delivered through Kubernetes Secret
+references; the underlying values never transit the control plane.
+
+Both forms of dependency make the consuming relationships explicit. The platform uses them for service discovery,
+network policy generation, resource readiness gating, and to track which components depend on which endpoints and
+Resources.
 
 ## Environment Progression
 
@@ -156,6 +200,12 @@ template. Since ComponentReleases are immutable snapshots, existing deployments 
 
 ### Deletion Cascades
 
-Resource relationships define deletion behavior. When a project is deleted, all its components are removed. When a
-component is deleted, its WorkflowRuns, ComponentReleases, ReleaseBindings, and RenderedReleases are cleaned up. These
-cascading relationships ensure that resources are properly cleaned up without leaving orphaned objects.
+Resource relationships define deletion behavior. When a project is deleted, all its components and Resources are
+removed. When a Component is deleted, its WorkflowRuns, ComponentReleases, ReleaseBindings, and RenderedReleases are
+cleaned up. When a Resource is deleted, deletion is blocked while any ResourceReleaseBinding still references it; once
+all bindings are gone, the owned ResourceReleases are removed. These cascading relationships ensure that resources are
+properly cleaned up without leaving orphaned objects.
+
+The retention of the underlying data-plane state on a binding deletion is governed by the binding's retention policy.
+Production environments can preserve volumes and databases on deletion while dev and staging dispose of them, the same
+shape as Kubernetes PersistentVolume reclaim policy applied per binding.

--- a/docs/concepts/runtime-model.md
+++ b/docs/concepts/runtime-model.md
@@ -100,6 +100,13 @@ Workload execution is environment-aware. The same component might run with diffe
 counts, or configuration values in different environments. The platform manages these variations through the binding
 system, where environment-specific bindings override default values from ComponentTypes, Traits, and workload specifications.
 
+Resources follow the same render-and-apply path. Each ResourceReleaseBinding renders its ResourceType template with
+the combined Resource parameters and environment overrides, produces a RenderedRelease, and applies the resulting
+manifests to the data plane. The provisioned outputs are resolved back to the binding so consuming components can read
+them at pod-start. The render gate on the consuming Component waits for its declared Resource dependencies to be
+Ready before producing its own RenderedRelease, so a component is not deployed until the infrastructure it depends on
+is healthy.
+
 ## Service Discovery and Load Balancing
 
 Service discovery uses standard Kubernetes DNS, allowing services to communicate using service names. Within a cell,

--- a/docs/developer-guide/dependencies/resources.md
+++ b/docs/developer-guide/dependencies/resources.md
@@ -1,0 +1,235 @@
+---
+title: Resource Dependencies
+description: Learn how a Component consumes a project-bound Resource by binding its outputs to environment variables and file mounts
+---
+
+# Resource Dependencies
+
+Components in OpenChoreo consume managed infrastructure—databases, queues, caches, object stores—by declaring **resource dependencies** in their Workload. Each entry references a project-bound [Resource](../../concepts/developer-abstractions.md#resource) and wires the named outputs declared on the referenced ResourceType into the consuming container.
+
+When a resource dependency is declared, the platform automatically:
+
+- Resolves the active `ResourceReleaseBinding` for the consumer's environment and reads its `status.outputs`
+- Gates the consumer's deployment until that binding reports `Ready`
+- Injects the resolved outputs as container environment variables (`envBindings`) and file mounts (`fileBindings`)
+- Keeps sensitive values on the data plane: only the underlying `{name, key}` reference to a Secret or ConfigMap transits the control plane
+
+## Defining a Dependency
+
+Resource dependencies are defined in the `spec.dependencies.resources` array of a Workload. Each entry references a Resource by name and picks which of its outputs to inject:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: doclet-document
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    componentName: doclet-document
+  container:
+    image: ghcr.io/openchoreo/samples/doclet-document:latest
+  dependencies:
+    resources:
+      - ref: doclet-postgres
+        envBindings:
+          host: DB_HOST
+          port: DB_PORT
+          username: DB_USER
+          password: DB_PASSWORD
+          database: DB_NAME
+```
+
+In this example, the `doclet-document` Workload declares a dependency on the `doclet-postgres` Resource (a Postgres database provisioned from a `ClusterResourceType`). The platform resolves five outputs—`host`, `port`, `username`, `password`, `database`—and injects each as the corresponding environment variable. The credential is delivered through a `valueFrom.secretKeyRef`; the container reads the actual value from the data-plane Secret at pod-start.
+
+## Dependency Fields
+
+| Field          | Type              | Required | Description                                                                                                                                          |
+| -------------- | ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ref`          | string            | Yes      | Name of the target Resource. Must live in the same project as the consuming Component                                                                |
+| `envBindings`  | map[string]string | No       | Maps a ResourceType output name (key) to a container environment variable name (value)                                                               |
+| `fileBindings` | map[string]string | No       | Maps a ResourceType output name (key) to a container mount path (value). The referenced output must be backed by `secretKeyRef` or `configMapKeyRef` |
+
+An entry must specify `ref` and at least one of `envBindings` or `fileBindings`. Outputs the ResourceType declares but the Workload does not list are ignored—each Workload picks only the outputs it actually needs.
+
+### Environment Bindings
+
+The `envBindings` map binds each output to an environment variable on the consuming container. The shape of the resulting `env` entry depends on the ResourceType output's source kind:
+
+| Output source kind | Resulting env var shape                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `value`            | Literal value: `env: [{name: DB_HOST, value: "postgres.doclet.svc.cluster.local"}]`                   |
+| `secretKeyRef`     | Secret reference: `env: [{name: DB_PASSWORD, valueFrom: {secretKeyRef: {name: ..., key: ...}}}]`      |
+| `configMapKeyRef`  | ConfigMap reference: `env: [{name: APP_REGION, valueFrom: {configMapKeyRef: {name: ..., key: ...}}}]` |
+
+Sensitive outputs are declared as `secretKeyRef` on the ResourceType. Only the `{name, key}` reference transits the control plane; the underlying credential is never serialized to the consumer's `ReleaseBinding.status` or to the rendered `Deployment` manifest.
+
+### File Bindings
+
+The `fileBindings` map mounts each output into the consuming container's filesystem. The referenced output must be backed by `secretKeyRef` or `configMapKeyRef`—`value`-kind outputs cannot be file-mounted because there is no data-plane object to mount.
+
+```yaml
+dependencies:
+  resources:
+    - ref: my-mtls-creds
+      fileBindings:
+        ca-bundle: /etc/ssl/certs/ca-bundle.pem
+        client-cert: /etc/ssl/certs/client.crt
+        client-key: /etc/ssl/private/client.key
+```
+
+The platform synthesizes one Volume per `(resource, output)` pair (deduplicated when the same output is referenced multiple times) and one VolumeMount per declared path. The container reads each file at the declared path; underlying Secret or ConfigMap updates propagate through the standard kubelet projection.
+
+## Multiple Dependencies
+
+A Workload can declare up to 50 resource dependencies. Each entry's `ref` must be unique within the Workload, and endpoint and resource dependencies can be declared together:
+
+```yaml
+dependencies:
+  endpoints:
+    - component: doclet-collab
+      name: ws
+      visibility: project
+      envBindings:
+        address: COLLAB_URL
+  resources:
+    - ref: doclet-postgres
+      envBindings:
+        host: DB_HOST
+        port: DB_PORT
+        username: DB_USER
+        password: DB_PASSWORD
+        database: DB_NAME
+    - ref: doclet-nats
+      envBindings:
+        url: DOCLET_NATS_URL
+```
+
+The render gate waits for both endpoint and resource dependencies before proceeding.
+
+## Complete Example
+
+A full example: a `doclet-document` Component depending on a Postgres Resource for storage and a NATS Resource for pub/sub.
+
+The Component, Workload, and matching Resources:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: doclet-document
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  autoDeploy: true
+  componentType:
+    kind: ClusterComponentType
+    name: deployment/service
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: doclet-document
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    componentName: doclet-document
+  container:
+    image: ghcr.io/openchoreo/samples/doclet-document:latest
+  endpoints:
+    http:
+      type: HTTP
+      port: 8080
+      visibility: [project]
+  dependencies:
+    resources:
+      - ref: doclet-postgres
+        envBindings:
+          host: DB_HOST
+          port: DB_PORT
+          username: DB_USER
+          password: DB_PASSWORD
+          database: DB_NAME
+      - ref: doclet-nats
+        envBindings:
+          url: DOCLET_NATS_URL
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-postgres
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: postgres
+  parameters:
+    database: doclet
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-nats
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: nats
+```
+
+And the `ResourceReleaseBinding` for the `development` environment (one per Resource per environment, authored by the platform engineer or GitOps tooling):
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-postgres-development
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-postgres
+  environment: development
+  resourceRelease: doclet-postgres-abc12345 # advanced via `occ resource promote`
+```
+
+After the bindings report `Ready` and the consuming Component is deployed, verify the injected variables from inside the pod:
+
+```bash
+kubectl exec -n <data-plane-namespace> <pod-name> -- env | grep -E 'DB_|NATS'
+```
+
+The output shows the resolved connection details, with the password loaded from a Secret reference:
+
+```text
+DB_HOST=postgres-doclet.openchoreo-dp-doclet-development.svc.cluster.local
+DB_PORT=5432
+DB_USER=doclet
+DB_NAME=doclet
+DB_PASSWORD=<value loaded from Secret at pod-start>
+DOCLET_NATS_URL=nats://<token>@nats-doclet.openchoreo-dp-doclet-development.svc.cluster.local:4222
+```
+
+## Inspecting Outputs on the Binding
+
+To inspect the resolved outputs without deploying a consumer, view the `ResourceReleaseBinding.status.outputs` directly:
+
+```bash
+kubectl get resourcereleasebinding doclet-postgres-development -o yaml
+```
+
+Each entry in `status.outputs[]` carries the output name and one of `value`, `secretKeyRef`, or `configMapKeyRef`. For credential outputs, only the Secret name and key are shown—the actual value never appears here, matching the shape that lands in the consuming pod.
+
+## Related Resources
+
+- [Workload](../workload/overview.md) - How to define Workloads
+- [Endpoint Dependencies](./endpoints.md) - Consuming endpoints exposed by other components
+- [Resource concept](../../concepts/developer-abstractions.md#resource) - Overview of the Resource abstraction
+- [Workload API Reference](../../reference/api/application/workload.md) - Full Workload CRD specification

--- a/docs/platform-engineer-guide/resource-types.md
+++ b/docs/platform-engineer-guide/resource-types.md
@@ -1,0 +1,301 @@
+---
+title: Overview
+description: Learn how to create ResourceTypes for OpenChoreo
+---
+
+# Authoring ResourceTypes
+
+This guide covers how to create custom [ResourceTypes](../reference/api/platform/resourcetype.md) and [ClusterResourceTypes](../reference/api/platform/clusterresourcetype.md) in OpenChoreo. A ResourceType is the platform-engineer-defined template that governs how a managed-infrastructure resource (database, queue, cache, object store) is provisioned on the data plane and exposed to consumers.
+
+## What is a ResourceType?
+
+A ResourceType plays the same role for managed infrastructure that a ComponentType plays for code components: it captures the manifests the platform emits, the parameters developers can supply, the environment-specific overrides bindings can apply, and the named outputs consumers wire into their containers.
+
+Platform engineers use ResourceTypes to:
+
+- Publish reusable provisioning templates (Postgres, NATS, Valkey, S3 buckets, Crossplane claims)
+- Define what developers can configure through a schema
+- Define what consumers can wire into their workloads through declared outputs
+- Set retention defaults so accidental deletes do not destroy stateful data
+
+Developers reference a ResourceType from `Resource.spec.type` and supply parameter values. Each `ResourceReleaseBinding` then renders the template per environment, applies the rendered manifests to the data plane, and surfaces the resulting outputs back through `status.outputs`.
+
+OpenChoreo ships example ClusterResourceTypes (`postgres`, `valkey`, `nats`) under `samples/getting-started/cluster-resource-types/` for local development and to demonstrate the pattern. These samples back stateful infrastructure with in-cluster StatefulSets and are not intended for production use; platform engineers should author their own templates targeting production-grade provisioners (Crossplane, ACK, native cloud operators).
+
+### ClusterResourceType
+
+A **ClusterResourceType** is the cluster-scoped variant of ResourceType. Use it for templates intended to be shared platform-wide; namespace-scoped ResourceTypes are available when a template should be available only within a specific namespace.
+
+ClusterResourceTypes share the same spec structure as ResourceTypes; only scope differs.
+
+**Key concepts:**
+
+- `parameters` / `environmentConfigs` — Define what developers can configure on a Resource, and what bindings can override per environment
+- `resources` — Kubernetes manifest templates the provisioner emits on the data plane (rendered through CEL)
+- `outputs` — Named values that consuming workloads bind to environment variables and file mounts
+- `retainPolicy` — Default deletion behavior (`Delete` or `Retain`) for bindings of this type
+
+## ResourceType Example
+
+The example below defines a simple Valkey (Redis-protocol) cache backed by a StatefulSet. It exposes three outputs—`host`, `port`, and `password`—that workloads can consume through `dependencies.resources[]`.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceType
+metadata:
+  name: valkey-cache
+  namespace: default
+spec:
+  # Developer-facing parameters; captured in the ResourceRelease snapshot.
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        version:
+          type: string
+          enum: ["7", "8"]
+          default: "8"
+
+  # Per-environment overrides applied through ResourceReleaseBinding.
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        memory:
+          type: string
+          default: "128Mi"
+
+  # Default retention. Per-environment override available on bindings.
+  retainPolicy: Delete
+
+  # Named outputs that consuming workloads wire into containers.
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "6379"
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+
+  # Kubernetes manifests rendered onto the data plane.
+  resources:
+    - id: password-secret
+      template:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        type: Opaque
+        stringData:
+          # Real templates generate this on the data plane (for example via
+          # an ExternalSecret + Password generator) so the literal never
+          # transits the control plane. See the example `valkey` sample for
+          # the full pattern.
+          password: "change-me"
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: valkey
+              port: 6379
+              targetPort: 6379
+
+    - id: statefulset
+      readyWhen: "${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          serviceName: ${metadata.name}
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: valkey
+                  image: valkey/valkey:${parameters.version}-alpine
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  env:
+                    - name: VALKEY_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${metadata.name}-creds
+                          key: password
+                  args:
+                    - --requirepass
+                    - $(VALKEY_PASSWORD)
+                  ports:
+                    - containerPort: 6379
+                      name: valkey
+```
+
+Real-world templates also generate credentials on the data plane (for example through an ExternalSecret backed by a Password generator) so secret material never reaches the control plane. The example templates under `samples/getting-started/cluster-resource-types/` (`postgres`, `valkey`, `nats`) demonstrate the full pattern. They use in-cluster StatefulSets for the underlying infrastructure and are intended for local development; production templates typically target a managed-provisioner abstraction (Crossplane, ACK, native cloud operator) instead.
+
+## Outputs
+
+Outputs are the contract between the ResourceType and the workloads that consume it. Each output is identified by a unique `name` and picks exactly one of three source kinds:
+
+| Source kind       | When to use                                                                                           | What transits to the control plane                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `value`           | Non-sensitive data (host, port, region, database name, composed connection URLs)                      | The resolved literal value. Stored on the binding's `status.outputs[].value`.                  |
+| `secretKeyRef`    | Sensitive credentials (passwords, tokens, private keys)                                               | Only `{name, key}` of the data-plane Secret. The underlying value never leaves the data plane. |
+| `configMapKeyRef` | Non-sensitive runtime configuration sourced from a data-plane ConfigMap (CA bundles, locale settings) | Only `{name, key}` of the data-plane ConfigMap.                                                |
+
+`value`, `secretKeyRef.name`, `secretKeyRef.key`, `configMapKeyRef.name`, and `configMapKeyRef.key` all support `${...}` CEL templating. The CEL context includes `applied.<id>.status.*`—use this to surface fields populated by the provisioner (for example a Crossplane claim's `status.connectionDetails`).
+
+Consumers reference outputs by name through `Workload.spec.dependencies.resources[].envBindings` and `fileBindings` (see the [Resource Dependencies developer guide](../developer-guide/dependencies/resources.md)). Outputs declared on the ResourceType but not requested by a consumer are simply unused; outputs requested by a consumer but missing on the ResourceType surface as a `ResourceDependenciesPending` reason on the consuming `ReleaseBinding`.
+
+## How Developers Consume a ResourceType
+
+Developers create a **Resource** that references the ResourceType, providing parameter values that conform to the declared schema. They then declare a dependency from a Workload to the Resource and bind the outputs they need:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-cache
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ResourceType
+    name: valkey-cache
+  parameters:
+    version: "8"
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: doclet-document
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    componentName: doclet-document
+  container:
+    image: ghcr.io/openchoreo/samples/doclet-document:latest
+  dependencies:
+    resources:
+      - ref: doclet-cache
+        envBindings:
+          host: REDIS_HOST
+          port: REDIS_PORT
+          password: REDIS_PASSWORD
+```
+
+To deploy the Resource into an environment, a platform engineer or GitOps process creates a `ResourceReleaseBinding`. The binding pins a specific `ResourceRelease`, targets an Environment, supplies per-environment overrides through `resourceTypeEnvironmentConfigs`, and optionally overrides the `retainPolicy`:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-cache-production
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-cache
+  environment: production
+  resourceRelease: doclet-cache-abc12345 # advanced via `occ resource promote`
+  retainPolicy: Retain
+  resourceTypeEnvironmentConfigs:
+    memory: "2Gi"
+```
+
+The binding controller renders the ResourceType template with the combined Resource parameters and environment overrides, produces a `RenderedRelease` applied to the data plane, and resolves declared outputs into `status.outputs` so consuming workloads can read them.
+
+## CEL Surface for Resource Templates
+
+Resource templates and output expressions have access to the following CEL context. The available bindings depend on which field is being evaluated:
+
+| Context                | In resource `template` | In `includeWhen` | In `readyWhen` | In `outputs` | Description                                                                               |
+| ---------------------- | :--------------------: | :--------------: | :------------: | :----------: | ----------------------------------------------------------------------------------------- |
+| `metadata.*`           |          yes           |       yes        |      yes       |     yes      | Platform-injected naming, namespace, resource/project/env UIDs, labels, annotations       |
+| `parameters.*`         |          yes           |       yes        |      yes       |     yes      | Values from `Resource.spec.parameters` after schema defaulting                            |
+| `environmentConfigs.*` |          yes           |       yes        |      yes       |     yes      | Values from `ResourceReleaseBinding.spec.resourceTypeEnvironmentConfigs` after defaulting |
+| `environment.*`        |          yes           |       yes        |      yes       |     yes      | Per-environment surface including the merged effective gateway for this environment       |
+| `dataplane.*`          |          yes           |       yes        |      yes       |     yes      | Target DataPlane attributes (secret store, raw gateway, observability ref)                |
+| `gateway.*`            |          yes           |       yes        |      yes       |     yes      | Effective gateway (Environment-level override merged onto DataPlane-level default)        |
+| `applied.<id>.*`       |           no           |        no        |      yes       |     yes      | Status of resources that were applied to the data plane—reference by template `id`        |
+
+`applied.<id>.*` is not available during rendering (the manifests have not been applied yet) but is available in `readyWhen` and `outputs` because both run after the data plane reports back. Use `applied.<id>.status.*` in outputs to surface provider-populated fields, such as a Crossplane claim's connection details or a StatefulSet's observed pod count.
+
+The `${...}` wrapper is required on `includeWhen`, `readyWhen`, and `outputs[].value`. Inside resource templates, both `${...}` interpolation (which substitutes a value into a string) and `${...}` whole-field replacement (when the entire field value is a `${...}` expression) are supported—same shape as ComponentType templates.
+
+## includeWhen and readyWhen
+
+Each resource template entry supports two optional CEL fields that shape its lifecycle:
+
+**`includeWhen`** is a boolean expression evaluated at render time. When it returns `false`, the entry is omitted from the rendered output and any previously-applied object is garbage-collected from the data plane. Common uses:
+
+- `${parameters.tlsEnabled}` — conditionally emit a Certificate/Issuer for TLS
+- `${environmentConfigs.adminEnabled && has(gateway.ingress.external)}` — only emit the admin UI when explicitly enabled and the environment has external ingress
+
+**`readyWhen`** is a boolean expression evaluated after the rendered object has been applied. When it returns `true`, the entry contributes positively to the binding's `ResourcesReady` condition. When unset, the binding falls back to the per-Kind health heuristics in `RenderedRelease` (replica counts, condition probes). Use `readyWhen` when the default heuristic does not match your provisioner's signal:
+
+- `${applied.claim.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}` — a Crossplane claim's `Ready` condition
+- `${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}` — explicit StatefulSet quorum
+
+Both fields must evaluate to a boolean and must be wrapped in `${...}`.
+
+## retainPolicy
+
+`retainPolicy` on the ResourceType sets the default deletion behavior for bindings of that type. Two values:
+
+- **`Delete`** (default) — When a `ResourceReleaseBinding` is deleted, the binding controller removes the emitted data-plane manifests as part of finalization.
+- **`Retain`** — The binding's finalizer holds when deleted, preserving the underlying data-plane state until the policy is flipped back to `Delete`.
+
+Per-environment bindings can override the type-level default through `ResourceReleaseBinding.spec.retainPolicy`. Production environments typically opt into `Retain` for non-recoverable infrastructure (databases, persistent volumes) while dev and staging keep the default `Delete`.
+
+## Syntax Systems
+
+ResourceTypes reuse the same syntax systems documented in the Component Types guide:
+
+| Syntax                                               | Purpose                                        | Used In                                                                |
+| ---------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
+| [Templating](./component-types/templating-syntax.md) | Dynamic value generation using CEL expressions | `resources[].template`, `includeWhen`, `readyWhen`, `outputs[]` fields |
+| [Schema](./component-types/schema-syntax.md)         | Parameter validation and defaults              | `parameters.openAPIV3Schema` and `environmentConfigs.openAPIV3Schema`  |
+
+Patching (Trait-only) and CEL-based validation rules do not apply to ResourceTypes.
+
+## CEL Reference
+
+- **[Context Variables](../reference/cel/context-variables.md)** — `metadata`, `parameters`, `environmentConfigs`, `dataplane`, `gateway`, `applied`
+- **[Built-in Functions](../reference/cel/built-in-functions.md)** — `oc_omit()`, `oc_merge()`, `oc_generate_name()`, `oc_dns_label()`
+- **[Configuration Helpers](../reference/cel/helper-functions.md)** — helpers for working with configs and secrets
+
+## Next Steps
+
+- **[Resource Dependencies (developer guide)](../developer-guide/dependencies/resources.md)** — How developers wire ResourceType outputs into containers
+
+## Related Resources
+
+- [ResourceType API Reference](../reference/api/platform/resourcetype.md) — Full CRD specification
+- [ClusterResourceType API Reference](../reference/api/platform/clusterresourcetype.md) — Cluster-scoped variant
+- [Resource API Reference](../reference/api/application/resource.md) — Developer-facing CRD
+- [ResourceReleaseBinding API Reference](../reference/api/platform/resourcereleasebinding.md) — Per-environment binding

--- a/docs/platform-engineer-guide/resource-types.md
+++ b/docs/platform-engineer-guide/resource-types.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Learn how to create ResourceTypes for OpenChoreo
+title: Authoring ResourceTypes
+description: Learn how to author ResourceTypes and ClusterResourceTypes in OpenChoreo
 ---
 
 # Authoring ResourceTypes

--- a/docs/reference/api/application/resource.md
+++ b/docs/reference/api/application/resource.md
@@ -1,0 +1,164 @@
+---
+title: Resource API Reference
+description: Developer-declared dependency on managed infrastructure provisioned through a ResourceType
+---
+
+# Resource
+
+A Resource represents a developer-declared dependency on managed infrastructure (database, queue, cache, object store) provisioned through a [ResourceType](../platform/resourcetype.md) or [ClusterResourceType](../platform/clusterresourcetype.md) template. Resources are project-bound: each Resource belongs to exactly one Project, and components in that project consume its outputs through Workload `dependencies.resources[]`.
+
+## API Version
+
+`openchoreo.dev/v1alpha1`
+
+## Resource Definition
+
+### Metadata
+
+Resources are namespace-scoped resources and belong to a Project through the owner field.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: <resource-name>
+  namespace: <namespace>
+```
+
+**Short names:** `res`
+
+### Spec Fields
+
+| Field        | Type                                | Required | Default | Description                                                                                                |
+| ------------ | ----------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `owner`      | [ResourceOwner](#resourceowner)     | Yes      | -       | Ownership information linking the Resource to a project (immutable)                                        |
+| `type`       | [ResourceTypeRef](#resourcetyperef) | Yes      | -       | Reference to a ResourceType or ClusterResourceType template (immutable)                                    |
+| `parameters` | object                              | No       | -       | Parameter values validated against the ResourceType's `parameters` schema; failures surface via conditions |
+
+:::note
+Both `owner` and `type` are immutable after creation. To re-target a Resource to a different template, delete and recreate it.
+:::
+
+### ResourceOwner
+
+| Field         | Type   | Required | Description                                          |
+| ------------- | ------ | -------- | ---------------------------------------------------- |
+| `projectName` | string | Yes      | Name of the project that owns this Resource (min: 1) |
+
+### ResourceTypeRef
+
+| Field  | Type   | Required | Default        | Description                                                                                                  |
+| ------ | ------ | -------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
+| `kind` | string | No       | `ResourceType` | Kind of the referenced template: `ResourceType` (namespace-scoped) or `ClusterResourceType` (cluster-scoped) |
+| `name` | string | Yes      | -              | Name of the ResourceType or ClusterResourceType (DNS-1123 label; min: 1)                                     |
+
+Mirrors the [ComponentTypeRef](./component.md#componenttyperef) shape. The kind disambiguates a namespace-scoped ResourceType from a cluster-scoped ClusterResourceType with the same name.
+
+### Status Fields
+
+| Field                | Type                                            | Default | Description                                                       |
+| -------------------- | ----------------------------------------------- | ------- | ----------------------------------------------------------------- |
+| `observedGeneration` | integer                                         | 0       | The generation observed by the controller                         |
+| `conditions`         | []Condition                                     | []      | Standard Kubernetes conditions tracking Resource state            |
+| `latestRelease`      | [LatestResourceRelease](#latestresourcerelease) | -       | Pointer to the most recent ResourceRelease cut from this Resource |
+
+#### LatestResourceRelease
+
+| Field  | Type   | Description                                                                                |
+| ------ | ------ | ------------------------------------------------------------------------------------------ |
+| `name` | string | Name of the latest ResourceRelease resource (shape: `{resource}-{hash}`)                   |
+| `hash` | string | Content hash covering `Resource.spec` + the referenced ResourceType's spec at release time |
+
+#### Condition Types
+
+Common condition types for Resource resources:
+
+- `Ready` — Indicates the Resource is in a healthy state, the referenced ResourceType has been resolved, and the latest ResourceRelease has been reconciled
+- `Finalizing` — Surfaced during deletion while the two-phase finalizer waits for ResourceReleaseBindings and owned ResourceReleases to be cleaned up
+
+## Examples
+
+### Postgres Resource
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-postgres
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: postgres
+  parameters:
+    database: doclet
+```
+
+### NATS Resource (no parameters)
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-nats
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: nats
+```
+
+### Resource Referencing a Namespace-Scoped ResourceType
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: order-cache
+  namespace: default
+spec:
+  owner:
+    projectName: order-service
+  type:
+    kind: ResourceType
+    name: valkey-cache
+  parameters:
+    version: "8"
+```
+
+## Usage
+
+A Resource is created by a developer (or by GitOps tooling on their behalf) and references a ResourceType that platform engineers have published. The Resource controller cuts a [ResourceRelease](../runtime/resourcerelease.md) when the hash of `Resource.spec` plus the referenced ResourceType's spec changes; release advance into environments happens through a [ResourceReleaseBinding](../platform/resourcereleasebinding.md) authored by a platform engineer or GitOps process.
+
+```bash
+# Create the Resource
+kubectl apply -f doclet-postgres.yaml
+
+# Inspect the cut release
+kubectl get resource doclet-postgres -o jsonpath='{.status.latestRelease}'
+
+# Inspect the rendered DP-side state once a binding is Ready
+kubectl get rrb -l openchoreo.dev/resource=doclet-postgres
+```
+
+## Annotations
+
+Resources support the following annotations:
+
+| Annotation                    | Description                          |
+| ----------------------------- | ------------------------------------ |
+| `openchoreo.dev/display-name` | Human-readable name for UI display   |
+| `openchoreo.dev/description`  | Detailed description of the Resource |
+
+## Related Resources
+
+- [Project](./project.md) — Owns Resources alongside Components
+- [Workload](./workload.md) — Declares resource dependencies through `dependencies.resources[]`
+- [ResourceType](../platform/resourcetype.md) — Platform-defined template referenced by a Resource
+- [ClusterResourceType](../platform/clusterresourcetype.md) — Cluster-scoped variant of ResourceType
+- [ResourceRelease](../runtime/resourcerelease.md) — Immutable snapshot cut by the Resource controller
+- [ResourceReleaseBinding](../platform/resourcereleasebinding.md) — Per-environment binding that deploys a release

--- a/docs/reference/api/platform/clusterresourcetype.md
+++ b/docs/reference/api/platform/clusterresourcetype.md
@@ -1,0 +1,138 @@
+---
+title: ClusterResourceType API Reference
+description: Cluster-scoped resource provisioning template reusable across all namespaces
+---
+
+# ClusterResourceType
+
+A ClusterResourceType is the cluster-scoped variant of [ResourceType](./resourcetype.md). Use it for templates intended to be shared platform-wide; namespace-scoped ResourceTypes are available when a template should be available only within a specific namespace.
+
+ClusterResourceTypes currently share the same spec structure as ResourceTypes; only scope differs. The shapes may diverge in a future release if cluster-only fields are added.
+
+## API Version
+
+`openchoreo.dev/v1alpha1`
+
+## Resource Definition
+
+### Metadata
+
+ClusterResourceTypes are cluster-scoped resources (no namespace).
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: <clusterresourcetype-name>
+```
+
+:::note
+ClusterResourceType manifests must **not** include `metadata.namespace`. If you are copying from a namespace-scoped ResourceType example, remove the `namespace` field.
+:::
+
+**Short names:** `crt`, `crts`
+
+### Spec Fields
+
+The spec currently mirrors [ResourceType.spec](./resourcetype.md#spec-fields) and may diverge in a future release. Refer to that page for the full field reference. The CEL surface, output kinds, manifest `includeWhen` / `readyWhen` semantics, and `retainPolicy` behavior all match the namespace-scoped form.
+
+| Field                | Type                                                             | Required | Default  | Description                                                             |
+| -------------------- | ---------------------------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------- |
+| `parameters`         | [SchemaSection](./resourcetype.md#schemasection)                 | No       | -        | Schema for `Resource.spec.parameters` values                            |
+| `environmentConfigs` | [SchemaSection](./resourcetype.md#schemasection)                 | No       | -        | Schema for `ResourceReleaseBinding.spec.resourceTypeEnvironmentConfigs` |
+| `retainPolicy`       | string                                                           | No       | `Delete` | Default retention behavior for bindings of this type                    |
+| `outputs`            | [[ResourceTypeOutput](./resourcetype.md#resourcetypeoutput)]     | No       | []       | Named outputs consumed by workloads                                     |
+| `resources`          | [[ResourceTypeManifest](./resourcetype.md#resourcetypemanifest)] | Yes      | -        | Kubernetes manifest templates emitted on the data plane                 |
+
+### Status Fields
+
+ClusterResourceType currently has no status fields.
+
+## Examples
+
+### Cluster-Scoped Valkey Cache
+
+A ClusterResourceType available to every namespace. Note the absence of `metadata.namespace`.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterResourceType
+metadata:
+  name: valkey
+spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        memory:
+          type: string
+          default: "128Mi"
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "6379"
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+
+  resources:
+    # ... omitted for brevity; see the ResourceType reference for the full pattern ...
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: valkey
+              port: 6379
+              targetPort: 6379
+    - id: statefulset
+      template:
+        # ... StatefulSet template ...
+```
+
+The example ClusterResourceTypes (`postgres`, `valkey`, `nats`) under `samples/getting-started/cluster-resource-types/` in the OpenChoreo repository demonstrate the full pattern—including ESO-backed credential generation and opt-in admin UIs. They use in-cluster StatefulSets for stateful infrastructure and are intended for local development and demonstration, not production use.
+
+## Usage
+
+A Resource references a ClusterResourceType by setting `spec.type.kind: ClusterResourceType`:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: doclet-cache
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+  type:
+    kind: ClusterResourceType
+    name: valkey
+```
+
+A Resource that omits `spec.type.kind` defaults to `ResourceType` (namespace-scoped) per the CRD default—set the kind explicitly when targeting the cluster-scoped form.
+
+## Best Practices
+
+1. **Use ClusterResourceTypes for shared infrastructure patterns** used across many namespaces (Postgres, Valkey, NATS). Reserve namespace-scoped ResourceTypes for templates that depend on namespace-local configuration.
+2. **Document the kind explicitly** on consumer manifests so reviewers see whether a Resource is consuming a cluster-wide or namespace-local template.
+3. **Apply the same retention defaults** as you would for ResourceTypes—stateful templates should ship with `retainPolicy: Retain`.
+
+## Related Resources
+
+- [ResourceType](./resourcetype.md) — Namespace-scoped variant
+- [Resource](../application/resource.md) — Developer-facing CRD
+- [ResourceRelease](../runtime/resourcerelease.md) — Immutable snapshot cut by the Resource controller
+- [ResourceReleaseBinding](./resourcereleasebinding.md) — Per-environment binding
+- [Authoring ResourceTypes (PE Guide)](../../../platform-engineer-guide/resource-types.md)

--- a/docs/reference/api/platform/resourcereleasebinding.md
+++ b/docs/reference/api/platform/resourcereleasebinding.md
@@ -1,0 +1,190 @@
+---
+title: ResourceReleaseBinding API Reference
+description: Binds a ResourceRelease to an environment and carries per-environment configuration overrides
+---
+
+# ResourceReleaseBinding
+
+A ResourceReleaseBinding pins a specific [ResourceRelease](../runtime/resourcerelease.md) to an [Environment](./environment.md) and carries per-environment overrides for the referenced ResourceType template. It is the resource-side counterpart of [ReleaseBinding](./releasebinding.md): platform engineers (or GitOps tooling) author one binding per Resource per environment to control rollout and retention.
+
+The Resource controller never creates or modifies ResourceReleaseBindings. The `spec.resourceRelease` pin is advanced manually—through `occ resource promote`, `kubectl edit`, or a GitOps commit.
+
+## API Version
+
+`openchoreo.dev/v1alpha1`
+
+## Resource Definition
+
+### Metadata
+
+ResourceReleaseBindings are namespace-scoped resources created in the same namespace as the Resource they deploy.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: <resource-name>-<environment-name>
+  namespace: <namespace>
+```
+
+**Short names:** `rrb`, `rrbs`
+
+### Spec Fields
+
+| Field                            | Type                                                        | Required | Default | Description                                                                                                                             |
+| -------------------------------- | ----------------------------------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `owner`                          | [ResourceReleaseBindingOwner](#resourcereleasebindingowner) | Yes      | -       | Identifies the Resource this binding deploys (immutable)                                                                                |
+| `environment`                    | string                                                      | Yes      | -       | Name of the target Environment (immutable; must match an existing Environment in the namespace)                                         |
+| `resourceRelease`                | string                                                      | No       | -       | Name of the ResourceRelease pinned by this binding. Unset until promoted; the binding stays pending without it                          |
+| `retainPolicy`                   | string                                                      | No       | -       | Per-environment override for retention. When unset, falls back to the ResourceType's `retainPolicy` (which itself defaults to `Delete`) |
+| `resourceTypeEnvironmentConfigs` | object                                                      | No       | -       | Per-environment values for the referenced ResourceType's `environmentConfigs` schema. Validated by the binding controller               |
+
+:::note
+`owner` and `environment` are immutable after creation. To re-target a binding, delete and recreate it.
+:::
+
+### ResourceReleaseBindingOwner
+
+Identifies the Resource this binding deploys.
+
+| Field          | Type   | Required | Description                                         |
+| -------------- | ------ | -------- | --------------------------------------------------- |
+| `projectName`  | string | Yes      | Name of the project that owns the Resource (min: 1) |
+| `resourceName` | string | Yes      | Name of the Resource (min: 1)                       |
+
+### Status Fields
+
+| Field        | Type                                                | Default | Description                                                                                    |
+| ------------ | --------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `conditions` | []Condition                                         | []      | Standard Kubernetes conditions tracking binding state                                          |
+| `outputs`    | [[ResolvedResourceOutput](#resolvedresourceoutput)] | []      | Resolved output values populated by the binding controller from the underlying RenderedRelease |
+
+#### ResolvedResourceOutput
+
+Each entry corresponds to a single output declared on the referenced ResourceType. Picks exactly one of `value`, `secretKeyRef`, or `configMapKeyRef`—matching the source kind on the ResourceType.
+
+| Field             | Type                                                 | Required | Description                                                                                  |
+| ----------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `name`            | string                                               | Yes      | Output name; matches the declared output on the ResourceType (min: 1)                        |
+| `value`           | string                                               | No       | Resolved literal value (for `value`-kind outputs)                                            |
+| `secretKeyRef`    | [SecretKeyRef](./resourcetype.md#secretkeyref)       | No       | Resolved `{name, key}` reference to a DP-side Secret (for `secretKeyRef`-kind outputs)       |
+| `configMapKeyRef` | [ConfigMapKeyRef](./resourcetype.md#configmapkeyref) | No       | Resolved `{name, key}` reference to a DP-side ConfigMap (for `configMapKeyRef`-kind outputs) |
+
+Sensitive material never appears in `status.outputs`. Only the `{name, key}` reference transits the control plane.
+
+#### Condition Types
+
+| Type              | Meaning                                                                                                        |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- |
+| `Synced`          | The binding has been rendered and a corresponding `RenderedRelease` is in sync with the pinned ResourceRelease |
+| `ResourcesReady`  | All declared `resources[]` entries on the ResourceType report healthy (via `readyWhen` or per-Kind heuristic)  |
+| `OutputsResolved` | Every declared output has been resolved against the applied data-plane state                                   |
+| `Ready`           | Aggregate condition over `Synced`, `ResourcesReady`, and `OutputsResolved`                                     |
+| `Finalizing`      | Surfaced during deletion. Reason is `RetainHold` when `retainPolicy: Retain` blocks the finalizer              |
+
+## Examples
+
+### Basic ResourceReleaseBinding
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-postgres-development
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-postgres
+  environment: development
+  resourceRelease: doclet-postgres-abc12345
+```
+
+### Binding With Environment-Specific Overrides
+
+Use `resourceTypeEnvironmentConfigs` to apply per-environment values declared in the ResourceType's `environmentConfigs` schema. Combine with a `retainPolicy` override for environments where the type-level default does not apply.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-postgres-production
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-postgres
+  environment: production
+  resourceRelease: doclet-postgres-abc12345
+  retainPolicy: Retain
+  resourceTypeEnvironmentConfigs:
+    memory: "2Gi"
+    storage: "100Gi"
+```
+
+### Pending Binding (No Release Pinned Yet)
+
+A binding can be created before any ResourceRelease has been cut. The binding stays `Synced=False, Reason=ResourceReleaseNotSet` until `spec.resourceRelease` is set:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceReleaseBinding
+metadata:
+  name: doclet-postgres-development
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-postgres
+  environment: development
+  # resourceRelease intentionally unset; promote with:
+  #   occ resource promote --env development doclet-postgres
+```
+
+## Promoting a Release
+
+Advance `spec.resourceRelease` manually when ready to roll a new release into the target environment. The `occ` CLI bundles the read-current-then-patch step:
+
+```bash
+# Pin the binding to the Resource's latest release
+occ resource promote --env development doclet-postgres
+
+# Equivalent kubectl flow
+kubectl get resource doclet-postgres -o jsonpath='{.status.latestRelease.name}'
+kubectl patch resourcereleasebinding doclet-postgres-development \
+  --type merge -p '{"spec":{"resourceRelease":"<release-name>"}}'
+```
+
+There is no auto-advance in v1.1. Auto-advance is tracked as a forward-compatible additive `releasePolicy` field for a later release.
+
+## Retention and Deletion
+
+`retainPolicy` controls what happens to the emitted data-plane state on binding deletion:
+
+- **`Delete`** (default-via-fallback) — finalizer removes the emitted manifests as part of deletion
+- **`Retain`** — finalizer holds; the binding stays in `Terminating` with `Finalizing` condition `Reason=RetainHold` and the data-plane state persists
+
+When unset on the binding, the effective policy is inherited from the referenced ResourceType's `spec.retainPolicy` (which itself defaults to `Delete`).
+
+To finalize a `Retain` binding, flip the policy and the controller's next reconcile will run the cascade:
+
+```bash
+kubectl patch rrb doclet-postgres-production \
+  --type merge -p '{"spec":{"retainPolicy":"Delete"}}'
+```
+
+See [Authoring ResourceTypes](../../../platform-engineer-guide/resource-types.md#retainpolicy) for the full retention pattern.
+
+## Authorization Context
+
+The binding controller checks RBAC against `{projectName, resourceName, environment}` for every operation. Cross-project access is rejected: a binding's `spec.owner.projectName` must match the Resource's `spec.owner.projectName`. A request that claims a different project in the body is rejected as a defense-in-depth check.
+
+## Related Resources
+
+- [Resource](../application/resource.md) — Owns the binding through `spec.owner.{projectName, resourceName}`
+- [ResourceRelease](../runtime/resourcerelease.md) — Immutable snapshot pinned by `spec.resourceRelease`
+- [ResourceType](./resourcetype.md) — Source of `resourceTypeEnvironmentConfigs` schema and `retainPolicy` default
+- [Environment](./environment.md) — Target environment for the binding
+- [RenderedRelease](../runtime/renderedrelease.md) — Final manifests produced by the binding controller
+- [ReleaseBinding](./releasebinding.md) — Component-side counterpart
+- [Authoring ResourceTypes (PE Guide)](../../../platform-engineer-guide/resource-types.md)

--- a/docs/reference/api/platform/resourcetype.md
+++ b/docs/reference/api/platform/resourcetype.md
@@ -303,7 +303,7 @@ To deploy the Resource into an environment, a platform engineer creates a [Resou
 1. **Generate credentials on the data plane.** Use ExternalSecret + a generator (Password, ECDSAKey, etc.) so secret material never enters the control plane. Surface credentials through `secretKeyRef` outputs.
 2. **Match `readyWhen` to the provisioner.** For Crossplane claims, check the claim's `Ready` condition. For StatefulSets, check `readyReplicas == replicas`. Leave `readyWhen` unset only when the per-Kind health heuristic captures provisioner semantics correctly.
 3. **Set `retainPolicy: Retain` on stateful templates.** Defaults are inherited by every binding of this type; per-environment overrides remain available.
-4. **Keep outputs developer-friendly.** Compose useful values like full connection URLs through `value:` CEL when possible (`postgres://${output.username}:${...}/...`)—but render them on the data plane via ExternalSecret templating when they contain credentials.
+4. **Keep outputs developer-friendly.** Compose useful values like full connection URLs through `value:` CEL when possible (for example, using `parameters.*` and `applied.<id>.status.*`)—but render credential-bearing values on the data plane via ExternalSecret templating so secret material does not transit the control plane.
 5. **Document outputs.** Use `openchoreo.dev/description` annotations on the ResourceType to document the contract.
 
 ## Related Resources

--- a/docs/reference/api/platform/resourcetype.md
+++ b/docs/reference/api/platform/resourcetype.md
@@ -1,0 +1,316 @@
+---
+title: ResourceType API Reference
+description: Platform-defined template that provisions managed infrastructure and declares the outputs consumers bind to
+---
+
+# ResourceType
+
+A ResourceType is a platform-defined template that governs how managed infrastructure (databases, queues, caches, object stores) is provisioned on the data plane and exposed to consumers. It captures the manifests the platform emits, the parameters developers can supply, the environment-specific overrides bindings can apply, and the named outputs consumers wire into their containers.
+
+Resources reference a ResourceType (or [ClusterResourceType](./clusterresourcetype.md)) by name; each [ResourceReleaseBinding](./resourcereleasebinding.md) then renders the template per environment and applies the manifests to the data plane.
+
+## API Version
+
+`openchoreo.dev/v1alpha1`
+
+## Resource Definition
+
+### Metadata
+
+ResourceTypes are namespace-scoped resources typically created in a namespace to be available for Resources in that namespace.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceType
+metadata:
+  name: <resourcetype-name>
+  namespace: <namespace>
+```
+
+**Short names:** `rt`, `rts`
+
+### Spec Fields
+
+| Field                | Type                                            | Required | Default  | Description                                                                                                                                            |
+| -------------------- | ----------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `parameters`         | [SchemaSection](#schemasection)                 | No       | -        | Schema for `Resource.spec.parameters` values. Validated by the Resource controller; failures surface via `status.conditions`                           |
+| `environmentConfigs` | [SchemaSection](#schemasection)                 | No       | -        | Schema for `ResourceReleaseBinding.spec.resourceTypeEnvironmentConfigs` per-environment overrides                                                      |
+| `retainPolicy`       | string                                          | No       | `Delete` | Default retention behavior for bindings of this type: `Delete` removes emitted DP-side state on binding delete; `Retain` holds the binding's finalizer |
+| `outputs`            | [[ResourceTypeOutput](#resourcetypeoutput)]     | No       | []       | Named outputs that workloads consume through `Workload.spec.dependencies.resources[].envBindings` and `fileBindings`                                   |
+| `resources`          | [[ResourceTypeManifest](#resourcetypemanifest)] | Yes      | -        | Kubernetes manifest templates the provisioner emits on the data plane. At least one entry is required                                                  |
+
+### ResourceTypeOutput
+
+Declares a single named output. Each output picks exactly one of `value`, `secretKeyRef`, or `configMapKeyRef`—setting more than one is a validation error.
+
+| Field             | Type                                | Required | Default | Description                                                                                                                        |
+| ----------------- | ----------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `name`            | string                              | Yes      | -       | Unique output identifier within the ResourceType. Referenced by consumer `envBindings` / `fileBindings` keys (min: 1)              |
+| `value`           | string                              | No       | -       | Literal value or `${...}` CEL expression evaluating to a string. Use for non-sensitive data; the resolved value transits to the CP |
+| `secretKeyRef`    | [SecretKeyRef](#secretkeyref)       | No       | -       | Reference to a data-plane Secret. Use for sensitive credentials; only `{name, key}` transits to the CP                             |
+| `configMapKeyRef` | [ConfigMapKeyRef](#configmapkeyref) | No       | -       | Reference to a data-plane ConfigMap. Both `name` and `key` support `${...}` CEL templating                                         |
+
+`value`, `secretKeyRef.{name,key}`, and `configMapKeyRef.{name,key}` all accept `${...}` CEL expressions evaluated against `metadata.*`, `parameters.*`, `environmentConfigs.*`, `dataplane.*`, `gateway.*`, and `applied.<id>.status.*`.
+
+### ResourceTypeManifest
+
+Defines a single Kubernetes manifest the ResourceType emits on the data plane.
+
+| Field         | Type   | Required | Default | Description                                                                                                                                                |
+| ------------- | ------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`          | string | Yes      | -       | Unique identifier within the ResourceType. Referenced by `readyWhen` and `outputs` via `applied.<id>.status.*` (min: 1)                                    |
+| `includeWhen` | string | No       | -       | `${...}`-wrapped CEL expression returning a boolean. When `false`, the entry is omitted from the render and any prior object is GC'd                       |
+| `template`    | object | Yes      | -       | Kubernetes resource template with `${...}` CEL expressions for dynamic values                                                                              |
+| `readyWhen`   | string | No       | -       | `${...}`-wrapped CEL expression evaluating after the manifest has been applied. When set, gates `ResourceReleaseBinding.status.conditions[ResourcesReady]` |
+
+When `readyWhen` is unset, readiness falls back to the per-Kind health heuristic in `RenderedRelease.status.resources[].healthStatus`.
+
+#### CEL Expression Surface
+
+Templates use CEL expressions enclosed in `${...}`. The available context bindings depend on the field being evaluated:
+
+| Context                | In `template` | In `includeWhen` | In `readyWhen` | In `outputs` | Description                                                                                           |
+| ---------------------- | :-----------: | :--------------: | :------------: | :----------: | ----------------------------------------------------------------------------------------------------- |
+| `metadata.*`           |      yes      |       yes        |      yes       |     yes      | Platform-injected naming, namespace, resource/project/env names + UIDs, labels, annotations           |
+| `parameters.*`         |      yes      |       yes        |      yes       |     yes      | Values from `Resource.spec.parameters` with schema defaults applied                                   |
+| `environmentConfigs.*` |      yes      |       yes        |      yes       |     yes      | Values from `ResourceReleaseBinding.spec.resourceTypeEnvironmentConfigs` with schema defaults applied |
+| `environment.*`        |      yes      |       yes        |      yes       |     yes      | Per-environment surface including the merged effective gateway for this environment                   |
+| `dataplane.*`          |      yes      |       yes        |      yes       |     yes      | DataPlane attributes (`secretStore`, raw gateway, observability reference)                            |
+| `gateway.*`            |      yes      |       yes        |      yes       |     yes      | Effective gateway (Environment override merged onto DataPlane default)                                |
+| `applied.<id>.*`       |      no       |        no        |      yes       |     yes      | Status of resources after they have been applied to the data plane—reference by manifest `id`         |
+
+##### metadata
+
+Platform-computed metadata for resource generation:
+
+| Field                        | Type   | Description                                                                |
+| ---------------------------- | ------ | -------------------------------------------------------------------------- |
+| `metadata.name`              | string | Platform-computed base name `{resource}-{env}-{hash}` for rendered objects |
+| `metadata.namespace`         | string | DP-side project-env mapped namespace                                       |
+| `metadata.resourceNamespace` | string | CP namespace where the Resource CR lives                                   |
+| `metadata.resourceName`      | string | Name of the owning Resource                                                |
+| `metadata.resourceUID`       | string | UID of the owning Resource                                                 |
+| `metadata.projectName`       | string | Name of the project                                                        |
+| `metadata.projectUID`        | string | UID of the project                                                         |
+| `metadata.environmentName`   | string | Name of the environment                                                    |
+| `metadata.environmentUID`    | string | UID of the environment                                                     |
+| `metadata.dataPlaneName`     | string | Name of the target data plane                                              |
+| `metadata.dataPlaneUID`      | string | UID of the target data plane                                               |
+| `metadata.labels`            | map    | Platform-injected standard labels propagated to every rendered object      |
+| `metadata.annotations`       | map    | Annotations propagated from the Resource CR                                |
+
+For the full CEL surface (built-in functions, helpers), see the [CEL Reference](../../cel/context-variables.md).
+
+### SchemaSection
+
+Both `parameters` and `environmentConfigs` use the `SchemaSection` type, which holds a schema in `openAPIV3Schema` format:
+
+| Field             | Type   | Required | Default | Description                            |
+| ----------------- | ------ | -------- | ------- | -------------------------------------- |
+| `openAPIV3Schema` | object | No       | -       | Standard OpenAPI v3 JSON Schema format |
+
+```yaml
+parameters:
+  openAPIV3Schema:
+    type: object
+    properties:
+      version:
+        type: string
+        enum: ["7", "8"]
+        default: "8"
+```
+
+### SecretKeyRef
+
+References a key inside a Kubernetes Secret on the data plane.
+
+| Field  | Type   | Required | Description                                                      |
+| ------ | ------ | -------- | ---------------------------------------------------------------- |
+| `name` | string | Yes      | Name of the Secret (supports `${...}` CEL templating; min: 1)    |
+| `key`  | string | Yes      | Key within the Secret (supports `${...}` CEL templating; min: 1) |
+
+### ConfigMapKeyRef
+
+References a key inside a Kubernetes ConfigMap on the data plane.
+
+| Field  | Type   | Required | Description                                                         |
+| ------ | ------ | -------- | ------------------------------------------------------------------- |
+| `name` | string | Yes      | Name of the ConfigMap (supports `${...}` CEL templating; min: 1)    |
+| `key`  | string | Yes      | Key within the ConfigMap (supports `${...}` CEL templating; min: 1) |
+
+### Status Fields
+
+ResourceType currently has no status fields.
+
+## Examples
+
+### Simple Valkey Cache
+
+A namespace-scoped ResourceType emitting a StatefulSet-backed Valkey cache with a Secret, Service, and a single output for each connection detail.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceType
+metadata:
+  name: valkey-cache
+  namespace: default
+spec:
+  parameters:
+    openAPIV3Schema:
+      type: object
+      properties:
+        version:
+          type: string
+          enum: ["7", "8"]
+          default: "8"
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        memory:
+          type: string
+          default: "128Mi"
+
+  retainPolicy: Delete
+
+  outputs:
+    - name: host
+      value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+    - name: port
+      value: "6379"
+    - name: password
+      secretKeyRef:
+        name: "${metadata.name}-creds"
+        key: password
+
+  resources:
+    - id: password-secret
+      template:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${metadata.name}-creds
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        type: Opaque
+        stringData:
+          password: "change-me"
+
+    - id: service
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+        spec:
+          selector:
+            app: ${metadata.name}
+          ports:
+            - name: valkey
+              port: 6379
+              targetPort: 6379
+
+    - id: statefulset
+      readyWhen: "${applied.statefulset.status.readyReplicas == applied.statefulset.status.replicas && applied.statefulset.status.replicas > 0}"
+      template:
+        apiVersion: apps/v1
+        kind: StatefulSet
+        metadata:
+          name: ${metadata.name}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          serviceName: ${metadata.name}
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ${metadata.name}
+          template:
+            metadata:
+              labels:
+                app: ${metadata.name}
+            spec:
+              containers:
+                - name: valkey
+                  image: valkey/valkey:${parameters.version}-alpine
+                  resources:
+                    limits:
+                      memory: ${environmentConfigs.memory}
+                  ports:
+                    - containerPort: 6379
+                      name: valkey
+```
+
+### ResourceType With Conditional Resources
+
+`includeWhen` lets a single template handle both bare and admin-UI variants without duplicating templates:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceType
+metadata:
+  name: redis-with-admin
+  namespace: default
+spec:
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      properties:
+        adminEnabled:
+          type: boolean
+          default: false
+
+  resources:
+    # ... bare cache resources omitted ...
+
+    - id: admin-deployment
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
+      template:
+        # ... admin UI Deployment ...
+
+    - id: admin-route
+      includeWhen: "${environmentConfigs.adminEnabled && has(gateway.ingress.external)}"
+      template:
+        # ... HTTPRoute exposing the admin UI ...
+```
+
+## Usage
+
+Developers reference a ResourceType from a Resource:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Resource
+metadata:
+  name: order-cache
+  namespace: default
+spec:
+  owner:
+    projectName: order-service
+  type:
+    kind: ResourceType
+    name: valkey-cache
+  parameters:
+    version: "8"
+```
+
+To deploy the Resource into an environment, a platform engineer creates a [ResourceReleaseBinding](./resourcereleasebinding.md) pinning a specific [ResourceRelease](../runtime/resourcerelease.md).
+
+## Best Practices
+
+1. **Generate credentials on the data plane.** Use ExternalSecret + a generator (Password, ECDSAKey, etc.) so secret material never enters the control plane. Surface credentials through `secretKeyRef` outputs.
+2. **Match `readyWhen` to the provisioner.** For Crossplane claims, check the claim's `Ready` condition. For StatefulSets, check `readyReplicas == replicas`. Leave `readyWhen` unset only when the per-Kind health heuristic captures provisioner semantics correctly.
+3. **Set `retainPolicy: Retain` on stateful templates.** Defaults are inherited by every binding of this type; per-environment overrides remain available.
+4. **Keep outputs developer-friendly.** Compose useful values like full connection URLs through `value:` CEL when possible (`postgres://${output.username}:${...}/...`)—but render them on the data plane via ExternalSecret templating when they contain credentials.
+5. **Document outputs.** Use `openchoreo.dev/description` annotations on the ResourceType to document the contract.
+
+## Related Resources
+
+- [ClusterResourceType](./clusterresourcetype.md) — Cluster-scoped variant of ResourceType
+- [Resource](../application/resource.md) — Developer-facing CRD that references a ResourceType
+- [ResourceRelease](../runtime/resourcerelease.md) — Immutable snapshot cut by the Resource controller
+- [ResourceReleaseBinding](./resourcereleasebinding.md) — Per-environment binding that renders this template
+- [Workload](../application/workload.md) — Consumes ResourceType outputs via `dependencies.resources[]`
+- [Authoring ResourceTypes (PE Guide)](../../../platform-engineer-guide/resource-types.md)

--- a/docs/reference/api/runtime/resourcerelease.md
+++ b/docs/reference/api/runtime/resourcerelease.md
@@ -1,0 +1,162 @@
+---
+title: ResourceRelease API Reference
+description: Immutable snapshot of a Resource and its ResourceType at a point in time
+---
+
+# ResourceRelease
+
+A ResourceRelease is an immutable snapshot of a [Resource](../application/resource.md) and the referenced [ResourceType](../platform/resourcetype.md) or [ClusterResourceType](../platform/clusterresourcetype.md) at the moment it was cut. ResourceReleases ensure reproducibility and enable reliable rollback by preserving the exact state used to render the binding for each environment.
+
+ResourceReleases are created exclusively by the Resource controller. When the hash of `Resource.spec` plus the referenced ResourceType's spec changes, a new ResourceRelease is cut with the name `{resource}-{hash}`. They are deleted by the Resource finalizer when the parent Resource is torn down.
+
+## API Version
+
+`openchoreo.dev/v1alpha1`
+
+## Resource Definition
+
+### Metadata
+
+ResourceReleases are namespace-scoped resources created in the same namespace as the Resource.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceRelease
+metadata:
+  name: <resource-name>-<hash>
+  namespace: <namespace>
+```
+
+The name shape mirrors the ComponentRelease pattern: a stable prefix derived from the Resource name plus a content-addressed hash discriminator. Two ResourceReleases for the same Resource can therefore coexist during a rolling promotion.
+
+### Spec Fields
+
+The entire spec is immutable after creation. Edits are rejected by a CEL validation rule on the CRD.
+
+| Field          | Type                                                        | Required | Default | Description                                                           |
+| -------------- | ----------------------------------------------------------- | -------- | ------- | --------------------------------------------------------------------- |
+| `owner`        | [ResourceReleaseOwner](#resourcereleaseowner)               | Yes      | -       | Identifies the Resource and project this snapshot belongs to          |
+| `resourceType` | [ResourceReleaseResourceType](#resourcereleaseresourcetype) | Yes      | -       | Frozen snapshot of the (Cluster)ResourceType resource at release time |
+| `parameters`   | object                                                      | No       | -       | Frozen snapshot of `Resource.spec.parameters` at release time         |
+
+### ResourceReleaseOwner
+
+| Field          | Type   | Required | Description                                           |
+| -------------- | ------ | -------- | ----------------------------------------------------- |
+| `projectName`  | string | Yes      | Name of the project that owns this Resource (min: 1)  |
+| `resourceName` | string | Yes      | Name of the Resource this release belongs to (min: 1) |
+
+### ResourceReleaseResourceType
+
+Captures both the identity (Kind + Name) and the full spec of the referenced (Cluster)ResourceType at release time, so a namespace-scoped ResourceType and a cluster-scoped ClusterResourceType with the same name can coexist in the snapshot history.
+
+| Field  | Type                                                        | Required | Description                                                                        |
+| ------ | ----------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `kind` | string                                                      | Yes      | Either `ResourceType` (namespace-scoped) or `ClusterResourceType` (cluster-scoped) |
+| `name` | string                                                      | Yes      | Name of the (Cluster)ResourceType resource (min: 1)                                |
+| `spec` | [ResourceTypeSpec](../platform/resourcetype.md#spec-fields) | Yes      | Frozen specification of the (Cluster)ResourceType                                  |
+
+ClusterResourceType snapshots currently share the namespaced ResourceType spec shape; if ClusterResourceType later gains cluster-only fields, snapshots taken from a ClusterResourceType source will not preserve them—mirrors the ComponentRelease precedent.
+
+### Status Fields
+
+ResourceRelease currently has no status fields. Observed deployment state (per-environment readiness, output resolution, finalization) lives on the [ResourceReleaseBinding](../platform/resourcereleasebinding.md) that pins this snapshot.
+
+## Examples
+
+### Basic ResourceRelease
+
+A snapshot cut by the Resource controller after a developer creates a Resource referencing the `postgres` ClusterResourceType.
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceRelease
+metadata:
+  name: doclet-postgres-abc12345
+  namespace: default
+spec:
+  owner:
+    projectName: doclet
+    resourceName: doclet-postgres
+  resourceType:
+    kind: ClusterResourceType
+    name: postgres
+    spec:
+      parameters:
+        openAPIV3Schema:
+          type: object
+          properties:
+            database:
+              type: string
+              default: postgres
+      environmentConfigs:
+        openAPIV3Schema:
+          type: object
+          properties:
+            storage:
+              type: string
+              default: "10Gi"
+      retainPolicy: Retain
+      outputs:
+        - name: host
+          value: "${metadata.name}.${metadata.namespace}.svc.cluster.local"
+        - name: port
+          value: "5432"
+        - name: password
+          secretKeyRef:
+            name: "${metadata.name}-creds"
+            key: password
+      resources:
+        - id: password-secret
+          template:
+            # ... ExternalSecret or Password generator manifest ...
+        - id: statefulset
+          readyWhen: "${applied.statefulset.status.readyReplicas == 1}"
+          template:
+            # ... Postgres StatefulSet ...
+  parameters:
+    database: doclet
+```
+
+### ResourceRelease From a Namespace-Scoped ResourceType
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: ResourceRelease
+metadata:
+  name: order-cache-def67890
+  namespace: default
+spec:
+  owner:
+    projectName: order-service
+    resourceName: order-cache
+  resourceType:
+    kind: ResourceType
+    name: valkey-cache
+    spec:
+      # ... frozen ResourceType spec at release time ...
+  parameters:
+    version: "8"
+```
+
+## Immutability
+
+ResourceRelease's spec is enforced immutable by a CEL validation rule (`self == oldSelf`). All fields—`owner`, `resourceType`, `parameters`—are part of the snapshot guarantee:
+
+- Spec edits via `kubectl edit` or API PATCH are rejected.
+- The Resource controller cuts a new ResourceRelease (new hash, new name) when either the Resource spec or the referenced (Cluster)ResourceType spec changes. The previous snapshot is left untouched until the Resource finalizer GC's it.
+
+## Lifecycle
+
+1. **Create.** Resource controller computes the hash of `Resource.spec + (Cluster)ResourceType.spec`. If no ResourceRelease with that hash exists, it creates one named `{resource}-{hash}` and updates `Resource.status.latestRelease`.
+2. **Promote.** A platform engineer or GitOps process updates a `ResourceReleaseBinding.spec.resourceRelease` to point at this snapshot. The binding controller renders the snapshot's `resourceType.spec` with the snapshot's `parameters` and the binding's `resourceTypeEnvironmentConfigs`, then applies the resulting manifests to the data plane.
+3. **Delete.** When the parent Resource is deleted, the Resource finalizer's second phase removes all owned ResourceReleases (matched by `spec.owner.resourceName`). Direct `kubectl delete resourcerelease ...` is not blocked by a finalizer but breaks the binding chain if any binding still references the snapshot.
+
+## Related Resources
+
+- [Resource](../application/resource.md) — Owns this snapshot through `spec.owner.{projectName, resourceName}`
+- [ResourceType](../platform/resourcetype.md) — Source template captured in `spec.resourceType.spec`
+- [ClusterResourceType](../platform/clusterresourcetype.md) — Cluster-scoped variant of the source template
+- [ResourceReleaseBinding](../platform/resourcereleasebinding.md) — Pins this snapshot to a specific environment
+- [RenderedRelease](./renderedrelease.md) — Final manifests produced by the binding controller
+- [ComponentRelease](./componentrelease.md) — Component-side counterpart

--- a/docs/reference/mcp-servers.mdx
+++ b/docs/reference/mcp-servers.mdx
@@ -36,7 +36,7 @@ For the best experience, configure **both** the Control Plane and Observability 
 
 ### Control Plane MCP Server
 
-The Control Plane MCP server is organized into six toolsets.
+The Control Plane MCP server is organized into seven toolsets.
 
 Note: On v1.1 onwards, the cluster-prefixed tools are deprecated and remain listed until v1.2 release (see [Deprecated cluster-prefixed tools](#deprecated-cluster-prefixed-tools)).
 
@@ -126,7 +126,30 @@ If your integration depends on the legacy `*_cluster_*` names, migrate to the ca
 </details>
 
 <details>
+<summary><strong>Resource Toolset</strong></summary>
+
+The Resource toolset mirrors the Component toolset for managed infrastructure: developers create Resources that reference platform-engineer-published ResourceTypes, and workloads consume the declared outputs via `dependencies.resources[]`. ResourceType writes, ResourceRelease management, and ResourceReleaseBinding CRUD live in the PE and Deployment toolsets respectively.
+
+**Resource Management**
+
+- `list_resources` — List all Resources in a project (managed-infrastructure dependencies like databases, queues, caches, object stores)
+- `get_resource` — Get a Resource's full spec including parameters, referenced (Cluster)ResourceType, latest cut release, and conditions
+- `create_resource` — Create a new Resource referencing a ResourceType or ClusterResourceType; the controller cuts the first ResourceRelease automatically
+- `update_resource` — Update a Resource's parameters (full replacement). `spec.owner` and `spec.type` are immutable
+- `delete_resource` — Delete a Resource; the two-phase finalizer blocks until all ResourceReleaseBindings are removed, then GCs owned ResourceReleases
+
+**Platform Standards — Read-Only, Namespace-Scoped**
+
+- `list_resource_types` † — List available ResourceTypes in a namespace (Postgres, Valkey, NATS, S3 buckets, Crossplane claims, etc.). Pass `scope: "cluster"` for ClusterResourceTypes
+- `get_resource_type` † — Get the full definition of a ResourceType including parameter schema, environmentConfigs schema, outputs, and rendered resources. Pass `scope: "cluster"` for a ClusterResourceType
+- `get_resource_type_schema` † — Get the parameter schema for a ResourceType. Pass `scope: "cluster"` for a ClusterResourceType
+
+</details>
+
+<details>
 <summary><strong>Deployment Toolset</strong></summary>
+
+**Components**
 
 - `create_release_binding` — Create a new release binding to deploy a component to a specific environment
 - `list_release_bindings` — List release bindings associating releases with environments for a component
@@ -134,6 +157,18 @@ If your integration depends on the legacy `*_cluster_*` names, migrate to the ca
 - `update_release_binding` — Update a release binding's configuration (release, release_state, overrides, traits, workload settings); set `release_state: Active` to deploy or `Undeploy` to remove from the data plane while keeping the binding
 - `delete_release_binding` — Delete a release binding entirely; for reversible removal that keeps the binding, use `update_release_binding` with `release_state: Undeploy` instead
 - `delete_component_release` — Delete a component release (immutable; useful for pruning old releases)
+
+**Resources**
+
+- `create_resource_release_binding` — Create a new ResourceReleaseBinding to deploy a Resource to a specific environment
+- `list_resource_release_bindings` — List ResourceReleaseBindings in a namespace; optionally filter by project, resource, or environment
+- `get_resource_release_binding` — Get detailed info for a ResourceReleaseBinding including the pinned ResourceRelease, retention policy, environment overrides, and resolved outputs
+- `update_resource_release_binding` — Update a ResourceReleaseBinding's configuration (`resource_release`, `retain_policy`, `resource_type_environment_configs`); promotion is performed by setting `resource_release` to a new ResourceRelease name
+- `delete_resource_release_binding` — Delete a ResourceReleaseBinding; if effective `retainPolicy` is `Retain`, the finalizer holds and the data-plane state persists until the policy is flipped to `Delete`
+- `delete_resource_release` — Delete a ResourceRelease snapshot (immutable; useful for pruning old releases)
+
+**Pipelines & Environments**
+
 - `list_deployment_pipelines` — List all deployment pipelines defining environment promotion order in a namespace
 - `get_deployment_pipeline` — Get detailed deployment pipeline info including stages, promotion order, and environments
 - `list_environments` † — List all environments (deployment targets like dev, staging, production) in a namespace
@@ -189,6 +224,12 @@ The PE toolset is enabled by default. These tools are intended for platform admi
 - `get_component_release` — Get detailed release info including build information, image tags, and deployment status
 - `get_component_release_schema` — Get the JSON schema for a component release's configuration options
 
+**Resource Releases**
+
+- `list_resource_releases` — List all ResourceReleases (immutable snapshots of `Resource.spec` + `(Cluster)ResourceType.spec`) for a Resource
+- `create_resource_release` — Manually cut a ResourceRelease from the current Resource and ResourceType state. Typically not needed in steady state—the Resource controller cuts releases automatically on hash change
+- `get_resource_release` — Get the full snapshot including the frozen (Cluster)ResourceType spec and the Resource parameters captured at release time
+
 **Infrastructure — Namespace-Scoped Planes**
 
 - `list_dataplanes` — List all data planes (clusters where workloads execute) in a namespace
@@ -215,6 +256,9 @@ The PE toolset is enabled by default. These tools are intended for platform admi
 - `list_traits` † — List available traits in a namespace
 - `get_trait` — Get the full definition of a trait including its complete spec
 - `get_trait_schema` † — Get the parameter schema for a trait
+- `list_resource_types` † — List available ResourceTypes in a namespace. Pass `scope: "cluster"` for ClusterResourceTypes
+- `get_resource_type` † — Get the full definition of a ResourceType including outputs and resource manifests. Pass `scope: "cluster"` for a ClusterResourceType
+- `get_resource_type_schema` † — Get the parameter schema for a ResourceType. Pass `scope: "cluster"` for a ClusterResourceType
 - `list_workflows` † — List all workflow templates in a namespace
 - `get_workflow` — Get the full definition of a workflow including its complete spec
 - `get_workflow_schema` † — Get the parameter schema for a workflow template
@@ -225,6 +269,7 @@ The PE toolset is enabled by default. These tools are intended for platform admi
 - `get_cluster_component_type_creation_schema` _(deprecated — use `get_component_type_creation_schema` with `scope: "cluster"`)_ — Get the spec schema for creating a cluster-scoped component type
 - `get_trait_creation_schema` — Get the spec schema for creating a trait
 - `get_cluster_trait_creation_schema` _(deprecated — use `get_trait_creation_schema` with `scope: "cluster"`)_ — Get the spec schema for creating a cluster-scoped trait
+- `get_resource_type_creation_schema` — Get the spec schema for creating a ResourceType. Pass `scope: "cluster"` for a ClusterResourceType
 - `get_workflow_creation_schema` — Get the spec schema for creating a workflow
 - `get_cluster_workflow_creation_schema` _(deprecated — use `get_workflow_creation_schema` with `scope: "cluster"`)_ — Get the spec schema for creating a cluster-scoped workflow
 
@@ -236,6 +281,9 @@ The PE toolset is enabled by default. These tools are intended for platform admi
 - `create_trait` — Create a new trait in a namespace
 - `update_trait` — Update an existing trait (full replacement)
 - `delete_trait` — Delete a trait from a namespace
+- `create_resource_type` — Create a new ResourceType. Pass `scope: "cluster"` to create a ClusterResourceType
+- `update_resource_type` — Update an existing ResourceType (full replacement). Pass `scope: "cluster"` for a ClusterResourceType
+- `delete_resource_type` — Delete a ResourceType. Pass `scope: "cluster"` to delete a ClusterResourceType
 - `create_workflow` — Create a new workflow in a namespace
 - `update_workflow` — Update an existing workflow (full replacement)
 - `delete_workflow` — Delete a workflow from a namespace
@@ -318,7 +366,7 @@ The Observability Plane MCP server provides tools covering logs, traces, metrics
 
 ## Configuring MCP Toolsets
 
-The Control Plane MCP server exposes six toolsets: `namespace`, `project`, `component`, `deployment`, `build`, and `pe`. All six are enabled by default. You can control which toolsets are active by passing a JSON array to `openchoreoApi.config.mcp.toolsets` via `helm upgrade`.
+The Control Plane MCP server exposes seven toolsets: `namespace`, `project`, `component`, `resource`, `deployment`, `build`, and `pe`. All seven are enabled by default. You can control which toolsets are active by passing a JSON array to `openchoreoApi.config.mcp.toolsets` via `helm upgrade`.
 
 **Syntax:**
 
@@ -339,7 +387,7 @@ The Control Plane MCP server exposes six toolsets: `namespace`, `project`, `comp
   --version ${versions.helmChart} \\
   --namespace openchoreo-control-plane \\
   --reuse-values \\
-  --set-json 'openchoreoApi.config.mcp.toolsets=["namespace","project","component","deployment","build"]'`}
+  --set-json 'openchoreoApi.config.mcp.toolsets=["namespace","project","component","resource","deployment","build"]'`}
 </CodeBlock>
 
 **Platform Engineer toolset:**

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -131,6 +131,11 @@ const sidebars: SidebarsConfig = {
           ],
         },
         {
+          type: "doc",
+          id: "platform-engineer-guide/resource-types",
+          label: "Resource Types",
+        },
+        {
           type: "category",
           label: "Workflows & CI",
           description:
@@ -293,6 +298,11 @@ const sidebars: SidebarsConfig = {
               id: "developer-guide/dependencies/endpoints",
               label: "Endpoint Dependencies",
             },
+            {
+              type: "doc",
+              id: "developer-guide/dependencies/resources",
+              label: "Resource Dependencies",
+            },
           ],
         },
         {
@@ -435,6 +445,11 @@ const sidebars: SidebarsConfig = {
                   id: "reference/api/application/workload",
                   label: "Workload",
                 },
+                {
+                  type: "doc",
+                  id: "reference/api/application/resource",
+                  label: "Resource",
+                },
               ],
             },
             {
@@ -521,6 +536,16 @@ const sidebars: SidebarsConfig = {
                     },
                     {
                       type: "doc",
+                      id: "reference/api/platform/resourcetype",
+                      label: "ResourceType",
+                    },
+                    {
+                      type: "doc",
+                      id: "reference/api/platform/clusterresourcetype",
+                      label: "ClusterResourceType",
+                    },
+                    {
+                      type: "doc",
                       id: "reference/api/platform/workflow",
                       label: "Workflow",
                     },
@@ -560,6 +585,11 @@ const sidebars: SidebarsConfig = {
                       type: "doc",
                       id: "reference/api/platform/releasebinding",
                       label: "ReleaseBinding",
+                    },
+                    {
+                      type: "doc",
+                      id: "reference/api/platform/resourcereleasebinding",
+                      label: "ResourceReleaseBinding",
                     },
                   ],
                 },
@@ -633,6 +663,11 @@ const sidebars: SidebarsConfig = {
                   type: "doc",
                   id: "reference/api/runtime/componentrelease",
                   label: "ComponentRelease",
+                },
+                {
+                  type: "doc",
+                  id: "reference/api/runtime/resourcerelease",
+                  label: "ResourceRelease",
                 },
                 {
                   type: "doc",


### PR DESCRIPTION
## Purpose

Documentation for the Resource Abstractions v1.1 feature (epic openchoreo/openchoreo#3107, issue openchoreo/openchoreo#3340). Resource Abstractions add first-class support for OpenChoreo workloads to depend on managed infrastructure — databases, queues, caches, object stores — through 5 new CRDs: `Resource`, `ResourceType` / `ClusterResourceType`, `ResourceRelease`, and `ResourceReleaseBinding`.

This PR ships the concept, developer-guide, PE-guide, API-reference, and MCP-reference coverage. The sample walkthrough that pairs with the developer guide ships in openchoreo/openchoreo#3528 (the `doclet` from-image sample).

## Related Issues

Related: openchoreo/openchoreo#3340
Related: openchoreo/openchoreo#3107

## Checklist
- [x] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)