### PR TITLE
docs: improve search discoverability for ABAC/RBAC

### DIFF
--- a/docs/platform-engineer-guide/authorization/conditions.md
+++ b/docs/platform-engineer-guide/authorization/conditions.md
@@ -2,11 +2,21 @@
 title: Conditions
 description: Restrict role grants by request attributes using CEL expressions on AuthzRoleBindings
 sidebar_position: 4
+keywords:
+  - ABAC
+  - attribute-based access control
+  - CEL
+  - common expression language
+  - policy
+  - constraints
+  - conditional access
+  - environment restriction
+  - request attributes
 ---
 
 # Conditions
 
-A role binding answers _who_, _what_, and _where_. **Conditions** add a fourth constraint — _under what circumstances_. For example, you can grant a developer permission to manage release bindings in the `crm` project, but only when the target environment is `dev` or `staging` — keeping production off-limits.
+A role binding answers _who_, _what_, and _where_. **Conditions** add a fourth constraint — _under what circumstances_. This is attribute-based access control (ABAC), layered on top of OpenChoreo's RBAC and expressed through CEL (Common Expression Language) policy. For example, you can grant a developer permission to manage release bindings in the `crm` project, but only when the target environment is `dev` or `staging` — keeping production off-limits.
 
 Conditions are optional. Omit them and the role mapping behaves like any other RBAC grant — every action the role grants applies within the binding's scope.
 

--- a/docs/platform-engineer-guide/authorization/overview.md
+++ b/docs/platform-engineer-guide/authorization/overview.md
@@ -2,6 +2,15 @@
 title: Overview
 description: Understand how authorization works in OpenChoreo
 sidebar_position: 1
+keywords:
+  - RBAC
+  - ABAC
+  - role-based access control
+  - attribute-based access control
+  - authorization model
+  - access control
+  - CEL
+  - policy
 ---
 
 # Authorization in OpenChoreo

--- a/versioned_docs/version-v1.1.x/platform-engineer-guide/authorization/conditions.md
+++ b/versioned_docs/version-v1.1.x/platform-engineer-guide/authorization/conditions.md
@@ -2,11 +2,21 @@
 title: Conditions
 description: Restrict role grants by request attributes using CEL expressions on AuthzRoleBindings
 sidebar_position: 4
+keywords:
+  - ABAC
+  - attribute-based access control
+  - CEL
+  - common expression language
+  - policy
+  - constraints
+  - conditional access
+  - environment restriction
+  - request attributes
 ---
 
 # Conditions
 
-A role binding answers _who_, _what_, and _where_. **Conditions** add a fourth constraint — _under what circumstances_. For example, you can grant a developer permission to manage release bindings in the `crm` project, but only when the target environment is `dev` or `staging` — keeping production off-limits.
+A role binding answers _who_, _what_, and _where_. **Conditions** add a fourth constraint — _under what circumstances_. This is attribute-based access control (ABAC), layered on top of OpenChoreo's RBAC and expressed through CEL (Common Expression Language) policy. For example, you can grant a developer permission to manage release bindings in the `crm` project, but only when the target environment is `dev` or `staging` — keeping production off-limits.
 
 Conditions are optional. Omit them and the role mapping behaves like any other RBAC grant — every action the role grants applies within the binding's scope.
 

--- a/versioned_docs/version-v1.1.x/platform-engineer-guide/authorization/overview.md
+++ b/versioned_docs/version-v1.1.x/platform-engineer-guide/authorization/overview.md
@@ -2,6 +2,15 @@
 title: Overview
 description: Understand how authorization works in OpenChoreo
 sidebar_position: 1
+keywords:
+  - RBAC
+  - ABAC
+  - role-based access control
+  - attribute-based access control
+  - authorization model
+  - access control
+  - CEL
+  - policy
 ---
 
 # Authorization in OpenChoreo


### PR DESCRIPTION
## Purpose
  - Add `keywords` frontmatter to the Authorization **Overview** and **Conditions** pages so Algolia DocSearch
  surfaces them for industry-standard terms users actually type — `ABAC`, `attribute-based access control`, `RBAC`,
  `role-based access control`, `CEL`, `policy`, etc.
  - Reword the **Conditions** intro to name *attribute-based access control (ABAC)* and *CEL (Common Expression 
  Language)* once in prose, so readers who land on the page recognise the feature by its industry name (not just the
  OpenChoreo-specific "Conditions" label).
  - Apply the same changes to both the unversioned docs and `version-v1.1.x` so the live docs and the current release
   branch stay in sync.
  
## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
