### PR TITLE
feat: add Try in Browser CTA to homepage

### DIFF
--- a/src/components/HomepageHero/index.tsx
+++ b/src/components/HomepageHero/index.tsx
@@ -37,6 +37,9 @@ export default function HomepageHero(): ReactNode {
 
         {/* Call-to-action buttons */}
         <div className={styles.heroButtons}>
+          <Button to="https://demo.openchoreo.wso2.com/">
+            Try in Browser
+          </Button>
           <Button to={useBaseUrl("/docs/getting-started/quick-start-guide/")}>
             Quick Start
           </Button>


### PR DESCRIPTION
## Summary
- Add a "Try in Browser" button to the homepage hero linking to the demo environment at https://demo.openchoreo.wso2.com/
- Three CTAs now clearly distinguish paths: browser demo, local quick start, and docs

## Test plan
- [ ] Verify the homepage renders three CTA buttons: "Try in Browser", "Quick Start", "Learn More"
- [ ] Verify "Try in Browser" opens the demo environment
- [ ] Verify existing "Quick Start" and "Learn More" links still work