### PR TITLE
docs(backstage-plugins): fix install gaps surfaced by end-to-end test

### DIFF
--- a/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
@@ -19,6 +19,7 @@ OpenChoreo plugins are published to **GitHub Packages** under the [`@openchoreo`
 ## 1. Prerequisites
 
 - A Backstage workspace on the [supported Backstage version](./compatibility-matrix.mdx). This guide pins to **Backstage `1.43.3`**.
+- The workspace must be scaffolded with the **legacy** frontend system: `npx @backstage/create-app@latest --legacy`. Current `create-app` versions default to the new declarative frontend system (`createApp({ features: [...] })` in `App.tsx`), which does not match the §4.3 edits below — those edits rely on the legacy structure (`apis.ts`, `createApp({ apis, plugins, bindRoutes })`, and `components/catalog/EntityPage.tsx`).
 - Node.js **20 or 22**, Yarn **4.4.1**.
 - Access to a running OpenChoreo control plane (local `k3d` or a deployed cluster).
 - OAuth client credentials for the OpenChoreo Identity Provider (used by the catalog sync and user sign-in). On `k3d` the helm chart pre-seeds these; for a deployed cluster see [Identity configuration](../identity-configuration.mdx).
@@ -660,7 +661,7 @@ These are **k3d dev cluster seed values, not real secrets** — never use them a
 ### 4.5 Verify
 
 ```bash
-yarn dev
+yarn start
 ```
 
 Expected:
@@ -768,7 +769,7 @@ openchoreo:
 
 ### 5.5 Verify
 
-Restart `yarn dev`. Open any Component → the **Logs**, **Metrics**, **Alerts** tabs appear. Open any System → **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
+Restart `yarn start`. Open any Component → the **Logs**, **Metrics**, **Alerts** tabs appear. Open any System → **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
 
 ---
 
@@ -830,7 +831,7 @@ openchoreo:
 
 ### 6.5 Verify
 
-Restart `yarn dev`. Open any Component → the **Build** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
+Restart `yarn start`. Open any Component → the **Build** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
 
 ---
 
@@ -894,7 +895,7 @@ import PlayCircleOutlineIcon from "@material-ui/icons/PlayCircleOutline";
 
 ### 7.4 Verify
 
-Restart `yarn dev`. Navigate to `http://localhost:3000/workflows` → see the org-level workflow list.
+Restart `yarn start`. Navigate to `http://localhost:3000/workflows` → see the org-level workflow list.
 
 ---
 
@@ -919,6 +920,38 @@ Delete the import and JSX usage from `packages/app/src/components/Root/Root.tsx`
 ```
 
 You can leave the `@backstage/plugin-notifications` package installed; it just shouldn't be referenced from the rendered tree.
+
+### Backend cleanup
+
+The `create-app --legacy` scaffold also registers four backend modules in `packages/backend/src/index.ts` that are not pinned by the [compatibility matrix](./compatibility-matrix.mdx). They drift to versions outside the 1.43.3 release line and crash the backend at startup with `TypeError: Cannot read properties of undefined (reading 'id')` (see [Troubleshooting → Backend module startup fails](./troubleshooting.mdx#backend-module-startup-fails-with-cannot-read-properties-of-undefined-reading-id)).
+
+Remove their `backend.add(...)` lines from `packages/backend/src/index.ts`:
+
+```ts
+// Remove:
+// backend.add(import('@backstage/plugin-scaffolder-backend-module-notifications'));
+// backend.add(import('@backstage/plugin-notifications-backend'));
+// backend.add(import('@backstage/plugin-signals-backend'));
+// backend.add(import('@backstage/plugin-mcp-actions-backend'));
+```
+
+Then drop the packages from `packages/backend/package.json`:
+
+```bash
+yarn workspace backend remove \
+  @backstage/plugin-scaffolder-backend-module-notifications \
+  @backstage/plugin-notifications-backend \
+  @backstage/plugin-signals-backend \
+  @backstage/plugin-mcp-actions-backend
+```
+
+The signals backend was paired with a `<SignalsDisplay />` component in `packages/app/src/App.tsx`. Remove that too so the frontend doesn't reference a backend that no longer exists:
+
+```tsx
+// Remove from packages/app/src/App.tsx:
+// import { SignalsDisplay } from '@backstage/plugin-signals';
+// <SignalsDisplay />
+```
 
 ---
 

--- a/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
@@ -211,9 +211,31 @@ NotImplementedError: No implementation available for
 apiRef{plugin.openchoreo-observability.service}
 ```
 
-**Cause:** the Environments tab consumes the observability API (`openchoreoObservabilityPlugin`) for incident counts. If you didn't install the observability tab pack, the plugin's API factory is never registered.
+**Cause:** the Environments tab consumes the observability API (`openchoreoObservabilityPlugin`) for incident counts. Earlier 1.1.0 tarballs of `@openchoreo/backstage-plugin` resolved this API with `useApi()`, which throws when no factory is registered — so the Deploy tab crashed unless the observability tab pack was also installed.
 
-**Fix:** install `@openchoreo/backstage-plugin-openchoreo-observability` + its backend counterpart and register `openchoreoObservabilityPlugin` in `createApp({ plugins: [...] })`. See the [installation guide → Observability tabs](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional).
+This was fixed in `@openchoreo/backstage-plugin@1.1.0` (republished). The hook now uses `useApiHolder().get()`, which returns `undefined` when observability is not installed; the Deploy tab renders environment tiles cleanly without incident chips.
+
+**Fix:** force a fresh resolve so yarn pulls the new tarball:
+
+```bash
+# from your Backstage workspace root
+rm -rf node_modules yarn.lock .yarn/install-state.gz .yarn/cache
+yarn install
+```
+
+Then restart `yarn start`. Confirm the installed tarball is the rebuilt one:
+
+```bash
+node -e "console.log(require('./node_modules/@openchoreo/backstage-plugin/package.json').version)"
+# should print: 1.1.0
+
+grep -E "useApiHolder" node_modules/@openchoreo/backstage-plugin/dist/index.cjs.js | head -1
+# should print at least one match (proves the rebuilt code is in node_modules)
+```
+
+If the second command prints nothing, your yarn cache or lockfile is still pinning the old tarball. Run `yarn up @openchoreo/backstage-plugin` to force re-resolution.
+
+If you actually want incident counts on the Deploy tab, install the observability tab pack as documented in the [installation guide → Observability tabs](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional) — it registers the API factory and feeds real incident data into the same UI.
 
 ## `openchoreo-auth` provider misconfigured
 
@@ -242,7 +264,7 @@ HTTP 401: Unauthorized
 **Cause:** one of two things, in order of likelihood:
 
 1. **`OpenChoreoPermissionApi` not registered** in `packages/app/src/apis.ts`. The default `PermissionClient` bypasses `fetchApi` entirely and never gets the IDP token, so every authorize call fails. Fix: [Override `permissionApi`](./installing-into-existing-backstage.mdx#permission-api).
-2. **Your user genuinely has no capabilities** in OpenChoreo. The IDP token is valid but Thunder hasn't granted them `release-binding:read` / `environment:read`. Confirm with `LOG_LEVEL=debug yarn dev`, hit a Deploy tab, and grep backend logs for `[AUTHZ] Parsed capabilities` — that dumps what the OpenChoreo authz service returned. If the expected capabilities aren't there, fix the user's role bindings on the OpenChoreo control plane, not in Backstage.
+2. **Your user genuinely has no capabilities** in OpenChoreo. The IDP token is valid but Thunder hasn't granted them `release-binding:read` / `environment:read`. Confirm with `LOG_LEVEL=debug yarn start`, hit a Deploy tab, and grep backend logs for `[AUTHZ] Parsed capabilities` — that dumps what the OpenChoreo authz service returned. If the expected capabilities aren't there, fix the user's role bindings on the OpenChoreo control plane, not in Backstage.
 
 ## `JWKSNoMatchingKey` warnings in permission backend logs
 

--- a/versioned_docs/version-v1.1.x/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
+++ b/versioned_docs/version-v1.1.x/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
@@ -19,6 +19,7 @@ OpenChoreo plugins are published to **GitHub Packages** under the [`@openchoreo`
 ## 1. Prerequisites
 
 - A Backstage workspace on the [supported Backstage version](./compatibility-matrix.mdx). This guide pins to **Backstage `1.43.3`**.
+- The workspace must be scaffolded with the **legacy** frontend system: `npx @backstage/create-app@latest --legacy`. Current `create-app` versions default to the new declarative frontend system (`createApp({ features: [...] })` in `App.tsx`), which does not match the §4.3 edits below — those edits rely on the legacy structure (`apis.ts`, `createApp({ apis, plugins, bindRoutes })`, and `components/catalog/EntityPage.tsx`).
 - Node.js **20 or 22**, Yarn **4.4.1**.
 - Access to a running OpenChoreo control plane (local `k3d` or a deployed cluster).
 - OAuth client credentials for the OpenChoreo Identity Provider (used by the catalog sync and user sign-in). On `k3d` the helm chart pre-seeds these; for a deployed cluster see [Identity configuration](../identity-configuration.mdx).
@@ -660,7 +661,7 @@ These are **k3d dev cluster seed values, not real secrets** — never use them a
 ### 4.5 Verify
 
 ```bash
-yarn dev
+yarn start
 ```
 
 Expected:
@@ -768,7 +769,7 @@ openchoreo:
 
 ### 5.5 Verify
 
-Restart `yarn dev`. Open any Component → the **Logs**, **Metrics**, **Alerts** tabs appear. Open any System → **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
+Restart `yarn start`. Open any Component → the **Logs**, **Metrics**, **Alerts** tabs appear. Open any System → **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
 
 ---
 
@@ -830,7 +831,7 @@ openchoreo:
 
 ### 6.5 Verify
 
-Restart `yarn dev`. Open any Component → the **Build** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
+Restart `yarn start`. Open any Component → the **Build** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
 
 ---
 
@@ -894,7 +895,7 @@ import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
 
 ### 7.4 Verify
 
-Restart `yarn dev`. Navigate to `http://localhost:3000/workflows` → see the org-level workflow list.
+Restart `yarn start`. Navigate to `http://localhost:3000/workflows` → see the org-level workflow list.
 
 ---
 
@@ -919,6 +920,38 @@ Delete the import and JSX usage from `packages/app/src/components/Root/Root.tsx`
 ```
 
 You can leave the `@backstage/plugin-notifications` package installed; it just shouldn't be referenced from the rendered tree.
+
+### Backend cleanup
+
+The `create-app --legacy` scaffold also registers four backend modules in `packages/backend/src/index.ts` that are not pinned by the [compatibility matrix](./compatibility-matrix.mdx). They drift to versions outside the 1.43.3 release line and crash the backend at startup with `TypeError: Cannot read properties of undefined (reading 'id')` (see [Troubleshooting → Backend module startup fails](./troubleshooting.mdx#backend-module-startup-fails-with-cannot-read-properties-of-undefined-reading-id)).
+
+Remove their `backend.add(...)` lines from `packages/backend/src/index.ts`:
+
+```ts
+// Remove:
+// backend.add(import('@backstage/plugin-scaffolder-backend-module-notifications'));
+// backend.add(import('@backstage/plugin-notifications-backend'));
+// backend.add(import('@backstage/plugin-signals-backend'));
+// backend.add(import('@backstage/plugin-mcp-actions-backend'));
+```
+
+Then drop the packages from `packages/backend/package.json`:
+
+```bash
+yarn workspace backend remove \
+  @backstage/plugin-scaffolder-backend-module-notifications \
+  @backstage/plugin-notifications-backend \
+  @backstage/plugin-signals-backend \
+  @backstage/plugin-mcp-actions-backend
+```
+
+The signals backend was paired with a `<SignalsDisplay />` component in `packages/app/src/App.tsx`. Remove that too so the frontend doesn't reference a backend that no longer exists:
+
+```tsx
+// Remove from packages/app/src/App.tsx:
+// import { SignalsDisplay } from '@backstage/plugin-signals';
+// <SignalsDisplay />
+```
 
 ---
 

--- a/versioned_docs/version-v1.1.x/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
+++ b/versioned_docs/version-v1.1.x/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
@@ -211,9 +211,31 @@ NotImplementedError: No implementation available for
 apiRef{plugin.openchoreo-observability.service}
 ```
 
-**Cause:** the Environments tab consumes the observability API (`openchoreoObservabilityPlugin`) for incident counts. If you didn't install the observability tab pack, the plugin's API factory is never registered.
+**Cause:** the Environments tab consumes the observability API (`openchoreoObservabilityPlugin`) for incident counts. Earlier 1.1.0 tarballs of `@openchoreo/backstage-plugin` resolved this API with `useApi()`, which throws when no factory is registered — so the Deploy tab crashed unless the observability tab pack was also installed.
 
-**Fix:** install `@openchoreo/backstage-plugin-openchoreo-observability` + its backend counterpart and register `openchoreoObservabilityPlugin` in `createApp({ plugins: [...] })`. See the [installation guide → Observability tabs](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional).
+This was fixed in `@openchoreo/backstage-plugin@1.1.0` (republished). The hook now uses `useApiHolder().get()`, which returns `undefined` when observability is not installed; the Deploy tab renders environment tiles cleanly without incident chips.
+
+**Fix:** force a fresh resolve so yarn pulls the new tarball:
+
+```bash
+# from your Backstage workspace root
+rm -rf node_modules yarn.lock .yarn/install-state.gz .yarn/cache
+yarn install
+```
+
+Then restart `yarn start`. Confirm the installed tarball is the rebuilt one:
+
+```bash
+node -e "console.log(require('./node_modules/@openchoreo/backstage-plugin/package.json').version)"
+# should print: 1.1.0
+
+grep -E "useApiHolder" node_modules/@openchoreo/backstage-plugin/dist/index.cjs.js | head -1
+# should print at least one match (proves the rebuilt code is in node_modules)
+```
+
+If the second command prints nothing, your yarn cache or lockfile is still pinning the old tarball. Run `yarn up @openchoreo/backstage-plugin` to force re-resolution.
+
+If you actually want incident counts on the Deploy tab, install the observability tab pack as documented in the [installation guide → Observability tabs](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional) — it registers the API factory and feeds real incident data into the same UI.
 
 ## `openchoreo-auth` provider misconfigured
 
@@ -242,7 +264,7 @@ HTTP 401: Unauthorized
 **Cause:** one of two things, in order of likelihood:
 
 1. **`OpenChoreoPermissionApi` not registered** in `packages/app/src/apis.ts`. The default `PermissionClient` bypasses `fetchApi` entirely and never gets the IDP token, so every authorize call fails. Fix: [Override `permissionApi`](./installing-into-existing-backstage.mdx#permission-api).
-2. **Your user genuinely has no capabilities** in OpenChoreo. The IDP token is valid but Thunder hasn't granted them `release-binding:read` / `environment:read`. Confirm with `LOG_LEVEL=debug yarn dev`, hit a Deploy tab, and grep backend logs for `[AUTHZ] Parsed capabilities` — that dumps what the OpenChoreo authz service returned. If the expected capabilities aren't there, fix the user's role bindings on the OpenChoreo control plane, not in Backstage.
+2. **Your user genuinely has no capabilities** in OpenChoreo. The IDP token is valid but Thunder hasn't granted them `release-binding:read` / `environment:read`. Confirm with `LOG_LEVEL=debug yarn start`, hit a Deploy tab, and grep backend logs for `[AUTHZ] Parsed capabilities` — that dumps what the OpenChoreo authz service returned. If the expected capabilities aren't there, fix the user's role bindings on the OpenChoreo control plane, not in Backstage.
 
 ## `JWKSNoMatchingKey` warnings in permission backend logs
 


### PR DESCRIPTION
Following the round-1 fixes through a clean install on a fresh create-app workspace surfaced four more gaps. Patches both docs/ (next) and versioned_docs/version-v1.1.x/ (the v1.1.x snapshot the live site serves).

1. §4.5/§5.5/§6.5/§7.4/troubleshooting referenced `yarn dev`, but the create-app scaffold (both --legacy and current default) provides `yarn start`, not `yarn dev`. Replaced 9 occurrences.

2. §1 Prerequisites did not call out that the workspace must be scaffolded with `--legacy`. Current create-app defaults to the v2 declarative frontend system (createApp({ features: [...] })) which does not match the §4.3 edits (apis.ts, createApp({ apis, plugins, bindRoutes }), components/catalog/EntityPage.tsx). Added an explicit bullet.

3. §8 only removed the frontend @backstage/plugin-notifications. The create-app scaffold also registers four backend modules (-notifications-backend, -signals-backend, -mcp-actions-backend, -scaffolder-backend-module-notifications) that are not in the compatibility-matrix resolutions, drift outside 1.43.3, and crash the backend with TypeError: Cannot read properties of undefined (reading 'id'). Added a "Backend cleanup" subsection covering all four removals plus the paired SignalsDisplay component in App.tsx.

4. troubleshooting.mdx "Observability API factory missing on Environments tab" entry was outdated — it instructed users to install §5 as a workaround. The underlying useApi/useApiHolder bug is now fixed in the rebuilt @openchoreo/backstage-plugin@ 1.1.0. Rewrote the entry to identify the symptom as a stale local install and document the recovery (drop node_modules + yarn.lock + .yarn/install-state + yarn cache, then reinstall).

Verified with `npm run build` — both trees compile, 591 markdown files exported, no MDX or link errors.
