### PR TITLE
fix: redirect /docs/<latestVersion>/* to unprefixed /docs/* paths

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,10 @@ import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import path from 'path';
+import versions from './versions.json';
+
+// Latest docs version (Docusaurus prepends new versions to versions.json).
+const latestVersion = versions[0];
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
@@ -54,6 +58,36 @@ const config: Config = {
     './plugins/docusaurus-plugin-markdown-export',
     './plugins/docusaurus-plugin-llms-txt',
     './plugins/docusaurus-plugin-docs-scripts',
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Docusaurus serves the latest docs version unprefixed (/docs/foo),
+        // so /docs/<latestVersion>/foo 404s. For each real /docs/foo page,
+        // register /docs/<latestVersion>/foo as an alias that redirects to it.
+        // Reads latestVersion from versions.json, so no manual updates per release.
+        createRedirects(existingPath: string) {
+          const isDocsPath =
+            existingPath === '/docs' || existingPath.startsWith('/docs/');
+          const isVersionedDocsPath = versions.some((v) => {
+            const versionedDocsPath = `/docs/${v}`;
+            return (
+              existingPath === versionedDocsPath ||
+              existingPath.startsWith(`${versionedDocsPath}/`)
+            );
+          });
+          const isLatestDocsPath =
+            isDocsPath && !isVersionedDocsPath;
+
+          if (!isLatestDocsPath) return undefined;
+
+          const aliasWithLatestVersionPrefix = existingPath.replace(
+            /^\/docs/,
+            `/docs/${latestVersion}`,
+          );
+          return [aliasWithLatestVersionPrefix];
+        },
+      },
+    ],
     function webpackPolyfillsPlugin() {
       const webpack = require('webpack');
       return {
@@ -135,7 +169,25 @@ const config: Config = {
       } satisfies Preset.Options,
     ],
   ],
-  
+
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `
+(function () {
+  var latestDocsVersionPath = '/docs/${latestVersion}';
+  var pathname = window.location.pathname;
+  var normalizedPathname =
+    pathname !== '/' && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+
+  if (normalizedPathname === latestDocsVersionPath) {
+    window.location.replace('/docs/' + window.location.search + window.location.hash);
+  }
+})();
+`,
+    },
+  ],
 
   clientModules: [
     path.join(__dirname, 'src/clientModules/gtagGuard.ts'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docsearch/docusaurus-adapter": "^4.6.3",
         "@docusaurus/core": "^3.9.2",
+        "@docusaurus/plugin-client-redirects": "3.9.2",
         "@docusaurus/preset-classic": "^3.9.2",
         "@docusaurus/theme-mermaid": "^3.9.2",
         "@mdx-js/react": "^3.1.1",
@@ -3615,6 +3616,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+      "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
@@ -18045,9 +18070,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@docsearch/docusaurus-adapter": "^4.6.3",
     "@docusaurus/core": "^3.9.2",
+    "@docusaurus/plugin-client-redirects": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.1.1",


### PR DESCRIPTION
## Purpose
This PR adds a production build redirection:
` /docs/<latestVersion>/*` --> `/docs/*`

> Note: The redirection doesn't work in the dev server. To test locally: `npm run build && npm run serve`

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3566

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
