### PR TITLE
docs(ecosystem): add ecosystem contribution guide link

### DIFF
--- a/docs/ecosystem/overview.md
+++ b/docs/ecosystem/overview.md
@@ -1,0 +1,34 @@
+---
+title: Ecosystem
+description: Extend OpenChoreo with modules, integrations, agents, and more.
+sidebar_position: 1
+---
+
+# OpenChoreo Ecosystem
+
+The OpenChoreo Ecosystem provides community-driven extensions that seamlessly integrate with the platform to expand its capabilities. Browse the [Ecosystem Catalog](/ecosystem) to discover available extensions.
+
+OpenChoreo is designed to be extensible. Rather than bundling every possible integration into the core platform, the ecosystem approach lets you choose the tools that fit your needs, stay current as extensions evolve independently, and contribute back to benefit from the community's work.
+
+## Extension Types
+
+| Type                | Description                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Modules**         | First-class platform extensions that plug into OpenChoreo's interfaces.                                               |
+| **Integrations**    | Integrate with external tools via tutorial-based configuration.                                                       |
+| **Agents**          | AI-powered assistants that analyze platform data and automate operational tasks.                                      |
+| **Skills**          | Reusable capabilities that agents invoke.                                                                             |
+| **Component Types** | Reusable templates that let platform engineers manage complexity while providing developers with a simpler interface. |
+| **Workflows**       | Platform engineer-defined templates for component CI builds and other automation tasks.                               |
+
+## Contributing
+
+The ecosystem is open to contributions. Submit your extension to the appropriate repository:
+
+- [openchoreo/community-modules](https://github.com/openchoreo/community-modules)
+- [openchoreo/skills](https://github.com/openchoreo/skills)
+
+### Get Help
+
+- [CNCF Slack (#openchoreo)](https://slack.cncf.io/)
+- [GitHub Discussions](https://github.com/openchoreo/openchoreo/discussions)

--- a/docs/ecosystem/overview.md
+++ b/docs/ecosystem/overview.md
@@ -16,8 +16,8 @@ OpenChoreo is designed to be extensible. Rather than bundling every possible int
 | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | **Modules**         | First-class platform extensions that plug into OpenChoreo's interfaces.                                               |
 | **Integrations**    | Integrate with external tools via tutorial-based configuration.                                                       |
-| **Agents**          | AI-powered assistants that analyze platform data and automate operational tasks.                                      |
-| **Skills**          | Reusable capabilities that agents invoke.                                                                             |
+| **Agents**          | AI-powered agents that analyze and perform operational tasks within OpenChoreo.                                       |
+| **Skills**          | Reusable capabilities that coding agents invoke.                                                                      |
 | **Component Types** | Reusable templates that let platform engineers manage complexity while providing developers with a simpler interface. |
 | **Workflows**       | Platform engineer-defined templates for component CI builds and other automation tasks.                               |
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -355,6 +355,11 @@ const sidebars: SidebarsConfig = {
       ],
     },
     {
+      type: "doc",
+      id: "ecosystem/overview",
+      label: "Ecosystem",
+    },
+    {
       type: "category",
       label: "Working with AI",
       link: {

--- a/src/pages/ecosystem.module.css
+++ b/src/pages/ecosystem.module.css
@@ -15,6 +15,22 @@
   padding: 2.5rem 0 1.75rem;
 }
 
+.heroHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .heroHeader {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+}
+
 .heroTitle {
   font-size: 2.25rem;
   font-weight: 700;
@@ -27,6 +43,39 @@
   font-size: 1.05rem;
   color: var(--ifm-color-emphasis-700);
   margin: 0 0 1.75rem 0;
+}
+
+.addModuleButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-700);
+  background: #fff;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.addModuleButton:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary-light);
+  text-decoration: none;
+}
+
+.addIcon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
 }
 
 .searchWrap {
@@ -406,4 +455,15 @@ html[data-theme='dark'] .emptyState {
 html[data-theme='dark'] .pageButton:disabled {
   background: var(--ifm-color-emphasis-200);
   color: var(--ifm-color-emphasis-500);
+}
+
+html[data-theme='dark'] .addModuleButton {
+  background: #1c1c1e;
+  color: #e4e4e7;
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+html[data-theme='dark'] .addModuleButton:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
 }

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -177,7 +177,7 @@ export default function Ecosystem(): ReactNode {
                     strokeWidth="2"
                   />
                 </svg>
-                Add Module
+                Add to Ecosystem
               </a>
             </div>
             <p className={styles.heroSubtitle}>

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -157,7 +157,29 @@ export default function Ecosystem(): ReactNode {
         {/* HERO */}
         <section className={styles.hero}>
           <div className={styles.container}>
-            <h1 className={styles.heroTitle}>OpenChoreo Ecosystem</h1>
+            <div className={styles.heroHeader}>
+              <h1 className={styles.heroTitle}>OpenChoreo Ecosystem</h1>
+              <a
+                href="#"
+                className={styles.addModuleButton}
+              >
+                <svg
+                  className={styles.addIcon}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 4v16m8-8H4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                  />
+                </svg>
+                Add a module
+              </a>
+            </div>
             <p className={styles.heroSubtitle}>
               Discover modules, integrations, agents, skills, component types, and workflows to extend OpenChoreo
             </p>

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -160,7 +160,7 @@ export default function Ecosystem(): ReactNode {
             <div className={styles.heroHeader}>
               <h1 className={styles.heroTitle}>OpenChoreo Ecosystem</h1>
               <a
-                href="#"
+                href="/docs/next/ecosystem/overview"
                 className={styles.addModuleButton}
               >
                 <svg
@@ -177,7 +177,7 @@ export default function Ecosystem(): ReactNode {
                     strokeWidth="2"
                   />
                 </svg>
-                Add a module
+                Contribute
               </a>
             </div>
             <p className={styles.heroSubtitle}>

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -177,7 +177,7 @@ export default function Ecosystem(): ReactNode {
                     strokeWidth="2"
                   />
                 </svg>
-                Contribute
+                Add Module
               </a>
             </div>
             <p className={styles.heroSubtitle}>


### PR DESCRIPTION
## Summary
- Add ecosystem overview documentation explaining extension types (Modules, Integrations, Agents, Skills, Component Types, Workflows)                                                                    
- Add "Add to Ecosytem" button on ecosystem catalog page linking to the overview                                                                                                                              
- Add ecosystem entry to docs sidebar    

## Screenshot
<img width="1323" height="679" alt="Screenshot 2026-05-21 at 14 22 31" src="https://github.com/user-attachments/assets/e84c6c68-cf8a-4bca-9844-3e18daca8bf4" />



## Related issue
https://github.com/openchoreo/openchoreo/discussions/3252#discussioncomment-16984038
