### PR TITLE
feat: list FinOps Agent in ecosystem page

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -621,7 +621,25 @@
     ],
     "logoUrl": "",
     "author": "OpenChoreo",
-    "sourceUrl": "https://openchoreo.dev/docs/next/ai/sre-agent/",
+    "sourceUrl": "https://openchoreo.dev/docs/ai/sre-agent/",
+    "default": false,
+    "released": true
+  },
+  {
+    "id": "finops-agent",
+    "group": "agent",
+    "name": "FinOps Agent",
+    "description": "AI agent that helps teams analyze cloud costs and identify optimization opportunities",
+    "category": "AI",
+    "tags": [
+      "ai-agent",
+      "finops",
+      "cost-optimization",
+      "cloud-cost"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://openchoreo.dev/docs/ai/finops-agent/",
     "default": false,
     "released": true
   },


### PR DESCRIPTION
## Purpose
- List FinOps agent in ecosystem page
- Change the documentation link of the SRE agent to use the stable version instead of the `next` version

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3454

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
