### PR TITLE
docs: add openchoreo-import skill to marketplace catalog

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -729,6 +729,25 @@
     "released": true
   },
   {
+    "id": "skill-openchoreo-import",
+    "group": "skill",
+    "name": "OpenChoreo Import",
+    "description": "Plans an OpenChoreo migration from a Helm chart, Kustomize overlay, Docker Compose file, or raw Kubernetes YAML. Renders the source, classifies what fits OpenChoreo's primitives, surfaces a fit verdict, and produces an interactive plan with per-Project apply steps. Plans only — never applies to a cluster.",
+    "category": "AI",
+    "tags": [
+      "import",
+      "migration",
+      "helm",
+      "kustomize",
+      "compose"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-import",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "componenttype-service",
     "group": "component-type",
     "name": "Service",


### PR DESCRIPTION
## Summary

- Adds the `openchoreo-import` skill to `src/data/marketplace-plugins.json` so it surfaces on the ecosystem page (`openchoreo.dev/ecosystem`).
- New entry slots in right after `skill-openchoreo-developer-gitops`, keeping all skills grouped together.

The skill itself is in [openchoreo/skills#9](https://github.com/openchoreo/skills/pull/9) — this docs PR is the accompanying catalog entry expected by the contributor workflow.

## What the skill does

`openchoreo-import` plans an OpenChoreo migration from a Helm chart, Kustomize overlay, Docker Compose file, or raw Kubernetes YAML. Renders the source, classifies what fits OpenChoreo's primitives, surfaces a fit verdict, and produces an interactive plan with per-Project apply steps. Plans only — never applies to a cluster.

## Test plan

- [ ] CI passes
- [ ] `openchoreo.dev/ecosystem` lists "OpenChoreo Import" under the AI category once deployed
- [ ] Entry links resolve: `sourceUrl` → openchoreo/skills/tree/main/skills/openchoreo-import