### PR TITLE
remove Learn More CTA

### DIFF
--- a/src/components/HomepageHero/index.tsx
+++ b/src/components/HomepageHero/index.tsx
@@ -37,13 +37,10 @@ export default function HomepageHero(): ReactNode {
 
         {/* Call-to-action buttons */}
         <div className={styles.heroButtons}>
-          <Button to="https://demo.openchoreo.wso2.com/">
-            Try in Browser
-          </Button>
+          <Button to="https://demo.openchoreo.wso2.com/">Try It Now</Button>
           <Button to={useBaseUrl("/docs/getting-started/quick-start-guide/")}>
             Quick Start
           </Button>
-          <Button to={useBaseUrl("/docs/")}>Learn More</Button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Purpose
Removed the Learn More CTA
Changed Try in Browser text to **Try It Now**
<img width="787" height="424" alt="Screenshot 2026-05-29 at 11 42 25" src="https://github.com/user-attachments/assets/cae21dbf-5410-46ad-8e52-c29a0890d035" />

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
