### PR TITLE
chore: update release information for v1.1.1

### DIFF
--- a/docs/releases/release-and-support-process.md
+++ b/docs/releases/release-and-support-process.md
@@ -30,7 +30,7 @@ Community support is provided for the latest three minor release lines. Publish 
 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
-| v1.1          | 2026-May-18 | v1.1.0       | Actively Supported | TBD                     | TBD         |
+| v1.1          | 2026-May-18 | v1.1.1       | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.1       | Actively Supported | TBD                     | TBD         |
 
 # Planned Future Minor Releases

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -195,9 +195,9 @@ const config: Config = {
 
   themeConfig: {
     announcementBar: {
-      id: 'release_v1_1_0',
+      id: 'release_v1_1_1',
       content:
-        '🎉️ OpenChoreo <a target="_blank" rel="noopener noreferrer" href="https://github.com/openchoreo/openchoreo/releases/tag/v1.1.0">v1.1.0</a> has been released! 🎉',
+        '🎉️ OpenChoreo <a target="_blank" rel="noopener noreferrer" href="https://github.com/openchoreo/openchoreo/releases/tag/v1.1.1">v1.1.1</a> has been released! 🎉',
       isCloseable: true,
     },
     docsearch: {

--- a/versioned_docs/version-v1.1.x/_constants.mdx
+++ b/versioned_docs/version-v1.1.x/_constants.mdx
@@ -1,9 +1,9 @@
 [//] # (This file stores the constants used across the documentation.)
 
 export const versions = {
-  dockerTag: "v1.1.0",
+  dockerTag: "v1.1.1",
   githubRef: "release-v1.1", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
-  helmChart: "1.1.0",
+  helmChart: "1.1.1",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };
 

--- a/versioned_docs/version-v1.1.x/changelog.md
+++ b/versioned_docs/version-v1.1.x/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version        | Date       | Changelog                                                                                 |
 | -------------- | ---------- | ----------------------------------------------------------------------------------------- |
+| v1.1.1        | 2026-05-29 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v111) |
 | v1.1.0        | 2026-05-18 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v110) |
 | v1.0.1         | 2026-05-07 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v101) |
 | v1.0.0         | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)         |


### PR DESCRIPTION
## Purpose

Update release information for v1.1.1

- Updated announcement bar to reflect the new release version v1.1.1.
- Modified release and support process documentation to indicate the latest patch as v1.1.1.
- Changed constants in documentation to reference the new docker tag and helm chart version v1.1.1.
- Added v1.1.1 entry to the changelog with a link to the detailed changelog.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3643

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
