### PR TITLE
Fix google site link issue

### DIFF
--- a/src/theme/DocBreadcrumbs/MarkdownButton.tsx
+++ b/src/theme/DocBreadcrumbs/MarkdownButton.tsx
@@ -96,10 +96,11 @@ export default function MarkdownButton({
         type="button"
         aria-expanded={isOpen}
         aria-haspopup="true"
-        aria-label="Copy page URL"
+        aria-label="Page actions"
+        title="Page actions"
       >
         <CopyIcon />
-        <span data-nosnippet>{copied ? "Copied!" : "Copy page"}</span>
+        {copied && <span aria-hidden="true">Copied!</span>}
         <ChevronIcon isOpen={isOpen} />
       </button>
 


### PR DESCRIPTION
## Purpose
Fix Google sitelink issue showing "Copy page" URL in search result previews.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
