### PR TITLE
Adding a seperate page for the Slack channel

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -23,7 +23,7 @@ const config: Config = {
   url: 'https://savisaluwadana.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/openchoreo.github.io/',
   // Set true for GitHub pages deployment.
   trailingSlash: true,
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://openchoreo.dev',
+  url: 'https://savisaluwadana.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
@@ -29,7 +29,7 @@ const config: Config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'openchoreo', // Usually your GitHub org/user name.
+  organizationName: 'savisaluwadana', // Usually your GitHub org/user name.
   projectName: 'openchoreo.github.io', // Usually your repo name.
 
   onBrokenLinks: 'throw',
@@ -141,7 +141,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/openchoreo/openchoreo.github.io/edit/main/',
+            'https://github.com/savisaluwadana/openchoreo.github.io/edit/main/',
         },
         blog: {
           showReadingTime: true,
@@ -153,7 +153,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/openchoreo/openchoreo.github.io/edit/main/',
+            'https://github.com/savisaluwadana/openchoreo.github.io/edit/main/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'throw',
           onInlineAuthors: 'throw',
@@ -266,7 +266,7 @@ const config: Config = {
           'aria-label': 'GitHub repository',
         },
         {
-          href: 'https://slack.cncf.io/',
+          to: '/slack',
           position: 'right',
           className: 'header-slack-link',
           'aria-label': 'Slack channel',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,16 +20,16 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://savisaluwadana.github.io',
+  url: 'https://openchoreo.dev',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/openchoreo.github.io/',
+  baseUrl: '/',
   // Set true for GitHub pages deployment.
   trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'savisaluwadana', // Usually your GitHub org/user name.
+  organizationName: 'openchoreo', // Usually your GitHub org/user name.
   projectName: 'openchoreo.github.io', // Usually your repo name.
 
   onBrokenLinks: 'throw',
@@ -141,7 +141,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/savisaluwadana/openchoreo.github.io/edit/main/',
+            'https://github.com/openchoreo/openchoreo.github.io/edit/main/',
         },
         blog: {
           showReadingTime: true,
@@ -153,7 +153,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/savisaluwadana/openchoreo.github.io/edit/main/',
+            'https://github.com/openchoreo/openchoreo.github.io/edit/main/',
           // Useful options to enforce blogging best practices
           onInlineTags: 'throw',
           onInlineAuthors: 'throw',

--- a/src/components/Community/index.tsx
+++ b/src/components/Community/index.tsx
@@ -40,7 +40,7 @@ const communityActions: CommunityAction[] = [
   {
     description: 'Join #openchoreo channel to get real-time support, ask questions, and engage with other users.',
     buttonText: 'Join CNCF Slack',
-    link: 'https://slack.cncf.io/',
+    link: '/slack',
     iconLight: '/img/icons/community-icon-slack.png',
     iconDark: '/img/icons/community-icon-slack-dark.png'
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -138,6 +138,9 @@ html[data-theme='dark'] {
   height: 24px;
   display: flex;
   background: var(--ifm-navbar-link-color);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
 }
 
 .header-github-link:hover,
@@ -150,7 +153,7 @@ html[data-theme='dark'] {
 }
 
 .header-slack-link:before {
-  mask-image: url("data:image/svg+xml,%3Csvg role='img' viewBox='63 63 144 144' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3ESlack%3C/title%3E%3Cpath d='M99.4,151.2c0,7.1-5.8,12.9-12.9,12.9s-12.9-5.8-12.9-12.9c0-7.1,5.8-12.9,12.9-12.9h12.9V151.2z M105.9,151.2c0-7.1,5.8-12.9,12.9-12.9s12.9,5.8,12.9,12.9v32.3c0,7.1-5.8,12.9-12.9,12.9s-12.9-5.8-12.9-12.9C105.9,183.5,105.9,151.2,105.9,151.2z M118.8,99.4c-7.1,0-12.9-5.8-12.9-12.9s5.8-12.9,12.9-12.9s12.9,5.8,12.9,12.9v12.9H118.8z M118.8,105.9c7.1,0,12.9,5.8,12.9,12.9s-5.8,12.9-12.9,12.9H86.5c-7.1,0-12.9-5.8-12.9-12.9s5.8-12.9,12.9-12.9C86.5,105.9,118.8,105.9,118.8,105.9z M170.6,118.8c0-7.1,5.8-12.9,12.9-12.9c7.1,0,12.9,5.8,12.9,12.9s-5.8,12.9-12.9,12.9h-12.9V118.8z M164.1,118.8c0,7.1-5.8,12.9-12.9,12.9c-7.1,0-12.9-5.8-12.9-12.9V86.5c0-7.1,5.8-12.9,12.9-12.9c7.1,0,12.9,5.8,12.9,12.9V118.8z M151.2,170.6c7.1,0,12.9,5.8,12.9,12.9c0,7.1-5.8,12.9-12.9,12.9c-7.1,0-12.9-5.8-12.9-12.9v-12.9H151.2z M151.2,164.1c-7.1,0-12.9-5.8-12.9-12.9c0-7.1,5.8-12.9,12.9-12.9h32.3c7.1,0,12.9,5.8,12.9,12.9c0,7.1-5.8,12.9-12.9,12.9H151.2z'/%3E%3C/svg%3E");
+  background: url('/img/icons/community-icon-slack.png') center/contain no-repeat;
 }
 
 /* Richer visual layout for workflow guides */

--- a/src/pages/slack.module.css
+++ b/src/pages/slack.module.css
@@ -104,18 +104,6 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
-.default {
-  border-color: rgba(15, 23, 42, 0.08);
-}
-
-.highlight {
-  border-color: rgba(43, 140, 247, 0.38);
-  box-shadow:
-    0 12px 26px rgba(43, 140, 247, 0.09),
-    0 0 0 1px rgba(43, 140, 247, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
-}
-
 .optionContent {
   display: flex;
   align-items: flex-start;
@@ -179,29 +167,15 @@
   border-radius: 8px;
   font-size: 0.9rem;
   font-weight: 700;
-}
-
-.secondary {
   background: #fff;
   color: var(--ifm-color-primary);
   border-color: var(--ifm-color-primary);
 }
 
-.secondary:hover {
-  background: rgba(43, 140, 247, 0.06);
-  color: var(--ifm-color-primary);
-}
-
-.primary {
+.optionButton:hover {
   background: var(--ifm-color-primary);
   color: #fff;
   border-color: var(--ifm-color-primary);
-}
-
-.primary:hover {
-  background: var(--ifm-color-primary-dark);
-  color: #fff;
-  border-color: var(--ifm-color-primary-dark);
 }
 
 [data-theme='dark'] .page {
@@ -223,14 +197,6 @@
   border-color: rgba(148, 163, 184, 0.18);
 }
 
-[data-theme='dark'] .highlight {
-  border-color: rgba(43, 140, 247, 0.5);
-  box-shadow:
-    0 18px 36px rgba(43, 140, 247, 0.16),
-    0 22px 40px rgba(2, 6, 23, 0.55),
-    0 0 0 1px rgba(43, 140, 247, 0.16);
-}
-
 [data-theme='dark'] .optionDescription {
   color: var(--ifm-color-emphasis-600);
 }
@@ -245,14 +211,15 @@
   background: rgba(43, 140, 247, 0.16);
 }
 
-[data-theme='dark'] .secondary {
+[data-theme='dark'] .optionButton {
   background: rgba(15, 23, 42, 0.7);
   color: var(--ifm-color-primary-light);
 }
 
-[data-theme='dark'] .secondary:hover {
-  background: rgba(43, 140, 247, 0.14);
-  color: var(--ifm-color-primary-light);
+[data-theme='dark'] .optionButton:hover {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  border-color: var(--ifm-color-primary);
 }
 
 @media (max-width: 996px) {

--- a/src/pages/slack.module.css
+++ b/src/pages/slack.module.css
@@ -1,0 +1,335 @@
+.page {
+  padding: 2.75rem 0 5rem;
+  background: #f5f6f7;
+}
+
+.shell {
+  box-sizing: border-box;
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 2.5rem 2.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 24px;
+  background: var(--ifm-card-background-color);
+  box-shadow:
+    0 22px 56px rgba(15, 23, 42, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+}
+
+.section {
+  width: 100%;
+  text-align: center;
+}
+
+.iconWrap {
+  width: 72px;
+  height: 72px;
+  border-radius: 18px;
+  margin: 0 auto 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  box-shadow:
+    0 12px 30px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
+}
+
+.icon {
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+}
+
+.header {
+  max-width: 920px;
+  margin: 0 auto;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--ifm-heading-color);
+}
+
+.subtitle {
+  max-width: 640px;
+  margin: 0.75rem auto 0;
+  font-size: 1.2rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.titleUnderline {
+  display: block;
+  width: 80px;
+  height: 4px;
+  margin: 1.25rem auto 0;
+  border-radius: 2px;
+  background: var(--ifm-color-primary);
+}
+
+.prompt {
+  max-width: 720px;
+  margin: 1.5rem auto 0;
+  font-size: 1.15rem;
+  line-height: 1.45;
+}
+
+.optionsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  justify-content: center;
+  gap: 1.5rem;
+  max-width: 760px;
+  margin: 1.5rem auto 0;
+}
+
+.optionCard {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 190px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.125rem;
+  padding: 1.25rem;
+  text-align: left;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 20px;
+  background: var(--ifm-card-background-color);
+  box-shadow:
+    0 8px 22px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.default {
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+.highlight {
+  border-color: rgba(43, 140, 247, 0.38);
+  box-shadow:
+    0 12px 26px rgba(43, 140, 247, 0.09),
+    0 0 0 1px rgba(43, 140, 247, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+}
+
+.optionContent {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.optionIcon {
+  width: 50px;
+  height: 50px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.negative {
+  color: #f04438;
+  background: #fff1f1;
+}
+
+.positive {
+  color: #2b8cf7;
+  background: #eef5ff;
+}
+
+.optionText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding-top: 0.05rem;
+}
+
+.optionTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--ifm-heading-color);
+}
+
+.optionDescription {
+  max-width: 240px;
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.optionButton {
+  width: auto;
+  min-width: 230px;
+  margin-top: auto;
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  min-height: auto;
+  align-self: center;
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.secondary {
+  background: #fff;
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+}
+
+.secondary:hover {
+  background: rgba(43, 140, 247, 0.06);
+  color: var(--ifm-color-primary);
+}
+
+.primary {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  border-color: var(--ifm-color-primary);
+}
+
+.primary:hover {
+  background: var(--ifm-color-primary-dark);
+  color: #fff;
+  border-color: var(--ifm-color-primary-dark);
+}
+
+[data-theme='dark'] .page {
+  background: var(--ifm-background-color);
+}
+
+[data-theme='dark'] .shell {
+  background: rgba(15, 23, 42, 0.96);
+  border-color: rgba(148, 163, 184, 0.1);
+  box-shadow:
+    0 28px 72px rgba(43, 140, 247, 0.18),
+    0 28px 70px rgba(2, 6, 23, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+[data-theme='dark'] .iconWrap,
+[data-theme='dark'] .optionCard {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(148, 163, 184, 0.18);
+}
+
+[data-theme='dark'] .highlight {
+  border-color: rgba(43, 140, 247, 0.5);
+  box-shadow:
+    0 18px 36px rgba(43, 140, 247, 0.16),
+    0 22px 40px rgba(2, 6, 23, 0.55),
+    0 0 0 1px rgba(43, 140, 247, 0.16);
+}
+
+[data-theme='dark'] .optionDescription {
+  color: var(--ifm-color-emphasis-600);
+}
+
+[data-theme='dark'] .negative {
+  color: #fda29b;
+  background: rgba(180, 35, 24, 0.22);
+}
+
+[data-theme='dark'] .positive {
+  color: #8bb8ff;
+  background: rgba(43, 140, 247, 0.16);
+}
+
+[data-theme='dark'] .secondary {
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--ifm-color-primary-light);
+}
+
+[data-theme='dark'] .secondary:hover {
+  background: rgba(43, 140, 247, 0.14);
+  color: var(--ifm-color-primary-light);
+}
+
+@media (max-width: 996px) {
+  .page {
+    padding: 1.25rem 0 1.5rem;
+  }
+
+  .page :global(.container) {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .shell {
+    padding: 1.5rem;
+  }
+
+  .optionsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+    max-width: 100%;
+  }
+
+  .optionCard {
+    padding: 1.15rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .shell {
+    padding: 1.25rem;
+    border-radius: 16px;
+  }
+
+  .iconWrap {
+    width: 56px;
+    height: 56px;
+    border-radius: 14px;
+  }
+
+  .icon {
+    width: 28px;
+    height: 28px;
+  }
+
+  .header h1 {
+    font-size: 2rem;
+  }
+
+  .prompt {
+    margin-top: 1rem;
+    font-size: 1.05rem;
+  }
+
+  .optionsGrid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .optionCard {
+    gap: 0.9rem;
+    padding: 1rem;
+  }
+
+  .optionContent {
+    gap: 0.8rem;
+  }
+
+  .optionIcon {
+    width: 50px;
+    height: 50px;
+  }
+
+  .optionButton {
+    width: 100%;
+    min-width: 0;
+    align-self: stretch;
+    padding: 0.55rem 1rem;
+  }
+
+}

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -70,7 +70,7 @@ export default function SlackCommunity(): ReactNode {
                   className={styles.icon}
                   sources={{
                     light: useBaseUrl('/img/icons/community-icon-slack.png'),
-                    dark: useBaseUrl('/img/icons/community-icon-slack-dark.png'),
+                    dark: useBaseUrl('/img/icons/community-icon-slack.png'),
                   }}
                 />
               </div>

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -14,8 +14,6 @@ type SlackOption = {
   buttonLink: string;
   icon: ReactNode;
   iconVariant: 'negative' | 'positive';
-  cardVariant: 'default' | 'highlight';
-  buttonVariant: 'secondary' | 'primary';
 };
 
 const slackOptions: SlackOption[] = [
@@ -26,8 +24,6 @@ const slackOptions: SlackOption[] = [
     buttonLink: 'https://slack.cncf.io/',
     icon: <UserPlus size={22} aria-hidden="true" />,
     iconVariant: 'negative',
-    cardVariant: 'default',
-    buttonVariant: 'secondary',
   },
   {
     title: "Yes, I'm already in",
@@ -36,14 +32,12 @@ const slackOptions: SlackOption[] = [
     buttonLink: 'https://cloud-native.slack.com/channels/openchoreo',
     icon: <Users size={22} aria-hidden="true" />,
     iconVariant: 'positive',
-    cardVariant: 'highlight',
-    buttonVariant: 'primary',
   },
 ];
 
 function SlackOptionCard({option}: {option: SlackOption}) {
   return (
-    <article className={`${styles.optionCard} ${styles[option.cardVariant]}`}>
+    <article className={styles.optionCard}>
       <div className={styles.optionContent}>
         <span className={`${styles.optionIcon} ${styles[option.iconVariant]}`} aria-hidden="true">
           {option.icon}
@@ -53,7 +47,7 @@ function SlackOptionCard({option}: {option: SlackOption}) {
           <p className={styles.optionDescription}>{option.description}</p>
         </div>
       </div>
-      <Button to={option.buttonLink} className={`${styles.optionButton} ${styles[option.buttonVariant]}`}>
+      <Button to={option.buttonLink} className={styles.optionButton}>
         <span>{option.buttonLabel}</span>
       </Button>
     </article>

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -32,7 +32,7 @@ const slackOptions: SlackOption[] = [
   {
     title: "Yes, I'm already in",
     description: 'Jump straight into the OpenChoreo channel and join the conversation.',
-    buttonLabel: 'Join openchoreo',
+    buttonLabel: 'Join OpenChoreo',
     buttonLink: 'https://cloud-native.slack.com/channels/openchoreo',
     icon: <Users size={22} aria-hidden="true" />,
     iconVariant: 'positive',

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -1,0 +1,103 @@
+import type {ReactNode} from 'react';
+import React from 'react';
+import Layout from '@theme/Layout';
+import ThemedImage from '@theme/ThemedImage';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import {UserPlus, Users} from 'lucide-react';
+import Button from '@site/src/components/common/Button';
+import styles from './slack.module.css';
+
+type SlackOption = {
+  title: string;
+  description: string;
+  buttonLabel: string;
+  buttonLink: string;
+  icon: ReactNode;
+  iconVariant: 'negative' | 'positive';
+  cardVariant: 'default' | 'highlight';
+  buttonVariant: 'secondary' | 'primary';
+};
+
+const slackOptions: SlackOption[] = [
+  {
+    title: 'No, not yet',
+    description: 'Get your CNCF Slack invite first, then join the OpenChoreo channel.',
+    buttonLabel: 'Get CNCF Slack Invite',
+    buttonLink: 'https://slack.cncf.io/',
+    icon: <UserPlus size={22} aria-hidden="true" />,
+    iconVariant: 'negative',
+    cardVariant: 'default',
+    buttonVariant: 'secondary',
+  },
+  {
+    title: "Yes, I'm already in",
+    description: 'Jump straight into the OpenChoreo channel and join the conversation.',
+    buttonLabel: 'Join openchoreo',
+    buttonLink: 'https://cloud-native.slack.com/channels/openchoreo',
+    icon: <Users size={22} aria-hidden="true" />,
+    iconVariant: 'positive',
+    cardVariant: 'highlight',
+    buttonVariant: 'primary',
+  },
+];
+
+function SlackOptionCard({option}: {option: SlackOption}) {
+  return (
+    <article className={`${styles.optionCard} ${styles[option.cardVariant]}`}>
+      <div className={styles.optionContent}>
+        <span className={`${styles.optionIcon} ${styles[option.iconVariant]}`} aria-hidden="true">
+          {option.icon}
+        </span>
+        <div className={styles.optionText}>
+          <h3 className={styles.optionTitle}>{option.title}</h3>
+          <p className={styles.optionDescription}>{option.description}</p>
+        </div>
+      </div>
+      <Button to={option.buttonLink} className={`${styles.optionButton} ${styles[option.buttonVariant]}`}>
+        <span>{option.buttonLabel}</span>
+      </Button>
+    </article>
+  );
+}
+
+export default function SlackCommunity(): ReactNode {
+  return (
+    <Layout
+      title="Slack Community"
+      description="Join the OpenChoreo community on CNCF Slack."
+    >
+      <main className={styles.page}>
+        <div className="container">
+          <section className={styles.shell}>
+            <div className={styles.section}>
+              <div className={styles.iconWrap}>
+                <ThemedImage
+                  alt="Slack"
+                  className={styles.icon}
+                  sources={{
+                    light: useBaseUrl('/img/icons/community-icon-slack.png'),
+                    dark: useBaseUrl('/img/icons/community-icon-slack-dark.png'),
+                  }}
+                />
+              </div>
+
+              <div className={styles.header}>
+                <h1>Join OpenChoreo on Slack</h1>
+                <p className={styles.subtitle}>Connect with the community, ask questions, and stay updated.</p>
+                <div className={styles.titleUnderline} />
+              </div>
+
+              <p className={styles.prompt}>Are you already a member of the CNCF Slack workspace?</p>
+
+              <div className={styles.optionsGrid}>
+                {slackOptions.map((option) => (
+                  <SlackOptionCard key={option.title} option={option} />
+                ))}
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Purpose
 updated the Slack page to include a direct link to the Openchoro channel alongside the standard CNCF workspace invite. This resolves the previous issue where users were invited to CNCF but lacked guidance on how to find Openchoro.
<img width="3024" height="1398" alt="image" src="https://github.com/user-attachments/assets/9d2fc5c2-22d6-4c6b-97db-fd6caf954088" />

## Related Issues
None
## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [X] Run `npm run start` to preview the changes locally
- [X] Run `npm run build` to ensure the build passes without errors
- [X] Verified all links are working (no broken links)
