### PR TITLE
fix: add flex sizing to   slack page container

### DIFF
--- a/src/pages/slack.module.css
+++ b/src/pages/slack.module.css
@@ -1,4 +1,5 @@
 .page {
+  flex: 1 0 auto;
   padding: 2.75rem 0 5rem;
   background: #f5f6f7;
 }


### PR DESCRIPTION
## Purpose
Fix the white space issue that occurs when slack page zoom out
## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [X] Updated `sidebars.ts` if adding a new documentation page
- [X] Run `npm run start` to preview the changes locally
- [X] Run `npm run build` to ensure the build passes without errors
- [X] Verified all links are working (no broken links)
