### PR TITLE
docs: fix observerURL browser-reachability guidance

### DIFF
--- a/docs/platform-engineer-guide/multi-cluster-connectivity.mdx
+++ b/docs/platform-engineer-guide/multi-cluster-connectivity.mdx
@@ -375,7 +375,7 @@ EOF
 
 ### Register an Observability Plane
 
-The `observerURL` must be reachable from the Control Plane cluster. In multi-cluster setups this cannot be an in-cluster `svc.cluster.local` address. Use the Observability Plane's external gateway URL or a routable DNS name instead.
+The `observerURL` must be reachable from the **user's browser** — the portal fetches telemetry directly from the Observer. Use the Observability Plane's external gateway URL and ensure `cors.allowedOrigins` includes the portal origin (e.g. `https://console.${DOMAIN}`) — see the [On Your Environment](../getting-started/try-it-out/on-your-environment.mdx) guide for the full gateway and CORS configuration.
 
 ```bash
 AGENT_CA=$(kubectl --context $REMOTE_CONTEXT get secret cluster-agent-tls \

--- a/docs/platform-engineer-guide/namespace-management.mdx
+++ b/docs/platform-engineer-guide/namespace-management.mdx
@@ -328,10 +328,14 @@ spec:
       clientCA:
         value: |
 $(echo "$OP_CA_CERT" | sed 's/^/ /')
-observerURL: http://observer.openchoreo-observability-plane.svc.cluster.local:8080
+observerURL: https://observer.<your-obs-domain>
 EOF`}
 
 </CodeBlock>
+
+:::note
+`observerURL` must be a browser-reachable HTTPS URL — the portal fetches telemetry directly from the Observer. Use the Observer's gateway-exposed hostname and ensure `observer.cors.allowedOrigins` includes the portal origin. See [On Your Environment](../getting-started/try-it-out/on-your-environment.mdx) for example gateway and CORS configuration.
+:::
 
 **Verification:**
 


### PR DESCRIPTION
## Summary

- `namespace-management.mdx`: replace `svc.cluster.local` example `observerURL` with a placeholder and add a note that it must be a browser-reachable HTTPS URL with CORS configured
- `multi-cluster-connectivity.mdx`: correct the reachability note (browser, not Control Plane) and add a CORS callout in the Register Observability Plane section

## Context

The portal fetches telemetry directly from the Observer (browser → Observer), so `observerURL` must be reachable from the user's browser. The `namespace-management.mdx` guide used a `svc.cluster.local` URL as its example, which came from the local k3d tryout values and is not appropriate for non-local deployments. The multi-cluster guide also described the URL as needing to be reachable from the Control Plane cluster, which is incorrect.

Ref: openchoreo/openchoreo#3722