### PR TITLE
feat: enhance events query schema with taskName and event type fields

### DIFF
--- a/static/api-specs/observability-logs-adapter-api.yaml
+++ b/static/api-specs/observability-logs-adapter-api.yaml
@@ -383,6 +383,9 @@ components:
           type: string
         workflowRunName:
           type: string
+        taskName:
+          type: string
+          description: Filter events to a specific workflow task
       required: [namespace]
 
     LogsQueryRequest:
@@ -544,9 +547,12 @@ components:
           type: string
           description: The timestamp of the event
           format: date-time
-        body:
+        message:
           type: string
           description: The event message
+        type:
+          type: string
+          description: The event type (e.g. Normal, Warning)
         reason:
           type: string
           description: The short, machine-readable reason for the event (e.g. SawCompletedJob)
@@ -790,4 +796,3 @@ components:
           type: string
           description: Human-readable error message
           example: "Missing required fields 'startTime' and 'endTime'"
-


### PR DESCRIPTION
## Purpose
This pull request updates the `observability-logs-adapter-api.yaml` specification to enhance event filtering and improve the event schema. The main changes include adding support for filtering by workflow task, renaming and clarifying event message fields, and introducing a new field for event type.

**API schema improvements:**

* Added a new optional `taskName` field to event filtering, allowing users to filter events for a specific workflow task.
* Renamed the `body` field to `message` in the event schema and clarified its purpose as the event message.
* Introduced a new `type` field in the event schema to specify the event type (e.g., Normal, Warning), sourced from the stored severity text.

Follow up for https://github.com/openchoreo/openchoreo.github.io/pull/686

## Related Issues
https://github.com/openchoreo/openchoreo/issues/1816

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
