### PR TITLE
docs: document GitHub Actions external CI integration for Backstage

### DIFF
--- a/docs/platform-engineer-guide/backstage-configuration.mdx
+++ b/docs/platform-engineer-guide/backstage-configuration.mdx
@@ -253,40 +253,45 @@ backstage:
 
 The chart sets the following environment variables on the Backstage container. Variables marked "from Secret" are read from the Secret referenced by `backstage.secretName`.
 
-| Variable                                                  | Description                                                            | Source                                                                                              |
-| --------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `NODE_ENV`                                                | Node.js environment                                                    | `backstage.env` (default: `production`)                                                             |
-| `LOG_LEVEL`                                               | Logging verbosity                                                      | `backstage.env` (default: `info`)                                                                   |
-| `PORT`                                                    | HTTP server port                                                       | `backstage.env` (default: `7007`)                                                                   |
-| `BACKSTAGE_BASE_URL`                                      | Public URL for OAuth redirects and links                               | `backstage.baseUrl`                                                                                 |
-| `OPENCHOREO_API_URL`                                      | Internal OpenChoreo API endpoint                                       | `backstage.openchoreoApi.url` (auto-configured)                                                     |
-| `BACKEND_SECRET`                                          | Session encryption key                                                 | from Secret (`backend-secret`)                                                                      |
-| `OPENCHOREO_AUTH_CLIENT_ID`                               | Sign-in client ID (authorization_code flow)                            | `backstage.auth.clientId`                                                                           |
-| `OPENCHOREO_AUTH_CLIENT_SECRET`                           | Sign-in client secret                                                  | from Secret (`client-secret`)                                                                       |
-| `OPENCHOREO_SERVICE_CLIENT_ID`                            | Service client ID (client_credentials flow — background tasks)         | `backstage.auth.serviceClientId` (falls back to `clientId`)                                         |
-| `OPENCHOREO_SERVICE_CLIENT_SECRET`                        | Service client secret                                                  | from Secret (key `backstage.auth.serviceClientSecretKey`, default: `client-secret`)                 |
-| `OPENCHOREO_AUTH_METADATA_URL`                            | OIDC discovery URL (omitted when unset)                                | `security.oidc.wellKnownEndpoint`                                                                   |
-| `OPENCHOREO_AUTH_AUTHORIZATION_URL`                       | OAuth authorization endpoint                                           | `security.oidc.authorizationUrl`                                                                    |
-| `OPENCHOREO_AUTH_TOKEN_URL`                               | OAuth token endpoint (shared by both clients)                          | `security.oidc.tokenUrl`                                                                            |
-| `OPENCHOREO_AUTH_OIDC_SCOPE`                              | OIDC scopes for the sign-in client                                     | `backstage.auth.oidcScope` (default: `openid profile email`)                                        |
-| `OPENCHOREO_AUTH_SCOPE`                                   | Scopes for the service client's client_credentials token request       | `backstage.auth.scope` (default: `""`)                                                              |
-| `OPENCHOREO_FEATURES_AUTH_ENABLED`                        | Enable authentication                                                  | `security.enabled`                                                                                  |
-| `OPENCHOREO_FEATURES_AUTHZ_ENABLED`                       | Enable authorization                                                   | `security.authz.enabled`                                                                            |
-| `OPENCHOREO_FEATURES_AUTH_REDIRECT_FLOW_ENABLED`          | Silent redirect vs sign-in popup                                       | `backstage.features.auth.redirectFlow.enabled`                                                      |
-| `OPENCHOREO_FEATURES_WORKFLOWS_ENABLED`                   | Show Workflows UI                                                      | `backstage.features.workflows.enabled`                                                              |
-| `OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED`               | Show Metrics/Traces/Logs UI                                            | `backstage.features.observability.enabled`                                                          |
-| `OPENCHOREO_FEATURES_ASSISTANT_ENABLED`                   | Enable the "Ask Perch" chat affordance                                 | `backstage.features.assistant.enabled`                                                              |
-| `OPENCHOREO_PERCH_AGENT_URL`                              | Upstream URL for the perch-agent (in-cluster fallback applied)         | `backstage.features.assistant.perchAgentUrl`                                                        |
-| `OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED`           | Enable the Secret management UI                                        | `features.secretManagement.enabled` (top-level)                                                     |
-| `OPENCHOREO_EVENTS_ENABLED`                               | Enable event-driven catalog sync                                       | `eventForwarder.enabled` (top-level)                                                                |
-| `OPENCHOREO_CATALOG_SYNC_FREQUENCY`                       | Periodic full-sync interval (seconds)                                  | `backstage.catalogSync.frequency`                                                                   |
-| `JENKINS_BASE_URL`                                        | Jenkins server base URL (consumed when Jenkins integration is enabled) | `backstage.externalCI.jenkins.baseUrl`                                                              |
-| `JENKINS_USERNAME`                                        | Jenkins username for API authentication                                | `backstage.externalCI.jenkins.username`                                                             |
-| `JENKINS_API_KEY`                                         | Jenkins API key                                                        | from Secret (`jenkins-api-key`)                                                                     |
-| `DATABASE_CLIENT`                                         | Database driver (`better-sqlite3` or `pg`)                             | `backstage.database.type`                                                                           |
-| `SQLITE_STORAGE_DIR`                                      | SQLite database directory (when using SQLite)                          | `backstage.database.sqlite.mountPath`                                                               |
-| `POSTGRES_HOST` / `_PORT` / `_USER` / `_PASSWORD` / `_DB` | PostgreSQL connection fields (when `database.type=postgresql`)         | from Secret (`postgres-host`, `postgres-port`, `postgres-user`, `postgres-password`, `postgres-db`) |
-| `PGSSLMODE`                                               | Set to `require` when PostgreSQL SSL is enabled                        | `backstage.database.postgresql.ssl` (conditional)                                                   |
+| Variable                                                  | Description                                                                   | Source                                                                                              |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `NODE_ENV`                                                | Node.js environment                                                           | `backstage.env` (default: `production`)                                                             |
+| `LOG_LEVEL`                                               | Logging verbosity                                                             | `backstage.env` (default: `info`)                                                                   |
+| `PORT`                                                    | HTTP server port                                                              | `backstage.env` (default: `7007`)                                                                   |
+| `BACKSTAGE_BASE_URL`                                      | Public URL for OAuth redirects and links                                      | `backstage.baseUrl`                                                                                 |
+| `OPENCHOREO_API_URL`                                      | Internal OpenChoreo API endpoint                                              | `backstage.openchoreoApi.url` (auto-configured)                                                     |
+| `BACKEND_SECRET`                                          | Session encryption key                                                        | from Secret (`backend-secret`)                                                                      |
+| `OPENCHOREO_AUTH_CLIENT_ID`                               | Sign-in client ID (authorization_code flow)                                   | `backstage.auth.clientId`                                                                           |
+| `OPENCHOREO_AUTH_CLIENT_SECRET`                           | Sign-in client secret                                                         | from Secret (`client-secret`)                                                                       |
+| `OPENCHOREO_SERVICE_CLIENT_ID`                            | Service client ID (client_credentials flow — background tasks)                | `backstage.auth.serviceClientId` (falls back to `clientId`)                                         |
+| `OPENCHOREO_SERVICE_CLIENT_SECRET`                        | Service client secret                                                         | from Secret (key `backstage.auth.serviceClientSecretKey`, default: `client-secret`)                 |
+| `OPENCHOREO_AUTH_METADATA_URL`                            | OIDC discovery URL (omitted when unset)                                       | `security.oidc.wellKnownEndpoint`                                                                   |
+| `OPENCHOREO_AUTH_AUTHORIZATION_URL`                       | OAuth authorization endpoint                                                  | `security.oidc.authorizationUrl`                                                                    |
+| `OPENCHOREO_AUTH_TOKEN_URL`                               | OAuth token endpoint (shared by both clients)                                 | `security.oidc.tokenUrl`                                                                            |
+| `OPENCHOREO_AUTH_OIDC_SCOPE`                              | OIDC scopes for the sign-in client                                            | `backstage.auth.oidcScope` (default: `openid profile email`)                                        |
+| `OPENCHOREO_AUTH_SCOPE`                                   | Scopes for the service client's client_credentials token request              | `backstage.auth.scope` (default: `""`)                                                              |
+| `OPENCHOREO_FEATURES_AUTH_ENABLED`                        | Enable authentication                                                         | `security.enabled`                                                                                  |
+| `OPENCHOREO_FEATURES_AUTHZ_ENABLED`                       | Enable authorization                                                          | `security.authz.enabled`                                                                            |
+| `OPENCHOREO_FEATURES_AUTH_REDIRECT_FLOW_ENABLED`          | Silent redirect vs sign-in popup                                              | `backstage.features.auth.redirectFlow.enabled`                                                      |
+| `OPENCHOREO_FEATURES_WORKFLOWS_ENABLED`                   | Show Workflows UI                                                             | `backstage.features.workflows.enabled`                                                              |
+| `OPENCHOREO_FEATURES_OBSERVABILITY_ENABLED`               | Show Metrics/Traces/Logs UI                                                   | `backstage.features.observability.enabled`                                                          |
+| `OPENCHOREO_FEATURES_ASSISTANT_ENABLED`                   | Enable the "Ask Perch" chat affordance                                        | `backstage.features.assistant.enabled`                                                              |
+| `OPENCHOREO_PERCH_AGENT_URL`                              | Upstream URL for the perch-agent (in-cluster fallback applied)                | `backstage.features.assistant.perchAgentUrl`                                                        |
+| `OPENCHOREO_FEATURES_SECRET_MANAGEMENT_ENABLED`           | Enable the Secret management UI                                               | `features.secretManagement.enabled` (top-level)                                                     |
+| `OPENCHOREO_EVENTS_ENABLED`                               | Enable event-driven catalog sync                                              | `eventForwarder.enabled` (top-level)                                                                |
+| `OPENCHOREO_CATALOG_SYNC_FREQUENCY`                       | Periodic full-sync interval (seconds)                                         | `backstage.catalogSync.frequency`                                                                   |
+| `JENKINS_BASE_URL`                                        | Jenkins server base URL (consumed when Jenkins integration is enabled)        | `backstage.externalCI.jenkins.baseUrl`                                                              |
+| `JENKINS_USERNAME`                                        | Jenkins username for API authentication                                       | `backstage.externalCI.jenkins.username`                                                             |
+| `JENKINS_API_KEY`                                         | Jenkins API key                                                               | from Secret (`jenkins-api-key`)                                                                     |
+| `GITHUB_HOST`                                             | GitHub host for the Actions integration (`github.com` or a GHES host)         | `backstage.externalCI.githubActions.host`                                                           |
+| `GITHUB_API_BASE_URL`                                     | GitHub API base URL (set for GHES, e.g. `https://ghe.example.com/api/v3`)     | `backstage.externalCI.githubActions.apiBaseUrl`                                                     |
+| `GITHUB_TOKEN`                                            | GitHub backend token (catalog, scaffolder, TechDocs — _not_ the Actions card) | from Secret (`github-actions-token`, optional)                                                      |
+| `AUTH_GITHUB_CLIENT_ID`                                   | GitHub OAuth App client ID for per-user sign-in (powers the Actions card)     | `backstage.externalCI.githubActions.oauth.clientId`                                                 |
+| `AUTH_GITHUB_CLIENT_SECRET`                               | GitHub OAuth App client secret                                                | from Secret (`github-oauth-client-secret`, optional)                                                |
+| `DATABASE_CLIENT`                                         | Database driver (`better-sqlite3` or `pg`)                                    | `backstage.database.type`                                                                           |
+| `SQLITE_STORAGE_DIR`                                      | SQLite database directory (when using SQLite)                                 | `backstage.database.sqlite.mountPath`                                                               |
+| `POSTGRES_HOST` / `_PORT` / `_USER` / `_PASSWORD` / `_DB` | PostgreSQL connection fields (when `database.type=postgresql`)                | from Secret (`postgres-host`, `postgres-port`, `postgres-user`, `postgres-password`, `postgres-db`) |
+| `PGSSLMODE`                                               | Set to `require` when PostgreSQL SSL is enabled                               | `backstage.database.postgresql.ssl` (conditional)                                                   |
 
 ## HTTP Routing Configuration
 
@@ -323,7 +328,11 @@ backstage:
 
 The API URL defaults to `http://openchoreo-api.{namespace}.svc.cluster.local:8080/api/v1`.
 
-## External CI Integration (Jenkins)
+## External CI Integration
+
+OpenChoreo Backstage ships with two external CI integrations — **Jenkins** and **GitHub Actions** — both wired through `backstage.externalCI.*`. For the end-to-end walkthroughs (OAuth setup, component annotations, what you see in the portal), see [External CI Integration](./workflows/external-ci.mdx). This section is the configuration reference.
+
+### Jenkins
 
 The chart wires Jenkins integration into Backstage via `backstage.externalCI.jenkins.*`. The `JENKINS_BASE_URL`, `JENKINS_USERNAME`, and `JENKINS_API_KEY` env vars are always set on the container; the `jenkins-api-key` Secret key is required even when Jenkins is not in use (use a placeholder value).
 
@@ -342,7 +351,33 @@ backstage:
 | `backstage.externalCI.jenkins.baseUrl`  | Jenkins server base URL                 | `"https://jenkins.example.com"` |
 | `backstage.externalCI.jenkins.username` | Jenkins username for API authentication | `"jenkins-user"`                |
 
-The Jenkins API token is read from the `jenkins-api-key` key in `backstage.secretName`. GitHub Actions and GitLab support are planned.
+The Jenkins API token is read from the `jenkins-api-key` key in `backstage.secretName`.
+
+### GitHub Actions
+
+The chart wires GitHub Actions integration into Backstage via `backstage.externalCI.githubActions.*`. Once enabled, the Component page surfaces a **CI/CD** tab showing recent `workflow_run` data for any Component annotated with `github.com/project-slug`.
+
+```yaml
+backstage:
+  externalCI:
+    githubActions:
+      enabled: false # Toggle GitHub Actions integration on/off
+      host: "github.com" # GHES: set to your instance host, e.g. ghe.example.com
+      apiBaseUrl: "" # GHES: set to e.g. https://ghe.example.com/api/v3
+      oauth:
+        clientId: "" # GitHub OAuth App client ID (powers per-user sign-in)
+```
+
+| Parameter                                           | Description                                                                    | Default        |
+| --------------------------------------------------- | ------------------------------------------------------------------------------ | -------------- |
+| `backstage.externalCI.githubActions.enabled`        | Toggle GitHub Actions integration                                              | `false`        |
+| `backstage.externalCI.githubActions.host`           | GitHub host (`github.com` or a GHES host)                                      | `"github.com"` |
+| `backstage.externalCI.githubActions.apiBaseUrl`     | GitHub API base URL (required for GHES, e.g. `https://ghe.example.com/api/v3`) | `""`           |
+| `backstage.externalCI.githubActions.oauth.clientId` | GitHub OAuth App client ID for the per-user sign-in the Actions card uses      | `""`           |
+
+:::info Two GitHub credentials are involved
+The GitHub Actions card authenticates **each portal user** through a GitHub **OAuth App** (`oauth.clientId` plus the `github-oauth-client-secret` Secret key) — this is what lets a user see runs for repositories they can access. The optional `github-actions-token` Secret key is a separate **backend** token used by catalog ingestion, the scaffolder, and TechDocs — it is _not_ what the Actions card reads. See the [GitHub Actions walkthrough](./workflows/external-ci.mdx#step-5-enable-github-actions-visibility-in-backstage) for the full setup.
+:::
 
 ## Operator Extensions
 
@@ -392,6 +427,8 @@ Required keys:
 Optional keys:
 
 - `service-client-secret`: Service client secret (client_credentials flow). Required only when using a dedicated service client (`backstage.auth.serviceClientSecretKey: "service-client-secret"`). When not present, the service client falls back to `client-secret`.
+- `github-oauth-client-secret`: GitHub OAuth App client secret. Required only when the GitHub Actions card is enabled (`backstage.externalCI.githubActions.oauth.clientId` set) — see the [GitHub Actions walkthrough](./workflows/external-ci.mdx#step-5-enable-github-actions-visibility-in-backstage).
+- `github-actions-token`: GitHub backend token for catalog ingestion, the scaffolder, and TechDocs. Declared `optional: true` on the Deployment, so the pod still starts without it. _Not_ the credential the GitHub Actions card uses to read runs.
 
 When `backstage.database.type=postgresql`, the same Secret must also include:
 

--- a/docs/platform-engineer-guide/workflows/external-ci.mdx
+++ b/docs/platform-engineer-guide/workflows/external-ci.mdx
@@ -34,7 +34,7 @@ This guide covers the External CI approach, where:
 - OpenChoreo handles deployment, scaling, and observability
 
 :::note
-Steps 1–3 use Jenkins as the worked example, but the same approach applies to any external CI pipeline — adapt the authentication and API call steps to your tooling. Steps 4 and 5 cover surfacing build status back in the Backstage portal for **Jenkins** and **GitHub Actions** respectively; enable whichever matches your CI.
+Steps 1–3 cover wiring an external CI pipeline to the Workload API, with worked examples for both **Jenkins** and **GitHub Actions** — the same approach applies to any CI tooling. Steps 4 and 5 cover surfacing build status back in the Backstage portal for **Jenkins** and **GitHub Actions** respectively; follow whichever matches your CI.
 :::
 
 ## Prerequisites
@@ -160,6 +160,109 @@ pipeline {
     }
 }
 ```
+
+### GitHub Actions
+
+The same two API calls work from a GitHub Actions workflow: build and push the image, then **register the Workload** with OpenChoreo. Store the OAuth client credentials and API/IDP URLs as [repository or organization secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions) before using this workflow:
+
+| Secret                     | Description                                                     |
+| -------------------------- | --------------------------------------------------------------- |
+| `OPENCHOREO_CLIENT_ID`     | Client ID from [Step 1](#step-1-create-a-service-account)       |
+| `OPENCHOREO_CLIENT_SECRET` | Client Secret from [Step 1](#step-1-create-a-service-account)   |
+| `THUNDER_URL`              | ThunderID IDP URL (e.g., `https://thunder.example.com`)         |
+| `OPENCHOREO_API_URL`       | OpenChoreo API URL (e.g., `https://api.openchoreo.example.com`) |
+
+```yaml
+name: Build and deploy to OpenChoreo
+
+on:
+  push:
+    branches: [main]
+
+env:
+  NAMESPACE: default
+  PROJECT: my-project
+  COMPONENT: my-service
+  REGISTRY: registry.example.com
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build & push image
+        run: |
+          IMAGE="${REGISTRY}/${COMPONENT}:${GITHUB_SHA::7}"
+          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
+          docker build -t "${IMAGE}" .
+          docker push "${IMAGE}"
+
+      - name: Register the workload with OpenChoreo
+        env:
+          CLIENT_ID: ${{ secrets.OPENCHOREO_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.OPENCHOREO_CLIENT_SECRET }}
+          THUNDER_URL: ${{ secrets.THUNDER_URL }}
+          OPENCHOREO_API_URL: ${{ secrets.OPENCHOREO_API_URL }}
+        run: |
+          set -euo pipefail
+
+          # 1. Get an access token (client_credentials grant)
+          TOKEN=$(curl -sf -X POST "${THUNDER_URL}/oauth2/token" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=${CLIENT_ID}" \
+            -d "client_secret=${CLIENT_SECRET}" \
+            | jq -r '.access_token')
+
+          # 2. Build the Workload CR payload (image only; add endpoints and
+          #    configurations here, or generate it from a workload.yaml — see note below)
+          WORKLOAD_NAME="${COMPONENT}"
+          cat > workload-cr.json <<EOF
+          {
+            "metadata": { "name": "${WORKLOAD_NAME}", "namespace": "${NAMESPACE}" },
+            "spec": {
+              "owner": { "projectName": "${PROJECT}", "componentName": "${COMPONENT}" },
+              "container": { "image": "${IMAGE}" }
+            }
+          }
+          EOF
+
+          # 3. Create the Workload; on HTTP 409 (already exists) fall back to PUT
+          CODE=$(curl -s -o resp.json -w '%{http_code}' -X POST \
+            "${OPENCHOREO_API_URL}/api/v1/namespaces/${NAMESPACE}/workloads" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d @workload-cr.json)
+          if [ "${CODE}" = "409" ]; then
+            curl -sf -X PUT \
+              "${OPENCHOREO_API_URL}/api/v1/namespaces/${NAMESPACE}/workloads/${WORKLOAD_NAME}" \
+              -H "Authorization: Bearer ${TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d @workload-cr.json
+          elif [ "${CODE}" -lt 200 ] || [ "${CODE}" -ge 300 ]; then
+            echo "Workload create failed (HTTP ${CODE}):"; cat resp.json; exit 1
+          fi
+
+          # 4. Annotate the WorkflowRun so the portal can display the build's
+          #    image and workload configuration. RUN_NAME is the WorkflowRun
+          #    created for this build (e.g. passed in as a workflow input).
+          curl -sf -X GET \
+            "${OPENCHOREO_API_URL}/api/v1/namespaces/${NAMESPACE}/workflowruns/${RUN_NAME}" \
+            -H "Authorization: Bearer ${TOKEN}" -o workflowrun.json
+          jq --rawfile wl workload-cr.json \
+            '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n"))
+             | .metadata.annotations["openchoreo.dev/workload-from-source"] = "false"' \
+            workflowrun.json > workflowrun-updated.json
+          curl -sf -X PUT \
+            "${OPENCHOREO_API_URL}/api/v1/namespaces/${NAMESPACE}/workflowruns/${RUN_NAME}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d @workflowrun-updated.json
+```
+
+:::note
+Steps 2–4 above are exactly what the built-in `generate-workload` workflow template does. For the full payload shape (endpoints, configurations), generating the CR from a `workload.yaml` descriptor with `occ workload create`, and the meaning of the `openchoreo.dev/workload` and `openchoreo.dev/workload-from-source` annotations, see [Workload Generation](./workload-generation.md) and the [Workload API Reference](../../reference/api/application/workload.md).
+:::
 
 ## Step 4: Enable Jenkins Visibility in Backstage
 

--- a/docs/platform-engineer-guide/workflows/external-ci.mdx
+++ b/docs/platform-engineer-guide/workflows/external-ci.mdx
@@ -34,7 +34,7 @@ This guide covers the External CI approach, where:
 - OpenChoreo handles deployment, scaling, and observability
 
 :::note
-This guide provides a step-by-step walkthrough using Jenkins. The same approach applies to any external CI pipeline — adapt the authentication and API call steps to your tooling.
+Steps 1–3 use Jenkins as the worked example, but the same approach applies to any external CI pipeline — adapt the authentication and API call steps to your tooling. Steps 4 and 5 cover surfacing build status back in the Backstage portal for **Jenkins** and **GitHub Actions** respectively; enable whichever matches your CI.
 :::
 
 ## Prerequisites
@@ -271,6 +271,183 @@ You can also configure Jenkins annotations during component creation by selectin
 - Cards only appear when the entity has a Jenkins annotation
 - If an external CI annotation is present, it replaces the OpenChoreo Workflows card
 - Check browser console for any JavaScript errors
+
+## Step 5: Enable GitHub Actions Visibility in Backstage
+
+OpenChoreo Backstage includes a built-in GitHub Actions plugin that displays `workflow_run` history directly in the portal. Once configured, a Component's **CI/CD** tab lists recent runs for the annotated repository.
+
+:::info Two GitHub credentials are involved
+The GitHub Actions card authenticates **each portal user** through a GitHub **OAuth App** — this is how a user who can see a private repository on GitHub sees its runs in the portal. The optional backend token in [section 5.4](#54-optional-provision-a-github-backend-token) is a _separate_ credential used only by Backstage backend plugins (catalog ingestion, scaffolder, TechDocs); it is **not** what the card reads. Set up the OAuth App first — without it the card cannot fetch runs even with a valid token.
+:::
+
+### 5.1 Create a GitHub OAuth App
+
+In GitHub, go to **Settings → Developer settings → OAuth Apps → New OAuth App** (use an organization-owned App for shared portals):
+
+| Field                      | Value                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Homepage URL               | Your portal base URL, e.g. `http://openchoreo.localhost:8080`                                                            |
+| Authorization callback URL | `<portal-base-url>/api/auth/github/handler/frame`, e.g. `http://openchoreo.localhost:8080/api/auth/github/handler/frame` |
+
+Record the **Client ID** and generate a **Client secret**. For GitHub Enterprise Server, create the OAuth App on your GHES instance instead of github.com.
+
+:::warning
+The callback URL must match the portal base URL **exactly** (scheme, host, and port). A mismatch makes GitHub reject the login with a `redirect_uri` error.
+:::
+
+### 5.2 Store the OAuth credentials
+
+The OAuth client secret is read from the `github-oauth-client-secret` key in the Backstage credentials secret (referenced by `backstage.secretName`). Add it the same way other Backstage secrets are managed.
+
+<Tabs>
+<TabItem value="external-secret" label="External Secret (Recommended)">
+
+If you followed the [k3d setup](../../getting-started/try-it-out/on-k3d-locally.mdx) or [on your environment](../../getting-started/try-it-out/on-your-environment.mdx) guide, `backstage-secrets` is owned by External Secrets Operator (`creationPolicy: Owner`). Do **not** patch the Kubernetes Secret directly — ESO overwrites it on the next sync. Seed the values into your secret backend and map them through the `ExternalSecret` instead.
+
+Seed the OpenBao KV (the convention is `secret/backstage-<secretKey>`, value under the `value` property):
+
+```bash
+kubectl exec -n openbao openbao-0 -- sh -c '
+  export BAO_ADDR=http://127.0.0.1:8200 BAO_TOKEN=root
+  bao kv put secret/backstage-github-oauth-client-secret value="your-real-client-secret"
+'
+```
+
+:::warning
+The client secret is sensitive. Read it into a variable rather than pasting it inline — inline values land in your shell history and in the `kubectl exec` process args (visible via `ps` and audit logs). Rotate any secret exposed that way.
+:::
+
+Add the key to the `backstage-secrets` `ExternalSecret` so ESO maps it onto the Kubernetes Secret. `/spec/data/-` appends, so run this **once** — re-running duplicates the entry:
+
+```bash
+kubectl patch externalsecret backstage-secrets -n openchoreo-control-plane --type=json -p='[
+  {"op":"add","path":"/spec/data/-","value":{"secretKey":"github-oauth-client-secret","remoteRef":{"key":"backstage-github-oauth-client-secret","property":"value"}}}
+]'
+```
+
+Force a re-sync rather than waiting for the `refreshInterval`:
+
+```bash
+kubectl annotate externalsecret backstage-secrets \
+  -n openchoreo-control-plane \
+  force-sync=$(date +%s) --overwrite
+```
+
+</TabItem>
+<TabItem value="direct-secret" label="Direct Secret">
+
+If you manage `backstage-secrets` directly (no External Secrets Operator), add the key to that Secret. Export the value first so the command is copy-paste-safe:
+
+```bash
+export GH_OAUTH_CLIENT_SECRET="your-real-client-secret"
+
+kubectl -n openchoreo-control-plane patch secret backstage-secrets --type=json -p='[
+  {"op":"add","path":"/data/github-oauth-client-secret","value":"'"$(printf %s "$GH_OAUTH_CLIENT_SECRET" | base64 | tr -d '\n')"'"}
+]'
+```
+
+</TabItem>
+</Tabs>
+
+### 5.3 Enable GitHub Actions in Helm Values
+
+Set the integration on and pass the OAuth **Client ID** (the client _secret_ comes from the Secret you stored in 5.2). The chart then renders the `auth.providers.github` block and the `integrations.github` config automatically.
+
+<Tabs>
+<TabItem value="public-github" label="Public GitHub (github.com)">
+
+```yaml
+backstage:
+  externalCI:
+    githubActions:
+      enabled: true
+      oauth:
+        clientId: "your-oauth-client-id"
+```
+
+The defaults (`host: github.com`, empty `apiBaseUrl`) are sufficient.
+
+</TabItem>
+<TabItem value="ghes" label="GitHub Enterprise Server">
+
+```yaml
+backstage:
+  externalCI:
+    githubActions:
+      enabled: true
+      host: "ghe.example.com"
+      apiBaseUrl: "https://ghe.example.com/api/v3"
+      oauth:
+        clientId: "your-oauth-client-id"
+```
+
+Both `host` and `apiBaseUrl` must be set for GHES — the plugin uses `host` for git URLs and `apiBaseUrl` for API calls.
+
+</TabItem>
+</Tabs>
+
+Restart Backstage to pick up the new configuration:
+
+```bash
+kubectl rollout restart deployment/backstage -n openchoreo-control-plane
+```
+
+### 5.4 (Optional) Provision a GitHub backend token
+
+Skip this unless you also use the Backstage **backend** GitHub integration (catalog ingestion, scaffolder git operations, TechDocs). The Actions card itself does not need it — it uses the per-user OAuth flow above.
+
+- **For github.com:** create a [fine-grained personal access token](https://github.com/settings/personal-access-tokens/new) scoped to the relevant repositories with `Actions: Read` and `Metadata: Read` permissions.
+- **For org-wide / production:** create a [GitHub App](https://docs.github.com/en/apps/creating-github-apps), install it on the org, and pass the installation token — App tokens scale better and don't expire with the user that created them.
+- **For GHES:** create the token on your GHES instance (the `host`/`apiBaseUrl` from 5.3 already point Backstage at it).
+
+Store it under the `github-actions-token` key the same way as 5.2 (OpenBao path `secret/backstage-github-actions-token`, or a direct Secret patch on `/data/github-actions-token`). The key is declared `optional: true` on the Deployment, so Backstage starts whether or not it is present.
+
+### Add the GitHub Annotation to Components
+
+For any Component whose workflows you want to see, set the `github.com/project-slug` annotation:
+
+```yaml
+apiVersion: openchoreo.dev/v1alpha1
+kind: Component
+metadata:
+  name: my-service
+  annotations:
+    github.com/project-slug: my-org/my-service
+spec:
+  # ...
+```
+
+This is the same annotation the upstream [`@backstage/plugin-github-actions`](https://www.npmjs.com/package/@backstage/plugin-github-actions) plugin reads.
+
+:::note
+The card reads this annotation from the **Backstage catalog entity**, not from the OpenChoreo Component CR directly. If your catalog sync does not copy the CR annotation onto the entity, set `github.com/project-slug` on the catalog entity itself.
+:::
+
+### What You'll See
+
+When configured correctly:
+
+- **CI/CD Tab**: A dedicated tab lists recent workflow runs for the annotated repository.
+- The first time you open it, complete the one-time GitHub login when the popup appears.
+
+### Troubleshooting GitHub Actions Visibility
+
+**The card shows a sign-in prompt that fails, or `/api/auth/github/start` returns `404 No auth provider registered for 'github'`:**
+
+- The GitHub OAuth provider is not registered. Complete [section 5.1](#51-create-a-github-oauth-app)–[5.3](#53-enable-github-actions-in-helm-values): create the OAuth App, set `oauth.clientId`, store `github-oauth-client-secret`, and restart Backstage.
+
+**The login popup opens but errors with a `redirect_uri` mismatch:**
+
+- The OAuth App's callback URL must be exactly `<portal-base-url>/api/auth/github/handler/frame` (scheme, host, and port matching the URL the browser uses).
+
+**The CI/CD tab shows no runs even though the workflow ran:**
+
+- Verify the `github.com/project-slug` annotation is on the Backstage **catalog entity** and matches the repository slug exactly (`<org>/<repo>`, case-sensitive).
+- For a **private** repository, the signed-in user must have access to it on GitHub and must have approved the `repo` scope during the OAuth consent.
+
+**GitHub Enterprise Server users see `Cannot find host` errors:**
+
+- Both `host` and `apiBaseUrl` must be set. Setting only one causes the other to fall back to github.com defaults.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Purpose

Documents the **GitHub Actions external CI integration for Backstage** that was wired into the `openchoreo-control-plane` Helm chart in openchoreo/openchoreo#3641.

That PR mirrored the existing **Jenkins** external-CI wiring for **GitHub Actions** (Helm values, Backstage `app-config` ConfigMap, Deployment env vars, OAuth provider). This docs PR mirrors the corresponding **documentation** the same way — slotting GitHub Actions in beside Jenkins in the two pages that already cover external CI, rather than introducing a new top-level page.

### Changes

- **`platform-engineer-guide/workflows/external-ci.mdx`** — adds **"Step 5: Enable GitHub Actions Visibility in Backstage"**, structurally parallel to the existing Jenkins "Step 4". Covers:
  - Creating a GitHub OAuth App (the per-user sign-in the Actions card uses)
  - Storing the OAuth client secret (External Secret vs Direct Secret tabs)
  - Enabling via Helm (public GitHub vs GitHub Enterprise Server tabs)
  - The optional backend token, the `github.com/project-slug` Component annotation, and GitHub-specific troubleshooting
- **`platform-engineer-guide/backstage-configuration.mdx`** — reference updates:
  - Adds `GITHUB_HOST`, `GITHUB_API_BASE_URL`, `GITHUB_TOKEN`, `AUTH_GITHUB_CLIENT_ID`, `AUTH_GITHUB_CLIENT_SECRET` to the env-var table
  - Adds a `backstage.externalCI.githubActions.*` Helm values reference subsection
  - Adds the optional `github-oauth-client-secret` and `github-actions-token` Secret keys
  - Corrects the now-stale note that "GitHub Actions and GitLab support are planned"

The docs call out the easy-to-miss detail that **two GitHub credentials** are involved: per-user OAuth (what the Actions card reads) vs. an optional backend token (catalog/scaffolder/TechDocs only).

> **Note on versioning:** these edits land in the current/unreleased (`Next`) docs under `docs/`, which is correct — the feature is not in the `lastVersion` (`v1.1.x`) release snapshot.

## Related Issues

- Follow-up to openchoreo/openchoreo#3641 (the Helm + Backstage wiring this documents)
- Part of openchoreo/openchoreo#3551 (complete GitHub Actions support)

## Checklist

- [x] Updated `sidebars.ts` if adding a new documentation page — _N/A, only edited existing pages_
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
