### PR TITLE
fix: remove Microsoft trademark asset from Azure SQL Database module

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -529,7 +529,7 @@
       "database",
       "sql"
     ],
-    "logoUrl": "https://raw.githubusercontent.com/devicons/devicon/master/icons/azuresqldatabase/azuresqldatabase-original.svg",
+    "logoUrl": "",
     "author": "OpenChoreo",
     "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/workflow-azure-sql-database",
     "default": false,


### PR DESCRIPTION
Microsoft's trademark policy is explicit:

> "our logos, app and product icons, illustrations, photographs, videos, and designs can never be used without an express license."

Source: https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks

The Azure SQL Database entry in this file was using a Microsoft service icon (hosted via devicon, but the icon itself is Microsoft's). 

This removes the trademarked icon. Matches the existing pattern for AWS CloudWatch entries which also ship with empty `logoUrl` for the same reason.

