### PR TITLE
docs: add 'Install via your Agent' page and prompt builder

### DIFF
--- a/docs/getting-started/try-it-out/with-an-agent.mdx
+++ b/docs/getting-started/try-it-out/with-an-agent.mdx
@@ -1,13 +1,13 @@
 ---
-title: Install with an Agent
-description: Use an AI coding agent to install OpenChoreo. Build a prompt for your agent, paste it, and let it walk the official install guide end to end.
+title: Install via your Agent
+description: Use an AI coding agent to install OpenChoreo. Pick your environment and planes, copy the generated prompt, and paste it into your agent.
 sidebar_position: 3
 ---
 
 import AgentSetupBuilder from "@site/src/components/AgentSetupBuilder";
 import { versions } from "../../_constants.mdx";
 
-# Install with an Agent
+# Install via your Agent
 
 Let an AI coding agent install OpenChoreo for you.
 

--- a/docs/getting-started/try-it-out/with-an-agent.mdx
+++ b/docs/getting-started/try-it-out/with-an-agent.mdx
@@ -1,0 +1,30 @@
+---
+title: Install with an Agent
+description: Use an AI coding agent to install OpenChoreo. Build a prompt for your agent, paste it, and let it walk the official install guide end to end.
+sidebar_position: 3
+---
+
+import AgentSetupBuilder from "@site/src/components/AgentSetupBuilder";
+import { versions } from "../../_constants.mdx";
+
+# Install with an Agent
+
+Let an AI coding agent install OpenChoreo for you.
+
+Works with Claude Code, Codex, Cursor, OpenCode, or any coding agent.
+
+<details>
+<summary>Prerequisite: install the <code>openchoreo-setup</code> skill</summary>
+
+```bash
+npx skills add openchoreo/skills --skill openchoreo-setup
+```
+
+</details>
+
+<AgentSetupBuilder currentVersion={versions.helmChart} />
+
+## Next steps
+
+- [Deploy and Explore](../deploy-and-explore.mdx)
+- [Connect an AI assistant via MCP](../../ai/mcp-servers.mdx)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -34,6 +34,11 @@ const sidebars: SidebarsConfig = {
         "getting-started/quick-start-guide",
         {
           type: "doc",
+          id: "getting-started/try-it-out/with-an-agent",
+          label: "Install via your Agent",
+        },
+        {
+          type: "doc",
           id: "getting-started/try-it-out/on-k3d-locally",
           label: "Run Locally on K3d",
         },
@@ -41,11 +46,6 @@ const sidebars: SidebarsConfig = {
           type: "doc",
           id: "getting-started/try-it-out/on-your-environment",
           label: "Run in Your Environment",
-        },
-        {
-          type: "doc",
-          id: "getting-started/try-it-out/with-an-agent",
-          label: "Install with an Agent",
         },
         {
           type: "doc",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -44,6 +44,11 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "doc",
+          id: "getting-started/try-it-out/with-an-agent",
+          label: "Install with an Agent",
+        },
+        {
+          type: "doc",
           id: "getting-started/cli-installation",
           label: "CLI Installation",
         },

--- a/src/components/AgentSetupBuilder/index.tsx
+++ b/src/components/AgentSetupBuilder/index.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from "react";
+import styles from "./styles.module.css";
+
+type Env =
+  | "k3d"
+  | "rancher-desktop"
+  | "gke"
+  | "eks"
+  | "aks"
+  | "self-managed";
+
+type Topology = "single" | "multi";
+
+const ENVS: { id: Env; label: string }[] = [
+  { id: "k3d", label: "Local k3d" },
+  { id: "rancher-desktop", label: "Rancher Desktop" },
+  { id: "gke", label: "GKE" },
+  { id: "eks", label: "EKS" },
+  { id: "aks", label: "AKS" },
+  { id: "self-managed", label: "Self-managed" },
+];
+
+const ENV_PROMPT: Record<Env, { single: string; multi: string }> = {
+  "k3d": {
+    single: "Install OpenChoreo locally on k3d.",
+    multi: "Install OpenChoreo locally on k3d using a multi-cluster topology.",
+  },
+  "rancher-desktop": {
+    single: "Install OpenChoreo on Rancher Desktop.",
+    multi: "Install OpenChoreo on Rancher Desktop using a multi-cluster topology.",
+  },
+  "gke": {
+    single: "Install OpenChoreo on GKE.",
+    multi: "Install OpenChoreo on GKE using a multi-cluster topology.",
+  },
+  "eks": {
+    single: "Install OpenChoreo on EKS.",
+    multi: "Install OpenChoreo on EKS using a multi-cluster topology.",
+  },
+  "aks": {
+    single: "Install OpenChoreo on AKS.",
+    multi: "Install OpenChoreo on AKS using a multi-cluster topology.",
+  },
+  "self-managed": {
+    single: "Install OpenChoreo on my Kubernetes cluster.",
+    multi: "Install OpenChoreo on my Kubernetes cluster using a multi-cluster topology.",
+  },
+};
+
+const PLANES = [
+  { id: "control", label: "Control Plane", desc: "API, console, and controllers", required: true },
+  { id: "data", label: "Data Plane", desc: "Runs your workloads", required: true },
+  { id: "workflow", label: "Workflow Plane", desc: "Build from source with CI", required: false },
+  { id: "observability", label: "Observability Plane", desc: "Logs, metrics, and traces", required: false },
+];
+
+function resolveVersion(helmChart: string): string {
+  const match = helmChart.match(/^(\d+)\.(\d+)\.\d+$/);
+  return match ? `v${match[1]}.${match[2]}.x` : "next";
+}
+
+function buildPrompt(
+  env: Env,
+  topology: Topology,
+  workflow: boolean,
+  obs: boolean,
+  version: string,
+): string {
+  const target = ENV_PROMPT[env][topology];
+
+  let planes: string;
+  if (workflow && obs) {
+    planes = "Install all four planes.";
+  } else if (workflow && !obs) {
+    planes = "Install the control, data, and workflow planes. Skip the observability plane.";
+  } else if (!workflow && obs) {
+    planes = "Install the control, data, and observability planes. Skip the workflow plane.";
+  } else {
+    planes = "Install only the control and data planes.";
+  }
+
+  return `${target} Use version ${version}. ${planes}`;
+}
+
+interface Props {
+  currentVersion?: string;
+}
+
+export default function AgentSetupBuilder({ currentVersion }: Props) {
+  const version = currentVersion ? resolveVersion(currentVersion) : "next";
+
+  const [env, setEnv] = useState<Env>("k3d");
+  const [topology, setTopology] = useState<Topology>("single");
+  const [workflow, setWorkflow] = useState(true);
+  const [obs, setObs] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  const prompt = buildPrompt(env, topology, workflow, obs, version);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(prompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    });
+  }
+
+  const planeEnabled = { control: true, data: true, workflow, observability: obs };
+
+  return (
+    <div className={styles.builder}>
+
+      <div className={styles.section}>
+        <span className={styles.sectionLabel}>Environment</span>
+        <div className={styles.pills}>
+          {ENVS.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              className={`${styles.pill} ${env === id ? styles.pillActive : ""}`}
+              onClick={() => setEnv(id)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <span className={styles.sectionLabel}>Cluster topology</span>
+        <div className={styles.topoGrid}>
+          {(["single", "multi"] as Topology[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`${styles.topoCard} ${topology === t ? styles.topoCardActive : ""}`}
+              onClick={() => setTopology(t)}
+            >
+              <span className={styles.topoRadio}>
+                <span className={topology === t ? styles.topoRadioDot : ""} />
+              </span>
+              <span className={styles.topoText}>
+                <span className={styles.topoTitle}>
+                  {t === "single" ? "Single cluster" : "Multi-cluster"}
+                </span>
+                <span className={styles.topoDesc}>
+                  {t === "single"
+                    ? "All planes on one cluster"
+                    : "One cluster per plane"}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <span className={styles.sectionLabel}>Planes</span>
+        <div className={styles.planesGrid}>
+          {PLANES.map((p) => {
+            const isOn = planeEnabled[p.id as keyof typeof planeEnabled];
+            return (
+              <button
+                key={p.id}
+                type="button"
+                disabled={p.required}
+                className={`${styles.planeCard} ${isOn ? styles.planeCardOn : ""} ${p.required ? styles.planeCardRequired : ""}`}
+                onClick={() => {
+                  if (p.id === "workflow") setWorkflow((v) => !v);
+                  if (p.id === "observability") setObs((v) => !v);
+                }}
+              >
+                <span className={`${styles.planeCheck} ${isOn ? styles.planeCheckOn : ""}`}>
+                  {isOn && (
+                    <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+                      <path d="M1 4L3.5 6.5L9 1" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                </span>
+                <span className={styles.planeName}>{p.label}</span>
+                <span className={styles.planeDesc}>{p.desc}</span>
+                {p.required && <span className={styles.planeReqBadge}>required</span>}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className={styles.outputSection}>
+        <div className={styles.outputHeader}>
+          <span className={styles.outputLabel}>Paste into your agent</span>
+          <button
+            type="button"
+            className={`${styles.copyBtn} ${copied ? styles.copyBtnDone : ""}`}
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <>
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                  <path d="M2 7L5 10L11 3" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                Copied
+              </>
+            ) : (
+              <>
+                <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                  <rect x="4.5" y="1.5" width="7" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.3"/>
+                  <path d="M8.5 1.5V1C8.5 0.724 8.276 0.5 8 0.5H2C1.448 0.5 1 0.948 1 1.5V9C1 9.552 1.448 10 2 10H3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                </svg>
+                Copy
+              </>
+            )}
+          </button>
+        </div>
+        <div className={styles.outputText}>{prompt}</div>
+      </div>
+
+    </div>
+  );
+}

--- a/src/components/AgentSetupBuilder/styles.module.css
+++ b/src/components/AgentSetupBuilder/styles.module.css
@@ -1,0 +1,271 @@
+.builder {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin: 1.25rem 0 1.75rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sectionLabel {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* Environment pills — matches .workflow-status-badge from custom.css */
+
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.pill {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: transparent;
+  color: var(--ifm-font-color-base);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+  line-height: 1.5;
+}
+
+.pill:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.pillActive {
+  background: rgba(43, 140, 247, 0.12);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+}
+
+/* Topology cards — matches .workflow-guide-step-chip from custom.css */
+
+.topoGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+@media (max-width: 480px) {
+  .topoGrid { grid-template-columns: 1fr; }
+}
+
+.topoCard {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-color-emphasis-100);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.topoCard:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.topoCardActive {
+  border-color: var(--ifm-color-primary);
+  background: rgba(43, 140, 247, 0.08);
+}
+
+.topoRadio {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--ifm-color-emphasis-400);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: border-color 0.12s;
+}
+
+.topoCardActive .topoRadio {
+  border-color: var(--ifm-color-primary);
+}
+
+.topoRadioDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+}
+
+.topoText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.topoTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+.topoDesc {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* Plane cards — same chip pattern as topology */
+
+.planesGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+@media (max-width: 480px) {
+  .planesGrid { grid-template-columns: 1fr; }
+}
+
+.planeCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.875rem 0.875rem 0.875rem 2.6rem;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-color-emphasis-100);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s, background 0.12s, opacity 0.12s;
+}
+
+.planeCardRequired {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.planeCard:not(.planeCardRequired):hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.planeCardOn:not(.planeCardRequired) {
+  border-color: var(--ifm-color-primary);
+  background: rgba(43, 140, 247, 0.08);
+}
+
+.planeCheck {
+  position: absolute;
+  left: 0.875rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 15px;
+  height: 15px;
+  border-radius: 3px;
+  border: 1.5px solid var(--ifm-color-emphasis-400);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: transparent;
+  transition: border-color 0.12s, background 0.12s;
+}
+
+.planeCheckOn {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary);
+  color: #fff;
+}
+
+.planeName {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+.planeDesc {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.planeReqBadge {
+  font-size: 0.68rem;
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
+}
+
+/* Prompt output — matches code block style */
+
+.outputSection {
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  padding-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.outputHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.outputLabel {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.outputText {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-code-background);
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+}
+
+.copyBtn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 20px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s;
+}
+
+.copyBtn:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.copyBtnDone {
+  border-color: var(--ifm-color-success);
+  color: var(--ifm-color-success) !important;
+}


### PR DESCRIPTION
## Summary

- Adds `docs/getting-started/try-it-out/with-an-agent.mdx` — a new getting-started page for users who want an AI coding agent to run the install for them
- Adds `src/components/AgentSetupBuilder/` — a React prompt builder component where users pick their environment, cluster topology, and optional planes to generate a ready-to-paste agent prompt
- The generated prompt includes the doc version (derived from `_constants.mdx`) so the agent fetches the right install guide automatically via the `openchoreo-setup` skill
- Registers the new page in `sidebars.ts` after "Run in Your Environment"


https://github.com/user-attachments/assets/70e51726-e96c-485e-bee6-d060e4b0afb8



## Test plan

- [ ] Dev server renders the page at `/docs/getting-started/try-it-out/with-an-agent`
- [ ] Page appears in the sidebar under Getting Started → Try it out
- [ ] Prompt updates as environment / topology / plane selections change
- [ ] Copy button copies the generated prompt to clipboard
- [ ] Light and dark mode both render correctly