### PR TITLE
feat(api-specs): add 501 to metrics runtime-topology endpoint

### DIFF
--- a/static/api-specs/observability-metrics-adapter.yaml
+++ b/static/api-specs/observability-metrics-adapter.yaml
@@ -153,6 +153,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "501":
+          description: >-
+            Not Implemented. The metrics backend does not support runtime
+            topology (for example, it has no pod-to-pod traffic data to build
+            the graph from).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /api/v1alpha1/alerts/rules:
     post:
@@ -342,6 +351,7 @@ components:
             - unauthorized
             - forbidden
             - internalServerError
+            - notImplemented
         errorCode:
           type: string
           description: The error code from observer service


### PR DESCRIPTION
## Purpose

Add a `501 Not Implemented` response to the `POST /api/v1alpha1/metrics/runtime-topology` operation in the observability metrics adapter API spec.

Some metrics backends cannot produce a runtime-topology graph at all because the data does not exist in that backend — for example, the Azure Container Insights backend (`Perf` / `KubePodInventory`) has only CPU/memory counters and pod inventory, no pod-to-pod traffic data. Today such an adapter has to overload `500` (a transient server error) to signal a permanent capability gap. A dedicated `501` lets the adapter say "this backend does not implement topology" cleanly, so the Observer can distinguish it from an actual failure.

## Approach

- Add a `501` response to `queryRuntimeTopology`, reusing the existing `ErrorResponse` schema (consistent with the other error responses on the operation).
- Add `notImplemented` to the `ErrorResponse.title` enum so adapters can set an accurate title for the `501`.

Both changes are additive and backward compatible; existing adapters that only return `200`/`4xx`/`500` are unaffected.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)