### PR TITLE
docs: add WSO2 API Platform AI gateway to ecosystem

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -354,6 +354,24 @@
     "released": true
   },
   {
+    "id": "wso2-api-platform-ai-gateway",
+    "group": "module",
+    "name": "WSO2 API Platform AI Gateway",
+    "description": "AI-native gateway built on the WSO2 API Platform runtime, providing model-aware routing, LLM passthrough, and token & cost control for components that consume LLM APIs.",
+    "category": "AI Gateway",
+    "tags": [
+      "ai-gateway",
+      "llm",
+      "wso2",
+      "model-routing"
+    ],
+    "logoUrl": "https://avatars.githubusercontent.com/u/533043?s=200&v=4",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/ai-gateway-wso2-api-platform",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "agent-sandbox",
     "group": "component-type",
     "name": "Agent Sandbox",


### PR DESCRIPTION
## Purpose
This PR adds the WSO2 API Platform AI gateway module to the OpenChoreo Ecosystem.

## Related Issues
https://github.com/openchoreo/community-modules/pull/205

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
