### PR TITLE
fix(docs): correct --header flag placement in Claude Code MCP token config

### DIFF
--- a/docs/ai/mcp-servers.mdx
+++ b/docs/ai/mcp-servers.mdx
@@ -172,12 +172,12 @@ Copy the `access_token` value and replace `<ACCESS_TOKEN>` in the configuration 
 
 ```bash
 claude mcp add --transport http \
-  --header "Authorization: Bearer <ACCESS_TOKEN>" \
-  openchoreo-cp http://api.openchoreo.localhost:8080/mcp
+  openchoreo-cp http://api.openchoreo.localhost:8080/mcp \
+  --header "Authorization: Bearer <ACCESS_TOKEN>"
 
 claude mcp add --transport http \
-  --header "Authorization: Bearer <ACCESS_TOKEN>" \
-  openchoreo-obs http://observer.openchoreo.localhost:11080/mcp
+  openchoreo-obs http://observer.openchoreo.localhost:11080/mcp \
+  --header "Authorization: Bearer <ACCESS_TOKEN>"
 ```
 
 </TabItem>


### PR DESCRIPTION
## Purpose
The latest claude code's `--header` flag placement is changed. This PR updates the openchoreo doc related to the openchoreo MCP server adding to claude code.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
