### PR TITLE
fix(community): clean up events data and date display

### DIFF
--- a/src/pages/community/events.json
+++ b/src/pages/community/events.json
@@ -2,16 +2,7 @@
   "events": [
     {
       "month": "JUN",
-      "day": "11",
-      "category": "Meetups",
-      "title": "Cloud Native Hyderabad",
-      "meta": "Virtual · Open to all",
-      "primaryAction": "Register",
-      "primaryActionHref": "https://ocgroups.dev/cncf/group/cloud-native-hyderabad/event/tr9jkbf"
-    },
-    {
-      "month": "JUN",
-      "day": "18  19",
+      "day": "18–19",
       "category": "Conferences",
       "title": "KubeCon + CloudNativeCon India 2026",
       "meta": "Bengaluru, India",
@@ -26,20 +17,6 @@
       "meta": "Zoom · Open to all",
       "primaryAction": "Add to calendar",
       "primaryActionHref": "https://zoom-lfx.platform.linuxfoundation.org/meetings/openchoreo?view=list"
-    }
-  ],
-  "pastEvents": [
-    {
-      "date": "June 4",
-      "title": "Kubernetes Sri Lanka",
-      "action": "More Details",
-      "actionHref": "https://ocgroups.dev/cncf/group/f8dnmxt/event/hkf8t4e"
-    },
-    {
-      "date": "June 3",
-      "title": "Cloud Native London",
-      "action": "More Details",
-      "actionHref": "https://www.meetup.com/cloud-native-london/events/312972430/?eventOrigin=group_upcoming_events"
     }
   ]
 }

--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -3,6 +3,7 @@ import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
 import communityEvents from './events.json';
+import pastEventsData from './past-events.json';
 
 type EventCategory = 'Meetups' | 'Community calls' | 'Conferences';
 
@@ -20,11 +21,11 @@ type PastEventItem = {
   date: string;
   title: string;
   action: string;
-  actionHref: string;
+  href: string;
 };
 
 const events = communityEvents.events as EventItem[];
-const pastEvents = communityEvents.pastEvents as PastEventItem[];
+const pastEvents = pastEventsData.pastEvents as PastEventItem[];
 
 const filters = [
   'All',
@@ -168,7 +169,14 @@ export default function Community(): React.JSX.Element {
 
                 return (
                   <article className={styles.eventCard} key={event.title}>
-                    <div className={styles.eventDate}>
+                    <div
+                      className={[
+                        styles.eventDate,
+                        event.day.length > 2 ? styles.eventDateRange : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                    >
                       <span>{event.month}</span>
                       <strong>{event.day}</strong>
                     </div>
@@ -223,7 +231,7 @@ export default function Community(): React.JSX.Element {
                   <strong>{event.title}</strong>
                   <Link
                     className='button button--link button--sm'
-                    to={event.actionHref}
+                    to={event.href}
                   >
                     {event.action}
                   </Link>

--- a/src/pages/community/past-events.json
+++ b/src/pages/community/past-events.json
@@ -1,6 +1,16 @@
 {
   "pastEvents": [
     {
+      "date": "June 11",
+      "year": "2026",
+      "title": "Cloud Native Hyderabad",
+      "description": "Talk: Role of Developer Platforms in the Era of Agentic Software Development",
+      "type": "Meetup",
+      "location": "Virtual",
+      "action": "More Details",
+      "href": "https://ocgroups.dev/cncf/group/cloud-native-hyderabad/event/tr9jkbf"
+    },
+    {
       "date": "June 4",
       "year": "2026",
       "title": "Kubernetes Sri Lanka",
@@ -18,7 +28,7 @@
       "type": "Meetup",
       "location": "London, UK",
       "action": "More Details",
-      "href": "https://www.meetup.com/cloud-native-london/events/312972430/?eventOrigin=group_upcoming_events"
+      "href": "https://www.meetup.com/cloud-native-london/events/312972430/"
     }
   ]
 }

--- a/src/pages/community/styles.module.css
+++ b/src/pages/community/styles.module.css
@@ -140,6 +140,10 @@
   line-height: 1;
 }
 
+.eventDateRange strong {
+  font-size: 1.15rem;
+}
+
 .eventDivider {
   width: 1px;
   background: var(--ifm-color-emphasis-200);
@@ -456,6 +460,10 @@
 
   .eventDate strong {
     font-size: 2rem;
+  }
+
+  .eventDateRange strong {
+    font-size: 1.15rem;
   }
 
   .pastEvent {


### PR DESCRIPTION
## Purpose
  Follow-up fixes for the Community page (#708):

  - **Move stale event to past events** — Cloud Native Hyderabad (June 11) was
    listed as upcoming but has already taken place. Moved it to past events with
    the talk details ("Role of Developer Platforms in the Era of Agentic
    Software Development").
  - **Fix KubeCon date range** — the date badge showed `18  19` (double space);
    now `18–19`. Also added a smaller font size for multi-day ranges so the text
    doesn't clip inside the fixed-width date badge (desktop and mobile).
  - **Remove duplicated past-events data** — the community page's past-events
    strip previously read from a `pastEvents` block in `events.json`, duplicating
    `past-events.json`. It now derives from `past-events.json`, so future event
    updates only touch one file.