### PR TITLE
fix: use plain code fence for OTel collector install snippet

### DIFF
--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -1120,43 +1120,43 @@ kubectl patch clusterworkflowplane default --type merge \
 
 #### Enable kubernetes events collection and exporting to logs module
 
-<CodeBlock language="bash">
-  {`helm upgrade --install observability-events-otel-collector \\
-    oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \\
-    --namespace openchoreo-observability-plane \\
-    --version 0.1.1 \\
-    -f - <<'EOF'
-  collector:
-    extraEnv:
-      - name: OPENSEARCH_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: opensearch-admin-credentials
-            key: username
-      - name: OPENSEARCH_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: opensearch-admin-credentials
-            key: password
-  extraExtensions:
-    basicauth/opensearch:
-      client_auth:
-        username: \${env:OPENSEARCH_USERNAME}
-        password: \${env:OPENSEARCH_PASSWORD}
-  exporters:
-    opensearch:
-      logs_index: "k8s-events"
-      logs_index_time_format: "yyyy-MM-dd"
-      http:
-        endpoint: "https://opensearch:9200"
-        tls:
-          insecure_skip_verify: true
-        auth:
-          authenticator: basicauth/opensearch
-  pipelineExporters:
-    - opensearch
-  EOF`}
-</CodeBlock>
+```bash
+helm upgrade --install observability-events-otel-collector \
+  oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \
+  --namespace openchoreo-observability-plane \
+  --version 0.1.1 \
+  -f - <<'EOF'
+collector:
+  extraEnv:
+    - name: OPENSEARCH_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-admin-credentials
+          key: username
+    - name: OPENSEARCH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-admin-credentials
+          key: password
+extraExtensions:
+  basicauth/opensearch:
+    client_auth:
+      username: ${env:OPENSEARCH_USERNAME}
+      password: ${env:OPENSEARCH_PASSWORD}
+exporters:
+  opensearch:
+    logs_index: "k8s-events"
+    logs_index_time_format: "yyyy-MM-dd"
+    http:
+      endpoint: "https://opensearch:9200"
+      tls:
+        insecure_skip_verify: true
+      auth:
+        authenticator: basicauth/opensearch
+pipelineExporters:
+  - opensearch
+EOF
+```
 
 Verify the observer is reachable:
 

--- a/versioned_docs/version-v1.2.0-m.1/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.2.0-m.1/getting-started/try-it-out/on-your-environment.mdx
@@ -1120,43 +1120,43 @@ kubectl patch clusterworkflowplane default --type merge \
 
 #### Enable kubernetes events collection and exporting to logs module
 
-<CodeBlock language="bash">
-  {`helm upgrade --install observability-events-otel-collector \\
-    oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \\
-    --namespace openchoreo-observability-plane \\
-    --version 0.1.1 \\
-    -f - <<'EOF'
-  collector:
-    extraEnv:
-      - name: OPENSEARCH_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: opensearch-admin-credentials
-            key: username
-      - name: OPENSEARCH_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: opensearch-admin-credentials
-            key: password
-  extraExtensions:
-    basicauth/opensearch:
-      client_auth:
-        username: \${env:OPENSEARCH_USERNAME}
-        password: \${env:OPENSEARCH_PASSWORD}
-  exporters:
-    opensearch:
-      logs_index: "k8s-events"
-      logs_index_time_format: "yyyy-MM-dd"
-      http:
-        endpoint: "https://opensearch:9200"
-        tls:
-          insecure_skip_verify: true
-        auth:
-          authenticator: basicauth/opensearch
-  pipelineExporters:
-    - opensearch
-  EOF`}
-</CodeBlock>
+```bash
+helm upgrade --install observability-events-otel-collector \
+  oci://ghcr.io/openchoreo/helm-charts/observability-events-otel-collector \
+  --namespace openchoreo-observability-plane \
+  --version 0.1.1 \
+  -f - <<'EOF'
+collector:
+  extraEnv:
+    - name: OPENSEARCH_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-admin-credentials
+          key: username
+    - name: OPENSEARCH_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-admin-credentials
+          key: password
+extraExtensions:
+  basicauth/opensearch:
+    client_auth:
+      username: ${env:OPENSEARCH_USERNAME}
+      password: ${env:OPENSEARCH_PASSWORD}
+exporters:
+  opensearch:
+    logs_index: "k8s-events"
+    logs_index_time_format: "yyyy-MM-dd"
+    http:
+      endpoint: "https://opensearch:9200"
+      tls:
+        insecure_skip_verify: true
+      auth:
+        authenticator: basicauth/opensearch
+pipelineExporters:
+  - opensearch
+EOF
+```
 
 Verify the observer is reachable:
 


### PR DESCRIPTION
## Purpose
The observability-events-otel-collector install snippet in the 'Run in Your Environment' guide was wrapped in a JSX
<CodeBlock>{`...`}</CodeBlock> template literal. The template-literal rendering stripped the YAML nesting indentation, so when copied and piped to `helm install -f -` the values flattened (e.g. `extraEnv` landed at the root instead of under `collector`), leaving `.Values.collector` empty and failing with a nil-pointer error.

Convert the block to a plain ```bash fence, matching the working on-k3d-locally snippet byte-for-byte. This also drops the awkward `\${env:...}` escaping in favor of the literal `${env:...}` OTel expects.

## Related Issues
openchoreo/openchoreo#3826

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
