### PR TITLE
docs: add Metrics - Azure Monitor to marketplace plugins

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -481,6 +481,25 @@
     "released": true
   },
   {
+    "id": "metrics-azure-monitor",
+    "group": "module",
+    "name": "Metrics - Azure Monitor",
+    "description": "The Observability Metrics Module for Azure Monitor queries OpenChoreo application and resource metrics from a Log Analytics workspace populated by the AKS Container Insights addon, and exposes them through the OpenChoreo Portal, CLI, and MCP servers, with support for metric-based alerts via Azure Monitor scheduled query rules.",
+    "category": "Observability",
+    "tags": [
+      "metrics",
+      "observability",
+      "azure",
+      "azuremonitor",
+      "aks"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/observability-metrics-azure-monitor",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "tracing-xray",
     "group": "module",
     "name": "Tracing - AWS X-Ray",


### PR DESCRIPTION
## Purpose

The `observability-metrics-azure-monitor` community module is missing from the
marketplace plugin listing. This PR adds its entry so it appears alongside the
other observability adapters in the ecosystem/marketplace.

## Approach

- Add a `metrics-azure-monitor` entry to `src/data/marketplace-plugins.json`,
  placed next to the sibling `metrics-cloudwatch` listing.
- Mirror the wording of the sibling `Metrics - AWS CloudWatch` and
  `Logs - Azure Log Analytics` entries: queries application/resource metrics from
  a Log Analytics workspace populated by the AKS Container Insights addon, with
  metric-based alerts via Azure Monitor scheduled query rules.
- Tags: `metrics, observability, azure, azuremonitor, aks`; `released: true`,
  `default: false`, matching the other cloud-provider observability entries.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)