### PR TITLE
docs: bump Gateway API to v1.5.1 and kgateway to v2.3.1

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -119,7 +119,7 @@ The [Gateway API](https://gateway-api.sigs.k8s.io/) is the Kubernetes-native way
 
 ```bash
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 ```
 
 #### cert-manager
@@ -155,14 +155,13 @@ helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/ex
 ```bash
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-control-plane \
-  --version v2.2.1
+  --version v2.3.1
 ```
 
 ```bash
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace \
-  --version v2.2.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 ```
 
 #### OpenBao (Secret Backend)

--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -119,7 +119,7 @@ The [Gateway API](https://gateway-api.sigs.k8s.io/) is the Kubernetes-native way
 
 ```bash
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 #### cert-manager

--- a/docs/getting-started/try-it-out/on-k3d-locally/k3d-prerequisites.sh
+++ b/docs/getting-started/try-it-out/on-k3d-locally/k3d-prerequisites.sh
@@ -9,7 +9,7 @@ step() {
 
 step "Installing Gateway API CRDs..."
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 
 step "Installing cert-manager..."
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
@@ -30,13 +30,12 @@ helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/ex
 step "Installing kgateway CRDs..."
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-control-plane \
-  --version v2.2.1
+  --version v2.3.1
 
 step "Installing kgateway..."
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace \
-  --version v2.2.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 
 step "Installing OpenBao..."
 helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \

--- a/docs/getting-started/try-it-out/on-k3d-locally/k3d-prerequisites.sh
+++ b/docs/getting-started/try-it-out/on-k3d-locally/k3d-prerequisites.sh
@@ -9,7 +9,7 @@ step() {
 
 step "Installing Gateway API CRDs..."
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 step "Installing cert-manager..."
 helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -91,7 +91,7 @@ The [Gateway API](https://gateway-api.sigs.k8s.io/) is the Kubernetes-native way
 
 ```bash
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 ```
 
 #### cert-manager

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -91,7 +91,7 @@ The [Gateway API](https://gateway-api.sigs.k8s.io/) is the Kubernetes-native way
 
 ```bash
 kubectl apply --server-side \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml
 ```
 
 #### cert-manager
@@ -127,14 +127,13 @@ helm upgrade --install external-secrets oci://ghcr.io/external-secrets/charts/ex
 ```bash
 helm upgrade --install kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
   --create-namespace --namespace openchoreo-control-plane \
-  --version v2.2.1
+  --version v2.3.1
 ```
 
 ```bash
 helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --namespace openchoreo-control-plane --create-namespace \
-  --version v2.2.1 \
-  --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
+  --version v2.3.1
 ```
 
 #### OpenBao (Secret Backend)


### PR DESCRIPTION
## Purpose
Update the K3d and on-your-environment installation guides to use Gateway API v1.5.1 and kgateway v2.3.1. Drop the KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES flag from the kgateway install since TLSRoute graduated to the standard channel in Gateway API 1.5.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3836

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
