### PR TITLE
docs: bump observability module versions in install guides

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -792,7 +792,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.3 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -804,7 +804,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -825,7 +825,7 @@ helm upgrade --install observability-metrics-prometheus \
 helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.3 \
   --reuse-values \
   --set fluent-bit.enabled=true
 ```

--- a/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
+++ b/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
@@ -21,7 +21,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.3 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 
 step "Installing OpenSearch-based traces module..."
@@ -29,7 +29,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 
@@ -44,7 +44,7 @@ step "Enabling logs collection in the configured logs module..."
 helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.3 \
   --reuse-values \
   --set fluent-bit.enabled=true
 

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -980,7 +980,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.1 \
+  --version 0.5.3 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -1002,7 +1002,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -1131,7 +1131,7 @@ kubectl patch clusterworkflowplane default --type merge \
 <CodeBlock language="bash">
   {`helm upgrade -n openchoreo-observability-plane observability-logs-opensearch \\
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \\
-  --version 0.5.1 \\
+  --version 0.5.3 \\
   --reuse-values \\
   --set fluent-bit.enabled=true`}
 </CodeBlock>

--- a/docs/platform-engineer-guide/upgrades.mdx
+++ b/docs/platform-engineer-guide/upgrades.mdx
@@ -141,27 +141,27 @@ kubectl patch deployment observer -n openchoreo-observability-plane \
 If you are using the default logs, metrics, and traces modules with the versions specified in OpenChoreo v1.0.0 documentation,
 you may also need to upgrade them to the versions compatible with OpenChoreo {versions.helmChart} as well.
 
-- Observability Logs OpenSearch module: v0.3.11 -> v0.4.1
+- Observability Logs OpenSearch module: v0.3.11 -> v0.5.3
 
 ```bash
 helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.5.3 \
   --reset-then-reuse-values \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials"
 ```
 
-- Observability Traces OpenSearch module: v0.3.11 -> v0.4.1
+- Observability Traces OpenSearch module: v0.3.11 -> v0.4.2
 
 ```bash
 helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.4.2 \
  --reset-then-reuse-values \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"


### PR DESCRIPTION
## Purpose
Update observability-logs-opensearch to 0.5.3 and observability-tracing-opensearch to 0.4.2 across the k3d, on-your-environment, and upgrade guides.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3836

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
