### PR TITLE
docs: add Tracing - Azure Application Insights to marketplace plugins

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -518,6 +518,25 @@
     "released": true
   },
   {
+    "id": "tracing-azure-appinsights",
+    "group": "module",
+    "name": "Tracing - Azure Application Insights",
+    "description": "The Observability Tracing Module for Azure Application Insights collects OpenChoreo application traces using the OpenTelemetry Collector and stores them in a workspace-based Application Insights resource, exposing them through the OpenChoreo Portal, CLI, and MCP servers by running KQL against the backing Log Analytics workspace.",
+    "category": "Observability",
+    "tags": [
+      "tracing",
+      "observability",
+      "azure",
+      "azuremonitor",
+      "appinsights"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/observability-tracing-azure-appinsights",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "networking-cilium",
     "group": "module",
     "name": "Networking - Cilium",


### PR DESCRIPTION
## Description

Adds the **Tracing - Azure Application Insights** community module to the marketplace plugins listing.

The module collects OpenChoreo application traces using the OpenTelemetry Collector and stores them in a workspace-based Application Insights resource, exposing them through the OpenChoreo Portal, CLI, and MCP servers by running KQL against the backing Log Analytics workspace.

The entry mirrors the existing sibling tracing/Azure modules (AWS X-Ray tracing, Azure Monitor metrics):
- **id:** `tracing-azure-appinsights`
- **category:** Observability
- **tags:** tracing, observability, azure, azuremonitor, appinsights
- **sourceUrl:** https://github.com/openchoreo/community-modules/tree/main/observability-tracing-azure-appinsights