### PR TITLE
docs(backstage-plugins): rewrite install guide for Backstage 1.51 + NFS

### DIFF
--- a/docs/platform-engineer-guide/backstage-plugins/compatibility-matrix.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/compatibility-matrix.mdx
@@ -53,32 +53,32 @@ All plugins ship with both a default (legacy) export and a `/alpha` export for u
 
 Installed and wired by [section 4 of the install guide](./installing-into-existing-backstage.mdx#core).
 
-| Package                                                                    | Role                    | `/alpha` | Notes                                        |
-| -------------------------------------------------------------------------- | ----------------------- | -------- | -------------------------------------------- |
+| Package                                                                    | Role                    | `/alpha` | Notes                                          |
+| -------------------------------------------------------------------------- | ----------------------- | -------- | ---------------------------------------------- |
 | `@openchoreo/backstage-plugin`                                             | `frontend-plugin`       | ✓        | Cell, Deploy, Definition tabs; overview cards. |
-| `@openchoreo/backstage-plugin-react`                                       | `web-library`           | —        | Shared React hooks (permission hooks, etc.). |
-| `@openchoreo/backstage-design-system`                                      | `web-library`           | —        | MUI v4 theme + form widgets.                 |
-| `@openchoreo/backstage-plugin-common`                                      | `common-library`        | —        | Constants, types, relation refs.             |
-| `@openchoreo/backstage-plugin-backend`                                     | `backend-plugin`        | —        | Powers `/api/openchoreo/*`.                  |
-| `@openchoreo/backstage-plugin-catalog-backend-module`                      | `backend-plugin-module` | —        | Catalog entity provider + service factories. |
-| `@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy` | `backend-plugin-module` | —        | Permission policy.                           |
-| `@openchoreo/backstage-plugin-scaffolder-backend-module`                   | `backend-plugin-module` | —        | Scaffolder actions.                          |
-| `@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth`         | `backend-plugin-module` | —        | OpenChoreo OIDC sign-in.                     |
-| `@openchoreo/openchoreo-client-node`                                       | `node-library`          | —        | Generated typed API client.                  |
-| `@openchoreo/openchoreo-auth`                                              | `node-library`          | —        | Token service + IDP middleware.              |
+| `@openchoreo/backstage-plugin-react`                                       | `web-library`           | —        | Shared React hooks (permission hooks, etc.).   |
+| `@openchoreo/backstage-design-system`                                      | `web-library`           | —        | MUI v4 theme + form widgets.                   |
+| `@openchoreo/backstage-plugin-common`                                      | `common-library`        | —        | Constants, types, relation refs.               |
+| `@openchoreo/backstage-plugin-backend`                                     | `backend-plugin`        | —        | Powers `/api/openchoreo/*`.                    |
+| `@openchoreo/backstage-plugin-catalog-backend-module`                      | `backend-plugin-module` | —        | Catalog entity provider + service factories.   |
+| `@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy` | `backend-plugin-module` | —        | Permission policy.                             |
+| `@openchoreo/backstage-plugin-scaffolder-backend-module`                   | `backend-plugin-module` | —        | Scaffolder actions.                            |
+| `@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth`         | `backend-plugin-module` | —        | OpenChoreo OIDC sign-in.                       |
+| `@openchoreo/openchoreo-client-node`                                       | `node-library`          | —        | Generated typed API client.                    |
+| `@openchoreo/openchoreo-auth`                                              | `node-library`          | —        | Token service + IDP middleware.                |
 
 ### Optional tab packs
 
 Installed and wired by [sections 5–7 of the install guide](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional). Each frontend/backend pair is installed together.
 
-| Package                                                         | Role              | `/alpha` | Tabs delivered                                                            |
-| --------------------------------------------------------------- | ----------------- | -------- | ------------------------------------------------------------------------- |
+| Package                                                         | Role              | `/alpha` | Tabs delivered                                                                            |
+| --------------------------------------------------------------- | ----------------- | -------- | ----------------------------------------------------------------------------------------- |
 | `@openchoreo/backstage-plugin-openchoreo-observability`         | `frontend-plugin` | ✓        | Component → Logs/Events/Metrics/Alerts/Wirelogs, System → Logs/Traces/Incidents/RCA/Cost. |
-| `@openchoreo/backstage-plugin-openchoreo-observability-backend` | `backend-plugin`  | —        | Backend + `/resolve-urls` for the observability tabs.                     |
-| `@openchoreo/backstage-plugin-openchoreo-ci`                    | `frontend-plugin` | ✓        | Component → Build.                                                        |
-| `@openchoreo/backstage-plugin-openchoreo-ci-backend`            | `backend-plugin`  | —        | Backend for the Build tab.                                                |
-| `@openchoreo/backstage-plugin-openchoreo-workflows`             | `frontend-plugin` | ✓        | Standalone `/workflows` page + Runs tab on Workflow/ClusterWorkflow.       |
-| `@openchoreo/backstage-plugin-openchoreo-workflows-backend`     | `backend-plugin`  | —        | Backend for the workflows page.                                           |
+| `@openchoreo/backstage-plugin-openchoreo-observability-backend` | `backend-plugin`  | —        | Backend + `/resolve-urls` for the observability tabs.                                     |
+| `@openchoreo/backstage-plugin-openchoreo-ci`                    | `frontend-plugin` | ✓        | Component → Build.                                                                        |
+| `@openchoreo/backstage-plugin-openchoreo-ci-backend`            | `backend-plugin`  | —        | Backend for the Build tab.                                                                |
+| `@openchoreo/backstage-plugin-openchoreo-workflows`             | `frontend-plugin` | ✓        | Standalone `/workflows` page + Runs tab on Workflow/ClusterWorkflow.                      |
+| `@openchoreo/backstage-plugin-openchoreo-workflows-backend`     | `backend-plugin`  | —        | Backend for the workflows page.                                                           |
 
 ### Also published
 

--- a/docs/platform-engineer-guide/backstage-plugins/compatibility-matrix.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/compatibility-matrix.mdx
@@ -12,131 +12,73 @@ The OpenChoreo plugin set is tested against a specific Backstage release line. I
 
 | Component              | Version      |
 | ---------------------- | ------------ |
-| Backstage release line | **1.43.3**   |
+| Backstage release line | **1.51.0**   |
 | Node.js                | 20.x or 22.x |
-| Yarn                   | 4.4.1        |
-| `@backstage/cli`       | 0.34.3       |
-| OpenChoreo plugin set  | `1.1.x`      |
+| Yarn                   | 4.13.x       |
+| `@backstage/cli`       | 0.36.x       |
+| OpenChoreo plugin set  | `1.2.x`      |
 
 ## Required `resolutions`
 
-Add the following to your workspace root `package.json`. These pins keep transitive `@backstage/*` ranges from drifting to newer minors that the plugins have not been validated against.
+Add the following to your workspace root `package.json`. The MUI pin keeps `material-ui-popup-state` from resolving to a nested MUI 5.13.x that lacks the `/version` subpath (which Rspack fails to compile against). The React pins keep types consistent across the dep graph.
 
-```json
+```json title="package.json"
 {
   "resolutions": {
-    "@types/react": "18.3.26",
-    "@types/react-dom": "18.3.7",
-    "csstype": "3.1.3",
-
-    "@backstage/app-defaults": "1.7.0",
-    "@backstage/backend-app-api": "1.2.7",
-    "@backstage/backend-defaults": "0.12.1",
-    "@backstage/backend-plugin-api": "1.4.3",
-    "@backstage/catalog-client": "1.12.0",
-    "@backstage/catalog-model": "1.7.5",
-    "@backstage/cli": "0.34.3",
-    "@backstage/cli-common": "0.1.15",
-    "@backstage/cli-node": "0.2.14",
-    "@backstage/config": "1.3.4",
-    "@backstage/config-loader": "1.10.4",
-    "@backstage/core-app-api": "1.19.0",
-    "@backstage/core-components": "0.18.1",
-    "@backstage/core-plugin-api": "1.11.0",
-    "@backstage/errors": "1.2.7",
-    "@backstage/integration": "1.18.0",
-    "@backstage/integration-react": "1.2.10",
-    "@backstage/plugin-api-docs": "0.12.11",
-    "@backstage/plugin-app-backend": "0.5.6",
-    "@backstage/plugin-auth-backend": "0.25.4",
-    "@backstage/plugin-auth-backend-module-github-provider": "0.3.7",
-    "@backstage/plugin-auth-backend-module-guest-provider": "0.2.12",
-    "@backstage/plugin-auth-node": "0.6.7",
-    "@backstage/plugin-catalog": "1.31.3",
-    "@backstage/plugin-catalog-backend": "3.1.1",
-    "@backstage/plugin-catalog-backend-module-logs": "0.1.14",
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "0.2.12",
-    "@backstage/plugin-catalog-common": "1.1.5",
-    "@backstage/plugin-catalog-graph": "0.5.1",
-    "@backstage/plugin-catalog-import": "0.13.5",
-    "@backstage/plugin-catalog-node": "1.19.0",
-    "@backstage/plugin-catalog-react": "1.21.1",
-    "@backstage/plugin-events-node": "0.4.15",
-    "@backstage/plugin-kubernetes": "0.12.11",
-    "@backstage/plugin-kubernetes-backend": "0.20.2",
-    "@backstage/plugin-kubernetes-node": "0.3.4",
-    "@backstage/plugin-org": "0.6.44",
-    "@backstage/plugin-permission-backend": "0.7.4",
-    "@backstage/plugin-permission-common": "0.9.1",
-    "@backstage/plugin-permission-node": "0.10.4",
-    "@backstage/plugin-permission-react": "0.4.36",
-    "@backstage/plugin-proxy-backend": "0.6.6",
-    "@backstage/plugin-scaffolder": "1.34.1",
-    "@backstage/plugin-scaffolder-backend": "2.2.1",
-    "@backstage/plugin-scaffolder-backend-module-github": "0.9.0",
-    "@backstage/plugin-scaffolder-common": "1.7.1",
-    "@backstage/plugin-scaffolder-node": "0.11.1",
-    "@backstage/plugin-scaffolder-react": "1.19.1",
-    "@backstage/plugin-search": "1.4.30",
-    "@backstage/plugin-search-backend": "2.0.6",
-    "@backstage/plugin-search-backend-module-catalog": "0.3.8",
-    "@backstage/plugin-search-backend-module-pg": "0.5.48",
-    "@backstage/plugin-search-backend-node": "1.3.15",
-    "@backstage/plugin-search-react": "1.9.4",
-    "@backstage/plugin-techdocs": "1.15.0",
-    "@backstage/plugin-techdocs-backend": "2.1.0",
-    "@backstage/plugin-techdocs-module-addons-contrib": "1.1.28",
-    "@backstage/plugin-techdocs-react": "1.3.3",
-    "@backstage/plugin-user-settings": "0.8.28",
-    "@backstage/test-utils": "1.7.11",
-    "@backstage/theme": "0.6.8",
-    "@backstage/types": "1.2.2"
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@mui/material": "^5.18.0"
   }
 }
 ```
+
+That is the minimum. After running `yarn backstage-cli versions:bump --release 1.51.0` you do **not** need to copy a full `@backstage/*` resolutions block — `versions:bump` writes caret ranges to every `package.json` in your workspace and the lockfile pins them. Reach for explicit `@backstage/*` resolutions only when you hit a transitive-drift error at startup; the previous (1.1.x) install guide carried a 70-entry block because 1.1.x plugins were validated against a single point release.
 
 ## Aligning your existing app
 
 If your Backstage app is on a different release line, run:
 
 ```bash
-yarn backstage-cli versions:bump --release 1.43.3
+yarn backstage-cli versions:bump --release 1.51.0
+yarn install
 ```
 
-…before adding the OpenChoreo packages. Note: `versions:bump` writes caret ranges (`^x.y.z`), which still allow yarn to resolve to newer minors via transitive deps. The `resolutions` block above is what actually pins.
+…before adding the OpenChoreo packages.
 
 ## Plugin packages
+
+All plugins ship with both a default (legacy) export and a `/alpha` export for use with the [New Frontend System (NFS)](./installing-into-existing-backstage.mdx). The default export remains the entry point for hosts on the legacy frontend; `/alpha` exports a `createFrontendPlugin` instance for use in `createApp({ features: [...] })`.
 
 ### Core (required)
 
 Installed and wired by [section 4 of the install guide](./installing-into-existing-backstage.mdx#core).
 
-| Package                                                                    | Role                    | Notes                                        |
-| -------------------------------------------------------------------------- | ----------------------- | -------------------------------------------- |
-| `@openchoreo/backstage-plugin`                                             | `frontend-plugin`       | Cell, Deploy, Definition tabs.               |
-| `@openchoreo/backstage-plugin-react`                                       | `web-library`           | Shared React hooks (permission hooks, etc.). |
-| `@openchoreo/backstage-design-system`                                      | `web-library`           | MUI v4 theme + form widgets.                 |
-| `@openchoreo/backstage-plugin-common`                                      | `common-library`        | Constants, types, relation refs.             |
-| `@openchoreo/backstage-plugin-backend`                                     | `backend-plugin`        | Powers `/api/openchoreo/*`.                  |
-| `@openchoreo/backstage-plugin-catalog-backend-module`                      | `backend-plugin-module` | Catalog entity provider + service factories. |
-| `@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy` | `backend-plugin-module` | Permission policy.                           |
-| `@openchoreo/backstage-plugin-scaffolder-backend-module`                   | `backend-plugin-module` | Scaffolder actions.                          |
-| `@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth`         | `backend-plugin-module` | OpenChoreo OIDC sign-in.                     |
-| `@openchoreo/openchoreo-client-node`                                       | `node-library`          | Generated typed API client.                  |
-| `@openchoreo/openchoreo-auth`                                              | `node-library`          | Token service + IDP middleware.              |
+| Package                                                                    | Role                    | `/alpha` | Notes                                        |
+| -------------------------------------------------------------------------- | ----------------------- | -------- | -------------------------------------------- |
+| `@openchoreo/backstage-plugin`                                             | `frontend-plugin`       | ✓        | Cell, Deploy, Definition tabs; overview cards. |
+| `@openchoreo/backstage-plugin-react`                                       | `web-library`           | —        | Shared React hooks (permission hooks, etc.). |
+| `@openchoreo/backstage-design-system`                                      | `web-library`           | —        | MUI v4 theme + form widgets.                 |
+| `@openchoreo/backstage-plugin-common`                                      | `common-library`        | —        | Constants, types, relation refs.             |
+| `@openchoreo/backstage-plugin-backend`                                     | `backend-plugin`        | —        | Powers `/api/openchoreo/*`.                  |
+| `@openchoreo/backstage-plugin-catalog-backend-module`                      | `backend-plugin-module` | —        | Catalog entity provider + service factories. |
+| `@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy` | `backend-plugin-module` | —        | Permission policy.                           |
+| `@openchoreo/backstage-plugin-scaffolder-backend-module`                   | `backend-plugin-module` | —        | Scaffolder actions.                          |
+| `@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth`         | `backend-plugin-module` | —        | OpenChoreo OIDC sign-in.                     |
+| `@openchoreo/openchoreo-client-node`                                       | `node-library`          | —        | Generated typed API client.                  |
+| `@openchoreo/openchoreo-auth`                                              | `node-library`          | —        | Token service + IDP middleware.              |
 
 ### Optional tab packs
 
 Installed and wired by [sections 5–7 of the install guide](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional). Each frontend/backend pair is installed together.
 
-| Package                                                         | Role              | Tabs delivered                                                            |
-| --------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------- |
-| `@openchoreo/backstage-plugin-openchoreo-observability`         | `frontend-plugin` | Component → Logs/Metrics/Alerts, System → Logs/Traces/Incidents/RCA/Cost. |
-| `@openchoreo/backstage-plugin-openchoreo-observability-backend` | `backend-plugin`  | Backend + `/resolve-urls` for the observability tabs.                     |
-| `@openchoreo/backstage-plugin-openchoreo-ci`                    | `frontend-plugin` | Component → Build.                                                        |
-| `@openchoreo/backstage-plugin-openchoreo-ci-backend`            | `backend-plugin`  | Backend for the Build tab.                                                |
-| `@openchoreo/backstage-plugin-openchoreo-workflows`             | `frontend-plugin` | Standalone org-level workflows page.                                      |
-| `@openchoreo/backstage-plugin-openchoreo-workflows-backend`     | `backend-plugin`  | Backend for the workflows page.                                           |
+| Package                                                         | Role              | `/alpha` | Tabs delivered                                                            |
+| --------------------------------------------------------------- | ----------------- | -------- | ------------------------------------------------------------------------- |
+| `@openchoreo/backstage-plugin-openchoreo-observability`         | `frontend-plugin` | ✓        | Component → Logs/Events/Metrics/Alerts/Wirelogs, System → Logs/Traces/Incidents/RCA/Cost. |
+| `@openchoreo/backstage-plugin-openchoreo-observability-backend` | `backend-plugin`  | —        | Backend + `/resolve-urls` for the observability tabs.                     |
+| `@openchoreo/backstage-plugin-openchoreo-ci`                    | `frontend-plugin` | ✓        | Component → Build.                                                        |
+| `@openchoreo/backstage-plugin-openchoreo-ci-backend`            | `backend-plugin`  | —        | Backend for the Build tab.                                                |
+| `@openchoreo/backstage-plugin-openchoreo-workflows`             | `frontend-plugin` | ✓        | Standalone `/workflows` page + Runs tab on Workflow/ClusterWorkflow.       |
+| `@openchoreo/backstage-plugin-openchoreo-workflows-backend`     | `backend-plugin`  | —        | Backend for the workflows page.                                           |
 
 ### Also published
 
@@ -145,7 +87,7 @@ These packages live in the `@openchoreo` scope and ship on the same release cade
 | Package                                                                | Use                                                                                                                                                                       |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@openchoreo/openapi-client-generator-node`                            | Build-time generator for the typed OpenChoreo API clients. Consumed by plugin authors, not Backstage runtime.                                                             |
-| `@openchoreo/backstage-plugin-platform-engineer-core`                  | Platform-engineer home/dashboard surface used by the in-tree portal. Not part of the canonical install.                                                                   |
+| `@openchoreo/backstage-plugin-platform-engineer-core`                  | Platform-engineer home/dashboard surface used by the in-tree portal. Not part of the canonical install. Ships an `/alpha` entry point.                                    |
 | `@openchoreo/backstage-plugin-platform-engineer-core-backend`          | Backend for the above.                                                                                                                                                    |
 | `@openchoreo/backstage-plugin-thunder-idp-client-node`                 | TypeScript client for the ThunderID IDP user/group API. Used by `catalog-backend-module-openchoreo-users` below.                                                          |
 | `@openchoreo/backstage-plugin-catalog-backend-module-openchoreo-users` | Syncs ThunderID users/groups into the Backstage catalog. Install only if your OpenChoreo cluster uses ThunderID as its IDP and you want user/group entities in Backstage. |

--- a/docs/platform-engineer-guide/backstage-plugins/entity-views.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/entity-views.mdx
@@ -1,64 +1,58 @@
 ---
 title: Entity views
-description: Wiring OpenChoreo cards and tabs onto your catalog entity pages.
-sidebar_position: 4
+description: OpenChoreo cards and tabs on your catalog entity pages.
+sidebar_position: 5
 ---
 
 # Entity views
 
 OpenChoreo ships entity-page tabs for **Domain**, **System**, and **Component** entities. They mirror what the in-tree OpenChoreo portal shows, so a user navigating from the OpenChoreo UI into your Backstage instance sees the same tabs they're used to.
 
+:::tip Under NFS, tabs auto-mount
+
+If you followed the [install guide Section 4 — Core](./installing-into-existing-backstage.mdx#core) on the default NFS scaffold, every tab in the table below is contributed by the plugin's `/alpha` export as an `EntityContentBlueprint` extension and mounts automatically on the correct entity kind. **You do not need to edit `EntityPage.tsx`** (the NFS scaffold does not even create one). The [wiring example](#legacy-wiring) further down applies only to legacy hosts.
+
+:::
+
 ## Tab catalog
 
-Every tab below ships in one of three "tab packs". Install only the packs whose tabs you want; tabs whose pack is not installed simply won't appear in the layout (you control which `<EntityLayout.Route>` blocks to include in your `EntityPage.tsx`).
+Every tab below ships in one of three "tab packs". Install only the packs whose tabs you want; tabs whose pack is not installed simply won't appear in the layout.
 
-| Kind      | Tab           | Component                         | Package                                                 | Notes                                                        |
-| --------- | ------------- | --------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
-| Domain    | Overview      | (built-in)                        | `@openchoreo/backstage-plugin`                          | Cards: `NamespaceProjectsCard`, `NamespaceResourcesCard`.    |
-| Domain    | Definition    | `ResourceDefinitionTab`           | `@openchoreo/backstage-plugin`                          | Raw OpenChoreo resource manifest.                            |
-| System    | Overview      | (built-in)                        | `@openchoreo/backstage-plugin`                          | Cards: `ProjectComponentsCard`, `DeploymentPipelineCard`.    |
-| System    | Definition    | `ResourceDefinitionTab`           | `@openchoreo/backstage-plugin`                          |                                                              |
-| System    | Cell          | `CellDiagram`                     | `@openchoreo/backstage-plugin`                          | Project-level architecture view.                             |
-| System    | Diagram       | `EntityCatalogGraphCard`          | `@backstage/plugin-catalog-graph`                       | Standard catalog-graph card; no OpenChoreo package required. |
-| System    | Logs          | `ObservabilityProjectRuntimeLogs` | `@openchoreo/backstage-plugin-openchoreo-observability` | Project-scoped runtime logs.                                 |
-| System    | Traces        | `ObservabilityTraces`             | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
-| System    | Incidents     | `ObservabilityProjectIncidents`   | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
-| System    | RCA Reports   | `ObservabilityRCA`                | `@openchoreo/backstage-plugin-openchoreo-observability` | Root-cause analysis agent reports.                           |
-| System    | Cost Analysis | `ObservabilityCostAnalysis`       | `@openchoreo/backstage-plugin-openchoreo-observability` | FinOps agent reports.                                        |
-| Component | Overview      | (built-in)                        | `@openchoreo/backstage-plugin`                          | Cards: `DeploymentStatusCard`, `RuntimeHealthCard`.          |
-| Component | Definition    | `ResourceDefinitionTab`           | `@openchoreo/backstage-plugin`                          |                                                              |
-| Component | Build         | `Workflows`                       | `@openchoreo/backstage-plugin-openchoreo-ci`            | Workflow runs / triggers.                                    |
-| Component | Deploy        | `Environments`                    | `@openchoreo/backstage-plugin`                          | Per-environment runtime status.                              |
-| Component | Logs          | `ObservabilityRuntimeLogs`        | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime logs.                               |
-| Component | Metrics       | `ObservabilityMetrics`            | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
-| Component | Alerts        | `ObservabilityAlerts`             | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| Kind      | Tab           | Component / Path                          | Package                                                 | Notes                                                        |
+| --------- | ------------- | ----------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
+| Domain    | Overview      | (built-in)                                | `@openchoreo/backstage-plugin`                          | Cards: `NamespaceProjectsCard`, `NamespaceResourcesCard`.    |
+| Domain    | Definition    | `ResourceDefinitionTab` (`/definition`)   | `@openchoreo/backstage-plugin`                          | Raw OpenChoreo resource manifest.                            |
+| System    | Overview      | (built-in)                                | `@openchoreo/backstage-plugin`                          | Cards: `ProjectComponentsCard`, `DeploymentPipelineCard`.    |
+| System    | Definition    | `ResourceDefinitionTab` (`/definition`)   | `@openchoreo/backstage-plugin`                          |                                                              |
+| System    | Cell Diagram  | `CellDiagram` (`/cell-diagram`)           | `@openchoreo/backstage-plugin`                          | Project-level architecture view.                             |
+| System    | Logs          | `ObservabilityProjectRuntimeLogs` (`/logs`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Project-scoped runtime logs.                                 |
+| System    | Traces        | `ObservabilityTraces` (`/traces`)         | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| System    | Incidents     | `ObservabilityProjectIncidents` (`/incidents`) | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                          |
+| System    | RCA Reports   | `ObservabilityRCA` (`/rca-reports`)       | `@openchoreo/backstage-plugin-openchoreo-observability` | Root-cause analysis agent reports.                           |
+| System    | Cost Analysis | `ObservabilityCostAnalysis` (`/cost-analysis`) | `@openchoreo/backstage-plugin-openchoreo-observability` | FinOps agent reports.                                        |
+| Component | Overview      | (built-in)                                | `@openchoreo/backstage-plugin`                          | Cards: `DeploymentStatusCard`, `RuntimeHealthCard`, Deployments widget. |
+| Component | Definition    | `ResourceDefinitionTab` (`/definition`)   | `@openchoreo/backstage-plugin`                          |                                                              |
+| Component | Build         | `Workflows` (`/workflows`)                | `@openchoreo/backstage-plugin-openchoreo-ci`            | Workflow runs / triggers.                                    |
+| Component | Deploy        | `Environments` (`/environments`)          | `@openchoreo/backstage-plugin`                          | Per-environment runtime status.                              |
+| Component | Logs          | `ObservabilityRuntimeLogs` (`/runtime-logs`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime logs.                            |
+| Component | Events        | `ObservabilityRuntimeEvents` (`/runtime-events`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime events.                      |
+| Component | Metrics       | `ObservabilityMetrics` (`/metrics`)       | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| Component | Alerts        | `ObservabilityAlerts` (`/alerts`)         | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
+| Component | Wirelogs      | `ObservabilityWirelogs` (`/wirelogs`)     | `@openchoreo/backstage-plugin-openchoreo-observability` | Service-mesh wire-level logs.                                |
+| Workflow / ClusterWorkflow | Runs | `WorkflowRuns` (`/runs`)                | `@openchoreo/backstage-plugin-openchoreo-workflows`     | Only for `spec.type === 'Generic'`.                          |
 
-Each `openchoreo-observability` / `openchoreo-ci` frontend package has a matching backend package (`-backend` suffix) — install both. The frontend talks to the backend at a Backstage discovery endpoint; the backend talks to OpenChoreo at `${openchoreo.baseUrl}` and `/resolve-urls` for observability.
+Each `openchoreo-observability` / `openchoreo-ci` / `openchoreo-workflows` frontend package has a matching backend package (`-backend` suffix) — install both. The frontend talks to the backend at a Backstage discovery endpoint; the backend talks to OpenChoreo at `${openchoreo.baseUrl}` and `/resolve-urls` for observability.
 
-## Wiring example
+## Cards on the Overview tab
 
-A minimal example showing all tabs wired across all three entity kinds:
+`@openchoreo/backstage-plugin`'s `/alpha` export contributes a wide set of `EntityCardBlueprint` extensions:
 
-```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
-import {
-  Environments,
-  CellDiagram,
-  ResourceDefinitionTab,
-} from "@openchoreo/backstage-plugin";
-import { Workflows } from "@openchoreo/backstage-plugin-openchoreo-ci";
-import {
-  ObservabilityMetrics,
-  ObservabilityAlerts,
-  ObservabilityRuntimeLogs,
-  ObservabilityProjectRuntimeLogs,
-  ObservabilityTraces,
-  ObservabilityProjectIncidents,
-  ObservabilityRCA,
-  ObservabilityCostAnalysis,
-} from "@openchoreo/backstage-plugin-openchoreo-observability";
-```
+- **Domain** Overview: `NamespaceProjectsCard`, `NamespaceResourcesCard`.
+- **System** Overview: `ProjectComponentsCard`, `DeploymentPipelineCard`, `CellTopologyCard`.
+- **Component** Overview: `DeploymentStatusCard`, `RuntimeHealthCard`, Deployments widget linking to the Deploy tab.
+- **Environment / DataPlane / WorkflowPlane / ObservabilityPlane / DeploymentPipeline** Overview: kind-specific status and configuration cards (30+ in total covering every OpenChoreo platform kind).
 
-See the full snippet in [Core install → Add the entity-page routes](./installing-into-existing-backstage.mdx#core-routes), plus the opt-in sections for [Observability](./installing-into-existing-backstage.mdx#5-add-observability-tabs-optional) and [CI/Build](./installing-into-existing-backstage.mdx#6-add-cibuild-tab-optional).
+Under NFS the cards auto-mount into the default Overview Grid alongside the upstream About / Links / Labels cards. Under the legacy install you compose them by hand in your `EntityPage.tsx`.
 
 ## What the views actually render
 
@@ -69,6 +63,108 @@ See the full snippet in [Core install → Add the entity-page routes](./installi
 Observability tabs first call the observability backend's `/resolve-urls` endpoint to discover the per-environment Observer/RCA/FinOps URLs, then call those services directly with the IDP token attached (header `x-openchoreo-direct: true` to bypass any intermediate proxies).
 
 The Build tab (`Workflows`) calls the CI backend, which proxies to OpenChoreo's workflow API.
+
+## Hiding or moving tabs under NFS {#nfs-customization}
+
+If you want to suppress a tab on a specific kind, or move it to a different path, override the contributed `EntityContentBlueprint` extension. Each tab is registered with a stable extension ID — find the ID in the plugin's `alpha.tsx` (e.g. `componentDeployEntityContent`) and override its `attachTo` or `disabled` in your `customAppModule`:
+
+```tsx
+import { openchoreoPluginAlphaBase } from '@openchoreo/backstage-plugin/alpha';
+
+const customised = openchoreoPluginAlphaBase.withOverrides({
+  extensions: [
+    openchoreoPluginAlphaBase
+      .getExtension('entity-content:openchoreo/component-deploy')
+      .override({
+        // hide on a specific kind, or change the route, etc.
+        disabled: true,
+      }),
+  ],
+});
+```
+
+Then add `customised` to `createApp({ features: [...] })` **instead of** `openchoreoPluginAlpha`.
+
+## Legacy wiring example {#legacy-wiring}
+
+For hosts on the legacy frontend system (see [install guide Section 9](./installing-into-existing-backstage.mdx#9-legacy-frontend-system-fallback)), tabs must be mounted by hand in `packages/app/src/components/catalog/EntityPage.tsx`:
+
+```tsx title="packages/app/src/components/catalog/EntityPage.tsx (legacy)"
+import {
+  Environments,
+  CellDiagram,
+  ResourceDefinitionTab,
+} from '@openchoreo/backstage-plugin';
+import { Workflows } from '@openchoreo/backstage-plugin-openchoreo-ci';
+import {
+  ObservabilityMetrics,
+  ObservabilityAlerts,
+  ObservabilityRuntimeLogs,
+  ObservabilityRuntimeEvents,
+  ObservabilityWirelogs,
+  ObservabilityProjectRuntimeLogs,
+  ObservabilityTraces,
+  ObservabilityProjectIncidents,
+  ObservabilityRCA,
+  ObservabilityCostAnalysis,
+} from '@openchoreo/backstage-plugin-openchoreo-observability';
+
+// componentEntityPage / defaultEntityPage:
+<EntityLayout.Route path="/environments" title="Deploy">
+  <Environments />
+</EntityLayout.Route>
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+<EntityLayout.Route path="/workflows" title="Build">
+  <Workflows />
+</EntityLayout.Route>
+<EntityLayout.Route path="/runtime-logs" title="Logs">
+  <ObservabilityRuntimeLogs />
+</EntityLayout.Route>
+<EntityLayout.Route path="/runtime-events" title="Events">
+  <ObservabilityRuntimeEvents />
+</EntityLayout.Route>
+<EntityLayout.Route path="/metrics" title="Metrics">
+  <ObservabilityMetrics />
+</EntityLayout.Route>
+<EntityLayout.Route path="/alerts" title="Alerts">
+  <ObservabilityAlerts />
+</EntityLayout.Route>
+<EntityLayout.Route path="/wirelogs" title="Wirelogs">
+  <ObservabilityWirelogs />
+</EntityLayout.Route>
+
+// systemPage:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+<EntityLayout.Route path="/cell-diagram" title="Cell">
+  <CellDiagram />
+</EntityLayout.Route>
+<EntityLayout.Route path="/logs" title="Logs">
+  <ObservabilityProjectRuntimeLogs />
+</EntityLayout.Route>
+<EntityLayout.Route path="/traces" title="Traces">
+  <ObservabilityTraces />
+</EntityLayout.Route>
+<EntityLayout.Route path="/incidents" title="Incidents">
+  <ObservabilityProjectIncidents />
+</EntityLayout.Route>
+<EntityLayout.Route path="/rca-reports" title="RCA Reports">
+  <ObservabilityRCA />
+</EntityLayout.Route>
+<EntityLayout.Route path="/cost-analysis" title="Cost Analysis">
+  <ObservabilityCostAnalysis />
+</EntityLayout.Route>
+
+// domainPage:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+```
+
+OpenChoreo synced components have type strings like `deployment/web-application` and `deployment/service`. The default `componentPage` `EntitySwitch` only routes `service`/`website` to the page that includes Environments — add the Environments route to `defaultEntityPage` too if you want it on every component kind.
 
 ## Other extensions you can opt into
 
@@ -85,12 +181,12 @@ The `@openchoreo/backstage-plugin` package re-exports more components than the i
 
 These ship in the same `@openchoreo/backstage-plugin` package — no extra installation step.
 
-## Hiding tabs when annotations are missing
+## Hiding tabs when annotations are missing (legacy)
 
-If you want the tabs to only appear on entities that the OpenChoreo provider synced, gate them on the `openchoreo.io/component-name` annotation:
+For legacy hosts that want a tab to only appear on entities the OpenChoreo provider synced, gate it on the `openchoreo.io/component-name` annotation:
 
 ```tsx
-import { isOpenChoreoComponent } from "@openchoreo/backstage-plugin-common";
+import { isOpenChoreoComponent } from '@openchoreo/backstage-plugin-common';
 
 <EntityLayout.Route
   path="/environments"
@@ -105,7 +201,7 @@ import { isOpenChoreoComponent } from "@openchoreo/backstage-plugin-common";
 
 ## Frontend dependencies
 
-The plugin uses **MUI v4** (`@material-ui/core@4.12.x`), matching Backstage's current default. If your host app has migrated to MUI v5, you must keep both: do not remove `@material-ui/core@4.x` from your dependencies.
+The plugin uses **MUI v4** (`@material-ui/core@4.12.x`), matching Backstage's current default. If your host app has migrated to MUI v5, you must keep both: do not remove `@material-ui/core@4.x` from your dependencies. Note that the install guide pins `@mui/material` (v5) via `resolutions` to fix a `material-ui-popup-state` transitive resolution issue — see [Section 2 of the install guide](./installing-into-existing-backstage.mdx#2-pin-backstage-versions).
 
 `@material-ui/lab@4.0.0-alpha.61` is required for some sub-components — add it to your app workspace if you do not already depend on it.
 

--- a/docs/platform-engineer-guide/backstage-plugins/entity-views.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/entity-views.mdx
@@ -18,28 +18,28 @@ If you followed the [install guide Section 4 — Core](./installing-into-existin
 
 Every tab below ships in one of three "tab packs". Install only the packs whose tabs you want; tabs whose pack is not installed simply won't appear in the layout.
 
-| Kind      | Tab           | Component / Path                          | Package                                                 | Notes                                                        |
-| --------- | ------------- | ----------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------ |
-| Domain    | Overview      | (built-in)                                | `@openchoreo/backstage-plugin`                          | Cards: `NamespaceProjectsCard`, `NamespaceResourcesCard`.    |
-| Domain    | Definition    | `ResourceDefinitionTab` (`/definition`)   | `@openchoreo/backstage-plugin`                          | Raw OpenChoreo resource manifest.                            |
-| System    | Overview      | (built-in)                                | `@openchoreo/backstage-plugin`                          | Cards: `ProjectComponentsCard`, `DeploymentPipelineCard`.    |
-| System    | Definition    | `ResourceDefinitionTab` (`/definition`)   | `@openchoreo/backstage-plugin`                          |                                                              |
-| System    | Cell Diagram  | `CellDiagram` (`/cell-diagram`)           | `@openchoreo/backstage-plugin`                          | Project-level architecture view.                             |
-| System    | Logs          | `ObservabilityProjectRuntimeLogs` (`/logs`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Project-scoped runtime logs.                                 |
-| System    | Traces        | `ObservabilityTraces` (`/traces`)         | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
-| System    | Incidents     | `ObservabilityProjectIncidents` (`/incidents`) | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                          |
-| System    | RCA Reports   | `ObservabilityRCA` (`/rca-reports`)       | `@openchoreo/backstage-plugin-openchoreo-observability` | Root-cause analysis agent reports.                           |
-| System    | Cost Analysis | `ObservabilityCostAnalysis` (`/cost-analysis`) | `@openchoreo/backstage-plugin-openchoreo-observability` | FinOps agent reports.                                        |
-| Component | Overview      | (built-in)                                | `@openchoreo/backstage-plugin`                          | Cards: `DeploymentStatusCard`, `RuntimeHealthCard`, Deployments widget. |
-| Component | Definition    | `ResourceDefinitionTab` (`/definition`)   | `@openchoreo/backstage-plugin`                          |                                                              |
-| Component | Build         | `Workflows` (`/workflows`)                | `@openchoreo/backstage-plugin-openchoreo-ci`            | Workflow runs / triggers.                                    |
-| Component | Deploy        | `Environments` (`/environments`)          | `@openchoreo/backstage-plugin`                          | Per-environment runtime status.                              |
-| Component | Logs          | `ObservabilityRuntimeLogs` (`/runtime-logs`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime logs.                            |
-| Component | Events        | `ObservabilityRuntimeEvents` (`/runtime-events`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime events.                      |
-| Component | Metrics       | `ObservabilityMetrics` (`/metrics`)       | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
-| Component | Alerts        | `ObservabilityAlerts` (`/alerts`)         | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                              |
-| Component | Wirelogs      | `ObservabilityWirelogs` (`/wirelogs`)     | `@openchoreo/backstage-plugin-openchoreo-observability` | Service-mesh wire-level logs.                                |
-| Workflow / ClusterWorkflow | Runs | `WorkflowRuns` (`/runs`)                | `@openchoreo/backstage-plugin-openchoreo-workflows`     | Only for `spec.type === 'Generic'`.                          |
+| Kind                       | Tab           | Component / Path                                 | Package                                                 | Notes                                                                   |
+| -------------------------- | ------------- | ------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Domain                     | Overview      | (built-in)                                       | `@openchoreo/backstage-plugin`                          | Cards: `NamespaceProjectsCard`, `NamespaceResourcesCard`.               |
+| Domain                     | Definition    | `ResourceDefinitionTab` (`/definition`)          | `@openchoreo/backstage-plugin`                          | Raw OpenChoreo resource manifest.                                       |
+| System                     | Overview      | (built-in)                                       | `@openchoreo/backstage-plugin`                          | Cards: `ProjectComponentsCard`, `DeploymentPipelineCard`.               |
+| System                     | Definition    | `ResourceDefinitionTab` (`/definition`)          | `@openchoreo/backstage-plugin`                          |                                                                         |
+| System                     | Cell Diagram  | `CellDiagram` (`/cell-diagram`)                  | `@openchoreo/backstage-plugin`                          | Project-level architecture view.                                        |
+| System                     | Logs          | `ObservabilityProjectRuntimeLogs` (`/logs`)      | `@openchoreo/backstage-plugin-openchoreo-observability` | Project-scoped runtime logs.                                            |
+| System                     | Traces        | `ObservabilityTraces` (`/traces`)                | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                                         |
+| System                     | Incidents     | `ObservabilityProjectIncidents` (`/incidents`)   | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                                         |
+| System                     | RCA Reports   | `ObservabilityRCA` (`/rca-reports`)              | `@openchoreo/backstage-plugin-openchoreo-observability` | Root-cause analysis agent reports.                                      |
+| System                     | Cost Analysis | `ObservabilityCostAnalysis` (`/cost-analysis`)   | `@openchoreo/backstage-plugin-openchoreo-observability` | FinOps agent reports.                                                   |
+| Component                  | Overview      | (built-in)                                       | `@openchoreo/backstage-plugin`                          | Cards: `DeploymentStatusCard`, `RuntimeHealthCard`, Deployments widget. |
+| Component                  | Definition    | `ResourceDefinitionTab` (`/definition`)          | `@openchoreo/backstage-plugin`                          |                                                                         |
+| Component                  | Build         | `Workflows` (`/workflows`)                       | `@openchoreo/backstage-plugin-openchoreo-ci`            | Workflow runs / triggers.                                               |
+| Component                  | Deploy        | `Environments` (`/environments`)                 | `@openchoreo/backstage-plugin`                          | Per-environment runtime status.                                         |
+| Component                  | Logs          | `ObservabilityRuntimeLogs` (`/runtime-logs`)     | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime logs.                                          |
+| Component                  | Events        | `ObservabilityRuntimeEvents` (`/runtime-events`) | `@openchoreo/backstage-plugin-openchoreo-observability` | Component-scoped runtime events.                                        |
+| Component                  | Metrics       | `ObservabilityMetrics` (`/metrics`)              | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                                         |
+| Component                  | Alerts        | `ObservabilityAlerts` (`/alerts`)                | `@openchoreo/backstage-plugin-openchoreo-observability` |                                                                         |
+| Component                  | Wirelogs      | `ObservabilityWirelogs` (`/wirelogs`)            | `@openchoreo/backstage-plugin-openchoreo-observability` | Service-mesh wire-level logs.                                           |
+| Workflow / ClusterWorkflow | Runs          | `WorkflowRuns` (`/runs`)                         | `@openchoreo/backstage-plugin-openchoreo-workflows`     | Only for `spec.type === 'Generic'`.                                     |
 
 Each `openchoreo-observability` / `openchoreo-ci` / `openchoreo-workflows` frontend package has a matching backend package (`-backend` suffix) — install both. The frontend talks to the backend at a Backstage discovery endpoint; the backend talks to OpenChoreo at `${openchoreo.baseUrl}` and `/resolve-urls` for observability.
 
@@ -69,12 +69,12 @@ The Build tab (`Workflows`) calls the CI backend, which proxies to OpenChoreo's 
 If you want to suppress a tab on a specific kind, or move it to a different path, override the contributed `EntityContentBlueprint` extension. Each tab is registered with a stable extension ID — find the ID in the plugin's `alpha.tsx` (e.g. `componentDeployEntityContent`) and override its `attachTo` or `disabled` in your `customAppModule`:
 
 ```tsx
-import { openchoreoPluginAlphaBase } from '@openchoreo/backstage-plugin/alpha';
+import { openchoreoPluginAlphaBase } from "@openchoreo/backstage-plugin/alpha";
 
 const customised = openchoreoPluginAlphaBase.withOverrides({
   extensions: [
     openchoreoPluginAlphaBase
-      .getExtension('entity-content:openchoreo/component-deploy')
+      .getExtension("entity-content:openchoreo/component-deploy")
       .override({
         // hide on a specific kind, or change the route, etc.
         disabled: true,
@@ -186,7 +186,7 @@ These ship in the same `@openchoreo/backstage-plugin` package — no extra insta
 For legacy hosts that want a tab to only appear on entities the OpenChoreo provider synced, gate it on the `openchoreo.io/component-name` annotation:
 
 ```tsx
-import { isOpenChoreoComponent } from '@openchoreo/backstage-plugin-common';
+import { isOpenChoreoComponent } from "@openchoreo/backstage-plugin-common";
 
 <EntityLayout.Route
   path="/environments"

--- a/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
@@ -1,14 +1,19 @@
 ---
 title: Installing into an existing Backstage app
 description: Step-by-step installation of OpenChoreo plugins into your Backstage workspace.
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Installing into an existing Backstage app
 
-This guide walks through installing the OpenChoreo plugin set into a Backstage app you already own. It assumes a standard Backstage workspace produced by `npx @backstage/create-app` with the [New Backend System](https://backstage.io/docs/backend-system/) (the default since Backstage 1.32).
+This guide walks through installing the OpenChoreo plugin set into a Backstage app you already own.
 
-The guide is **organized by feature**. Sections 1–3 are setup. Section 4 (**Core**) is the only mandatory install — after finishing it you have a working OpenChoreo-aware Backstage with Domain/System/Component pages and the Cell, Deploy, and Definition tabs rendering real data. Sections 5–7 each add one optional capability on top of Core; you can install any subset independently.
+Two install paths are supported:
+
+- **New Frontend System (NFS)** — the default scaffold from `npx @backstage/create-app@latest`. Plugins are added as features to `createApp({ features: [...] })`, and every OpenChoreo entity tab and overview card auto-mounts. **No `EntityPage.tsx` edits.** This is the path you should follow unless you have a reason not to.
+- **Legacy frontend system** — for hosts scaffolded with `--legacy`, or older apps where you have heavy `EntityPage.tsx` customization you want to keep. See [Section 9 — Legacy frontend system (fallback)](#9-legacy-frontend-system-fallback).
+
+The guide is **organized by feature**. Sections 1–3 are setup. Section 4 (**Core**) is the only mandatory install — after finishing it you have a working OpenChoreo-aware Backstage with Domain/System/Component pages and the **Cell**, **Deploy**, and **Definition** tabs rendering real data. Sections 5–7 each add one optional tab pack on top of Core; you can install any subset independently.
 
 :::info
 
@@ -16,37 +21,42 @@ OpenChoreo plugins are published to **GitHub Packages** under the [`@openchoreo`
 
 :::
 
+:::tip Tracking the upcoming 1.2.0 release
+
+The install commands on this page reference `@openchoreo/<pkg>@^1.2.0`, which will be the GA dist-tag of the next plugin release. While `1.2.0` is still under active development, install via the `next` dist-tag to get the latest prerelease today:
+
+```bash
+yarn workspace app add @openchoreo/backstage-plugin@next
+```
+
+Once `1.2.0` GA is announced, swap `@next` for `@^1.2.0` to pin to the stable release.
+
+:::
+
 ## 1. Prerequisites
 
-- A Backstage workspace on the [supported Backstage version](./compatibility-matrix.mdx). This guide pins to **Backstage `1.43.3`**.
-- The workspace must be scaffolded with the **legacy** frontend system: `npx @backstage/create-app@latest --legacy`. Current `create-app` versions default to the new declarative frontend system (`createApp({ features: [...] })` in `App.tsx`), which does not match the §4.3 edits below — those edits rely on the legacy structure (`apis.ts`, `createApp({ apis, plugins, bindRoutes })`, and `components/catalog/EntityPage.tsx`).
-- Node.js **20 or 22**, Yarn **4.4.1**.
+- A Backstage workspace on the [supported Backstage version](./compatibility-matrix.mdx). This guide pins to **Backstage `1.51.0`**.
+- The workspace must be scaffolded with the **default NFS scaffold**: `npx @backstage/create-app@latest`. (Do NOT pass `--legacy`. If you must stay on legacy, see [Section 9](#9-legacy-frontend-system-fallback).)
+- Node.js **20 or 22**, Yarn **4.13.x** (the current `create-app` scaffold ships Yarn 4.13.0 in `.yarn/releases/`).
 - Access to a running OpenChoreo control plane (local `k3d` or a deployed cluster).
 - OAuth client credentials for the OpenChoreo Identity Provider (used by the catalog sync and user sign-in). On `k3d` the helm chart pre-seeds these; for a deployed cluster see [Identity configuration](../identity-configuration.mdx).
 
+:::tip Backstage version
+
+`create-app@latest` will likely give you Backstage `1.52.x` or newer at the time you read this. After scaffolding, run `yarn backstage-cli versions:bump --release 1.51.0` (covered in [Section 2](#2-pin-backstage-versions)) to align with the tested combination.
+
+:::
+
 ## 2. Pin Backstage versions
 
-Add the following resolutions to your workspace `package.json`. They lock every `@backstage/*` package to the version line that the OpenChoreo plugins are tested against. **Without these pins, transitive `@backstage/*` deps drift to newer minor versions and you will hit missing `serviceRef{alpha.core.metrics}` and similar errors at startup.**
+Add the following resolutions to your workspace `package.json`. They lock every `@backstage/*` package to the version line that the OpenChoreo plugins are tested against, and pin `@mui/material` to a version that satisfies all transitive consumers (without this `@mui/material` pin, `material-ui-popup-state` resolves to a nested copy of MUI 5.13.x that lacks the `/version` subpath and Rspack fails to compile).
 
-```json
+```json title="package.json"
 {
   "resolutions": {
-    "@types/react": "18.3.26",
-    "@types/react-dom": "18.3.7",
-    "csstype": "3.1.3",
-    "@backstage/backend-defaults": "0.12.1",
-    "@backstage/backend-plugin-api": "1.4.3",
-    "@backstage/catalog-model": "1.7.5",
-    "@backstage/cli": "0.34.3",
-    "@backstage/config": "1.3.4",
-    "@backstage/core-plugin-api": "1.11.0",
-    "@backstage/plugin-catalog-backend": "3.1.1",
-    "@backstage/plugin-catalog-backend-module-logs": "0.1.14",
-    "@backstage/plugin-catalog-node": "1.19.0",
-    "@backstage/plugin-permission-backend": "0.7.4",
-    "@backstage/plugin-permission-node": "0.10.4",
-    "@backstage/plugin-scaffolder-backend": "2.2.1",
-    "@backstage/plugin-scaffolder-node": "0.11.1"
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@mui/material": "^5.18.0"
   }
 }
 ```
@@ -56,7 +66,8 @@ For the full pinned set see the [compatibility matrix](./compatibility-matrix.md
 If your existing app is at a different Backstage release line, run:
 
 ```bash
-yarn backstage-cli versions:bump --release 1.43.3
+yarn backstage-cli versions:bump --release 1.51.0
+yarn install
 ```
 
 …to align before adding the OpenChoreo packages.
@@ -65,9 +76,17 @@ yarn backstage-cli versions:bump --release 1.43.3
 
 GitHub Packages requires authentication even for `read:packages`-only operations. Create a [classic Personal Access Token](https://github.com/settings/tokens/new) with the `read:packages` scope, then wire it into your package manager.
 
-**Yarn 4 (Berry):** add to your workspace `.yarnrc.yml`:
+**Yarn 4 (Berry)** — the current `create-app` scaffold's `.yarnrc.yml` enables a 3-day [npm minimum-age gate](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) that blocks newly published packages. Update `.yarnrc.yml` to both add the `@openchoreo` scope auth **and** pre-approve the scope so fresh OpenChoreo releases install immediately:
 
-```yaml
+```yaml title=".yarnrc.yml"
+nodeLinker: node-modules
+npmMinimalAgeGate: 3d
+npmPreapprovedPackages:
+  - '@backstage/*'
+  - '@openchoreo/*'
+
+yarnPath: .yarn/releases/yarn-4.13.0.cjs
+
 npmScopes:
   openchoreo:
     npmRegistryServer: "https://npm.pkg.github.com"
@@ -76,13 +95,6 @@ npmScopes:
 ```
 
 …then `export GITHUB_PACKAGES_TOKEN=<your-pat>` before running `yarn install`. Berry expands the `${...}` placeholder from the environment so the token never lands in the repo.
-
-**npm / Yarn Classic:** add to your workspace `.npmrc`:
-
-```
-@openchoreo:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}
-```
 
 In **CI**, GitHub Actions can use the auto-issued `GITHUB_TOKEN` instead of a PAT, provided the workflow has `permissions: { packages: read }` and the running repo is in (or a fork of) an org the package is published from.
 
@@ -104,54 +116,56 @@ If your OpenChoreo cluster runs with `features.auth.enabled: false` (no IDP), th
 
 ### 4.1 Install packages
 
-In your **app** workspace (`packages/app`):
+In your **app** workspace:
 
 ```bash
 yarn workspace app add \
-  @openchoreo/backstage-design-system@^1.1.0 \
-  @openchoreo/backstage-plugin-common@^1.1.0 \
-  @openchoreo/backstage-plugin-react@^1.1.0 \
-  @openchoreo/backstage-plugin@^1.1.0 \
+  @openchoreo/backstage-design-system@^1.2.0 \
+  @openchoreo/backstage-plugin-common@^1.2.0 \
+  @openchoreo/backstage-plugin-react@^1.2.0 \
+  @openchoreo/backstage-plugin@^1.2.0 \
   @material-ui/lab@4.0.0-alpha.61
 ```
 
-In your **backend** workspace (`packages/backend`):
+In your **backend** workspace:
 
 ```bash
 yarn workspace backend add \
-  @openchoreo/openchoreo-client-node@^1.1.0 \
-  @openchoreo/openchoreo-auth@^1.1.0 \
-  @openchoreo/backstage-plugin-common@^1.1.0 \
-  @openchoreo/backstage-plugin-catalog-backend-module@^1.1.0 \
-  @openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy@^1.1.0 \
-  @openchoreo/backstage-plugin-scaffolder-backend-module@^1.1.0 \
-  @openchoreo/backstage-plugin-backend@^1.1.0 \
-  @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth@^1.1.0
+  @openchoreo/openchoreo-client-node@^1.2.0 \
+  @openchoreo/openchoreo-auth@^1.2.0 \
+  @openchoreo/backstage-plugin-common@^1.2.0 \
+  @openchoreo/backstage-plugin-catalog-backend-module@^1.2.0 \
+  @openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy@^1.2.0 \
+  @openchoreo/backstage-plugin-scaffolder-backend-module@^1.2.0 \
+  @openchoreo/backstage-plugin-backend@^1.2.0 \
+  @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth@^1.2.0
 ```
 
 :::tip Pinning all `@openchoreo/*` to the same minor
 
-The packages above are linked together by the OpenChoreo release process — they always release with matching versions. Pinning them all to the same `^x.y.0` caret keeps your install on one consistent release line. If you want to track the cutting edge, swap `^1.1.0` for the `next` dist-tag: `yarn workspace app add @openchoreo/backstage-plugin@next` (etc.). Prereleases are published under `next`; stable releases are under `latest`.
+The packages above are linked together by the OpenChoreo release process — they always release with matching versions. Pinning them all to the same `^x.y.0` caret keeps your install on one consistent release line. If you want to track the cutting edge, swap `^1.2.0` for the `next` dist-tag: `yarn workspace app add @openchoreo/backstage-plugin@next` (etc.). Prereleases are published under `next`; stable releases are under `latest`.
 
 :::
 
 ### 4.2 Wire the backend
 
+The NFS scaffold's `packages/backend/src/index.ts` already wires `scaffolder`, `search`, `techdocs`, `kubernetes`, `notifications`, `signals`, and `mcp-actions` for you. **Add the OpenChoreo modules on top — don't replace the file.**
+
 Edit `packages/backend/src/index.ts`:
 
 ```ts title="packages/backend/src/index.ts"
-import { createBackend } from "@backstage/backend-defaults";
-import { rootHttpRouterServiceFactory } from "@backstage/backend-defaults/rootHttpRouter";
+import { createBackend } from '@backstage/backend-defaults';
+import { rootHttpRouterServiceFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import {
   immediateCatalogServiceFactory,
   annotationStoreFactory,
-} from "@openchoreo/backstage-plugin-catalog-backend-module";
-import { createIdpTokenHeaderMiddleware } from "@openchoreo/openchoreo-auth";
-import { OpenChoreoAuthModule } from "@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth";
+} from '@openchoreo/backstage-plugin-catalog-backend-module';
+import { createIdpTokenHeaderMiddleware } from '@openchoreo/openchoreo-auth';
+import { OpenChoreoAuthModule } from '@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth';
 
 const backend = createBackend();
 
-// Service factories required by the OpenChoreo plugins.
+// OpenChoreo service factories.
 // AnnotationStore is shared between the catalog module and openchoreo-backend.
 // ImmediateCatalogService lets scaffolder actions register entities synchronously.
 backend.add(immediateCatalogServiceFactory);
@@ -174,28 +188,25 @@ backend.add(
   }),
 );
 
-// ... your existing backend.add(...) lines ...
+// ... keep all the existing scaffold backend.add(...) lines ...
 
 // Sign-in: register OpenChoreo as an OIDC provider.
-backend.add(import("@backstage/plugin-auth-backend"));
 backend.add(OpenChoreoAuthModule);
-backend.add(import("@backstage/plugin-auth-backend-module-guest-provider"));
 
-// Replace `@backstage/plugin-permission-backend-module-allow-all-policy`
+// Replace the scaffold's `@backstage/plugin-permission-backend-module-allow-all-policy`
 // with the OpenChoreo permission policy. The OpenChoreo policy delegates
 // `openchoreo.*` permissions to the OpenChoreo authorization service and
 // falls back to ALLOW for everything else, so it is composable with
 // other host-app policies.
-backend.add(import("@backstage/plugin-permission-backend"));
 backend.add(
-  import("@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy"),
+  import('@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy'),
 );
 
 // IMPORTANT: register catalog-backend-module BEFORE openchoreo-backend.
 // openchoreo-backend depends on the AnnotationStore initialized by the catalog module.
-backend.add(import("@openchoreo/backstage-plugin-catalog-backend-module"));
-backend.add(import("@openchoreo/backstage-plugin-backend"));
-backend.add(import("@openchoreo/backstage-plugin-scaffolder-backend-module"));
+backend.add(import('@openchoreo/backstage-plugin-catalog-backend-module'));
+backend.add(import('@openchoreo/backstage-plugin-backend'));
+backend.add(import('@openchoreo/backstage-plugin-scaffolder-backend-module'));
 
 backend.start();
 ```
@@ -204,27 +215,68 @@ If your existing `index.ts` registers `@backstage/plugin-permission-backend-modu
 
 ### 4.3 Wire the frontend
 
-Five sub-steps, all in `packages/app/src/`. Steps 4.3.1, 4.3.3, and 4.3.4 are also prerequisites for the opt-in sections that follow.
+Three sub-steps, all in `packages/app/src/`. Compared to the legacy install, **you do not edit `EntityPage.tsx`** — every Core OpenChoreo tab (Cell, Deploy, Definition) and overview card is contributed automatically by the plugin's `/alpha` export.
 
-#### 4.3.1 Register the plugin {#register-plugin}
+#### 4.3.1 Add the OpenChoreo plugin to `createApp` {#register-plugin}
 
-Backstage's plugin auto-discovery walks the JSX tree of the rendered app to find plugins. Plugins whose only mount points are `EntityLayout.Route` tabs inside `EntitySwitch.Case` branches are **not discovered** at boot (those branches only render once an entity is loaded), so their API factories are never registered. Register `choreoPlugin` explicitly in `packages/app/src/App.tsx`:
+A fresh NFS scaffold's `packages/app/src/App.tsx` is roughly:
 
 ```tsx title="packages/app/src/App.tsx"
-import { choreoPlugin } from '@openchoreo/backstage-plugin';
+import { createApp } from '@backstage/frontend-defaults';
+import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import { navModule } from './modules/nav';
 
-const app = createApp({
-  apis,
-  plugins: [choreoPlugin], // <-- add this; opt-in sections will append more
-  bindRoutes({ bind }) { ... },
+export default createApp({
+  features: [catalogPlugin, navModule],
 });
 ```
 
-#### 4.3.2 Wire OpenChoreo sign-in {#wire-signin}
+Add the OpenChoreo plugin to the `features` array:
 
-Create `packages/app/src/apis/authRefs.ts`:
+```tsx title="packages/app/src/App.tsx"
+import { createApp } from '@backstage/frontend-defaults';
+import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import openchoreoPluginAlpha from '@openchoreo/backstage-plugin/alpha';
+import { navModule } from './modules/nav';
+import { customAppModule } from './customAppModule';
 
-```ts title="packages/app/src/apis/authRefs.ts"
+export default createApp({
+  features: [
+    catalogPlugin,
+    openchoreoPluginAlpha,
+    navModule,
+    customAppModule, // see 4.3.2 below
+  ],
+});
+```
+
+That single import gives you the **Cell**, **Deploy**, and **Definition** entity tabs (auto-mounted on Domain / System / Component pages by kind) and the OpenChoreo overview cards (Project Contents, Deployment Pipeline, Deployments widget, etc.).
+
+#### 4.3.2 Author the `customAppModule` {#custom-app-module}
+
+Create `packages/app/src/customAppModule.tsx`. It bundles three things into one frontend module:
+
+- A `SignInPageBlueprint` extension that toggles between OpenChoreo OIDC sign-in and guest sign-in based on `openchoreo.features.auth.enabled`.
+- An `ApiBlueprint` extension that registers `OpenChoreoFetchApi` against `fetchApiRef` so every tab data fetch carries the `x-openchoreo-token` header.
+- An `ApiBlueprint` extension that registers `OpenChoreoPermissionApi` against `permissionApiRef` so the Deploy tab's env-scoped permission checks include the IDP token.
+
+The `OpenChoreoFetchApi` and `OpenChoreoPermissionApi` classes are the same as the legacy install — they are not shipped by the OpenChoreo plugins; you copy them into your app.
+
+```tsx title="packages/app/src/customAppModule.tsx"
+import {
+  ApiBlueprint,
+  configApiRef,
+  createFrontendModule,
+  discoveryApiRef,
+  fetchApiRef,
+  identityApiRef,
+  oauthRequestApiRef,
+  useApi,
+} from '@backstage/frontend-plugin-api';
+import { SignInPageBlueprint } from '@backstage/plugin-app-react';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+import { SignInPage } from '@backstage/core-components';
+import { OAuth2 } from '@backstage/core-app-api';
 import {
   ApiRef,
   BackstageIdentityApi,
@@ -232,62 +284,130 @@ import {
   OAuthApi,
   ProfileInfoApi,
   SessionApi,
-} from "@backstage/core-plugin-api";
+} from '@backstage/core-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import type { Config } from '@backstage/config';
+import type { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
+import type { FetchApi } from '@backstage/frontend-plugin-api';
+
+const OPENCHOREO_TOKEN_HEADER = 'x-openchoreo-token';
+const DIRECT_MODE_HEADER = 'x-openchoreo-direct';
 
 export const openChoreoAuthApiRef: ApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 > = createApiRef({
-  id: "auth.openchoreo-auth",
+  id: 'auth.openchoreo-auth',
 });
-```
 
-Register the OAuth2 factory in `packages/app/src/apis.ts`:
+class OpenChoreoFetchApi implements FetchApi {
+  private readonly authEnabled: boolean;
 
-```tsx title="packages/app/src/apis.ts"
-import {
-  AnyApiFactory,
-  configApiRef,
-  createApiFactory,
-  discoveryApiRef,
-  oauthRequestApiRef,
-} from "@backstage/core-plugin-api";
-import { OAuth2 } from "@backstage/core-app-api";
-import { openChoreoAuthApiRef } from "./apis/authRefs";
+  constructor(
+    private readonly identityApi: IdentityApi,
+    private readonly oauthApi: OAuthApi,
+    configApi: Config,
+  ) {
+    this.authEnabled =
+      configApi.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
+    this.fetch = this.fetch.bind(this);
+  }
 
-export { openChoreoAuthApiRef };
+  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    const headers = new Headers(init?.headers);
+    const isDirect = headers.has(DIRECT_MODE_HEADER);
+    if (isDirect) headers.delete(DIRECT_MODE_HEADER);
 
-export const apis: AnyApiFactory[] = [
-  // ... your existing factories ...
-  createApiFactory({
-    api: openChoreoAuthApiRef,
-    deps: {
-      discoveryApi: discoveryApiRef,
-      oauthRequestApi: oauthRequestApiRef,
-      configApi: configApiRef,
-    },
-    factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
-      OAuth2.create({
-        discoveryApi,
-        oauthRequestApi,
-        configApi,
-        provider: {
-          id: "openchoreo-auth",
-          title: "OpenChoreo",
-          icon: () => null,
-        },
-        environment: configApi.getOptionalString("auth.environment"),
-        defaultScopes: ["openid", "profile", "email"],
+    if (isDirect) {
+      if (this.authEnabled) {
+        try {
+          const idpToken = await this.oauthApi.getAccessToken();
+          if (idpToken) headers.set('Authorization', `Bearer ${idpToken}`);
+        } catch {
+          // No IDP token — proceed unauthenticated.
+        }
+      }
+    } else {
+      const { token: backstageToken } = await this.identityApi.getCredentials();
+      if (backstageToken)
+        headers.set('Authorization', `Bearer ${backstageToken}`);
+
+      if (this.authEnabled) {
+        try {
+          const idpToken = await this.oauthApi.getAccessToken();
+          if (idpToken) headers.set(OPENCHOREO_TOKEN_HEADER, idpToken);
+        } catch {
+          // No IDP token available — proceed with just the Backstage token.
+        }
+      }
+    }
+
+    return fetch(input, { ...init, headers });
+  }
+}
+
+class OpenChoreoPermissionApi {
+  private readonly enabled: boolean;
+  private readonly authEnabled: boolean;
+  private readonly discovery: DiscoveryApi;
+  private readonly identityApi: IdentityApi;
+  private readonly oauthApi: OAuthApi;
+
+  constructor(options: {
+    config: Config;
+    discovery: DiscoveryApi;
+    identity: IdentityApi;
+    oauthApi: OAuthApi;
+  }) {
+    this.discovery = options.discovery;
+    this.identityApi = options.identity;
+    this.oauthApi = options.oauthApi;
+    this.enabled =
+      options.config.getOptionalBoolean('permission.enabled') ?? false;
+    this.authEnabled =
+      options.config.getOptionalBoolean('openchoreo.features.auth.enabled') ??
+      true;
+  }
+
+  async authorize(request: {
+    permission: { name: string };
+    resourceRef?: string;
+  }) {
+    if (!this.enabled) return { result: AuthorizeResult.ALLOW };
+
+    const permissionApiUrl = await this.discovery.getBaseUrl('permission');
+    const { token: backstageToken } = await this.identityApi.getCredentials();
+
+    let idpToken: string | undefined;
+    if (this.authEnabled) {
+      try {
+        idpToken = await this.oauthApi.getAccessToken();
+      } catch {
+        // No IDP token — proceed with just the Backstage token.
+      }
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (backstageToken) headers.Authorization = `Bearer ${backstageToken}`;
+    if (idpToken) headers[OPENCHOREO_TOKEN_HEADER] = idpToken;
+
+    const response = await fetch(`${permissionApiUrl}/authorize`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        items: [{ id: crypto.randomUUID(), ...request }],
       }),
-  }),
-];
-```
+    });
 
-Swap the `SignInPage` component in `packages/app/src/App.tsx` for a feature-gated wrapper. This lets you toggle sign-in via `openchoreo.features.auth.enabled` without changing code — when your cluster runs with auth off, it falls through to guest sign-in:
+    if (!response.ok) {
+      throw new Error(`Permission request failed: ${response.statusText}`);
+    }
 
-```tsx title="packages/app/src/App.tsx"
-import { SignInPage } from '@backstage/core-components';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { openChoreoAuthApiRef } from './apis/authRefs';
+    const data = await response.json();
+    return data.items[0];
+  }
+}
 
 function DynamicSignInPage(props: any) {
   const configApi = useApi(configApiRef);
@@ -311,254 +431,94 @@ function DynamicSignInPage(props: any) {
   );
 }
 
-const app = createApp({
-  apis,
-  plugins: [...],
-  components: { SignInPage: DynamicSignInPage }, // <-- here
-  // ...
+export const customAppModule = createFrontendModule({
+  pluginId: 'app',
+  extensions: [
+    SignInPageBlueprint.make({
+      params: {
+        loader: async () => DynamicSignInPage,
+      },
+    }),
+    ApiBlueprint.make({
+      name: 'openchoreo-auth',
+      params: defineParams =>
+        defineParams({
+          api: openChoreoAuthApiRef,
+          deps: {
+            discoveryApi: discoveryApiRef,
+            oauthRequestApi: oauthRequestApiRef,
+            configApi: configApiRef,
+          },
+          factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
+            OAuth2.create({
+              discoveryApi,
+              oauthRequestApi,
+              configApi,
+              provider: {
+                id: 'openchoreo-auth',
+                title: 'OpenChoreo',
+                icon: () => null,
+              },
+              environment: configApi.getOptionalString('auth.environment'),
+              defaultScopes: ['openid', 'profile', 'email'],
+            }),
+        }),
+    }),
+    ApiBlueprint.make({
+      name: 'fetch-api',
+      params: defineParams =>
+        defineParams({
+          api: fetchApiRef,
+          deps: {
+            identityApi: identityApiRef,
+            oauthApi: openChoreoAuthApiRef,
+            configApi: configApiRef,
+          },
+          factory: ({ identityApi, oauthApi, configApi }) =>
+            new OpenChoreoFetchApi(identityApi, oauthApi, configApi),
+        }),
+    }),
+    ApiBlueprint.make({
+      name: 'permission-api',
+      params: defineParams =>
+        defineParams({
+          api: permissionApiRef,
+          deps: {
+            configApi: configApiRef,
+            discoveryApi: discoveryApiRef,
+            identityApi: identityApiRef,
+            oauthApi: openChoreoAuthApiRef,
+          },
+          factory: ({ configApi, discoveryApi, identityApi, oauthApi }) =>
+            new OpenChoreoPermissionApi({
+              config: configApi,
+              discovery: discoveryApi,
+              identity: identityApi,
+              oauthApi,
+            }) as any,
+        }),
+    }),
+  ],
 });
 ```
 
-:::warning Backend and frontend gates must agree
+:::warning Backend and frontend auth flags must agree
 
-`openchoreo.features.auth.enabled` is read in both places. If the backend module sees it as `true` but the SignInPage falls through to guest, the OpenChoreo authz API will reject the guest token. Set it once in `app-config` and let both sides read it.
+`openchoreo.features.auth.enabled` is read in both places (4.3.2 here and 4.2 on the backend). If the backend module sees it as `true` but `DynamicSignInPage` falls through to guest, the OpenChoreo authz API will reject the guest token. Set it once in `app-config` and let both sides read it.
 
 :::
 
-#### 4.3.3 Override `fetchApi` to inject the IDP token {#fetch-api}
+#### 4.3.3 Entity-page tabs — already done {#entity-tabs-auto}
 
-The OpenChoreo backend modules read an `x-openchoreo-token` header from incoming requests, populated by `createIdpTokenHeaderMiddleware()` you wired in [4.2 Wire the backend](#42-wire-the-backend). Backstage's default `fetchApi` does not know about that header — it only injects the Backstage identity token in `Authorization`. Without overriding `fetchApi`, **every tab data fetch goes out without the IDP token and the backend responds 401**.
+Under NFS, every Core OpenChoreo tab is contributed by `openchoreoPluginAlpha` as an `EntityContentBlueprint` extension. You do not need to edit `EntityPage.tsx` (the NFS scaffold does not even create one).
 
-Create `packages/app/src/apis/OpenChoreoFetchApi.ts`:
+After [Section 4.5 — Verify](#45-verify) you should see:
 
-```ts title="packages/app/src/apis/OpenChoreoFetchApi.ts"
-import {
-  ConfigApi,
-  FetchApi,
-  IdentityApi,
-  OAuthApi,
-} from "@backstage/core-plugin-api";
+- **Domain** pages: `OVERVIEW`, `TECHDOCS`, `DEFINITION`.
+- **System** pages: `OVERVIEW`, `TECHDOCS`, `DEFINITION`, `CELL DIAGRAM` — plus auto-mounted overview cards (Project Contents, Deployment Pipeline, etc.).
+- **Component** pages: `OVERVIEW`, `TECHDOCS`, `APIS`, `DEFINITION`, `DEPLOY` — plus the Deployments widget on Overview.
 
-const OPENCHOREO_TOKEN_HEADER = "x-openchoreo-token";
-const DIRECT_MODE_HEADER = "x-openchoreo-direct";
-
-export class OpenChoreoFetchApi implements FetchApi {
-  private readonly authEnabled: boolean;
-
-  constructor(
-    private readonly identityApi: IdentityApi,
-    private readonly oauthApi: OAuthApi,
-    configApi: ConfigApi,
-  ) {
-    this.authEnabled =
-      configApi.getOptionalBoolean("openchoreo.features.auth.enabled") ?? true;
-    this.fetch = this.fetch.bind(this);
-  }
-
-  async fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    const headers = new Headers(init?.headers);
-
-    // Direct mode: caller wants to bypass the Backstage backend and hit an
-    // external API directly. Strip the signal header; put IDP token in
-    // Authorization instead of x-openchoreo-token.
-    const isDirect = headers.has(DIRECT_MODE_HEADER);
-    if (isDirect) headers.delete(DIRECT_MODE_HEADER);
-
-    if (isDirect) {
-      if (this.authEnabled) {
-        try {
-          const idpToken = await this.oauthApi.getAccessToken();
-          if (idpToken) headers.set("Authorization", `Bearer ${idpToken}`);
-        } catch {
-          // No IDP token — proceed unauthenticated.
-        }
-      }
-    } else {
-      const { token: backstageToken } = await this.identityApi.getCredentials();
-      if (backstageToken)
-        headers.set("Authorization", `Bearer ${backstageToken}`);
-
-      if (this.authEnabled) {
-        try {
-          const idpToken = await this.oauthApi.getAccessToken();
-          if (idpToken) headers.set(OPENCHOREO_TOKEN_HEADER, idpToken);
-        } catch {
-          // No IDP token available — proceed with just the Backstage token.
-        }
-      }
-    }
-
-    return fetch(input, { ...init, headers });
-  }
-}
-```
-
-Register it against `fetchApiRef` in `packages/app/src/apis.ts`. The factory must come **after** the `openChoreoAuthApiRef` factory (it depends on it):
-
-```ts title="packages/app/src/apis.ts"
-import { fetchApiRef, identityApiRef } from "@backstage/core-plugin-api";
-import { OpenChoreoFetchApi } from "./apis/OpenChoreoFetchApi";
-
-export const apis: AnyApiFactory[] = [
-  // ... existing factories, including the openChoreoAuthApiRef one from 4.3.2 ...
-  createApiFactory({
-    api: fetchApiRef,
-    deps: {
-      identityApi: identityApiRef,
-      oauthApi: openChoreoAuthApiRef,
-      configApi: configApiRef,
-    },
-    factory: ({ identityApi, oauthApi, configApi }) =>
-      new OpenChoreoFetchApi(identityApi, oauthApi, configApi),
-  }),
-];
-```
-
-#### 4.3.4 Override `permissionApi` to inject the IDP token {#permission-api}
-
-Backstage's default `PermissionClient` uses `cross-fetch` directly and **bypasses `fetchApi` entirely** — so even with the `OpenChoreoFetchApi` step above, permission `/authorize` requests would still miss the `x-openchoreo-token` header. The Deploy tab's env-scoped permission hooks (and similar hooks in the opt-in tab packs) depend on this.
-
-Create `packages/app/src/apis/OpenChoreoPermissionApi.ts`:
-
-```ts title="packages/app/src/apis/OpenChoreoPermissionApi.ts"
-import { Config } from "@backstage/config";
-import {
-  DiscoveryApi,
-  IdentityApi,
-  OAuthApi,
-} from "@backstage/core-plugin-api";
-import { AuthorizeResult } from "@backstage/plugin-permission-common";
-
-const OPENCHOREO_TOKEN_HEADER = "x-openchoreo-token";
-
-export class OpenChoreoPermissionApi {
-  private readonly enabled: boolean;
-  private readonly authEnabled: boolean;
-  private readonly discovery: DiscoveryApi;
-  private readonly identityApi: IdentityApi;
-  private readonly oauthApi: OAuthApi;
-
-  constructor(options: {
-    config: Config;
-    discovery: DiscoveryApi;
-    identity: IdentityApi;
-    oauthApi: OAuthApi;
-  }) {
-    this.discovery = options.discovery;
-    this.identityApi = options.identity;
-    this.oauthApi = options.oauthApi;
-    this.enabled =
-      options.config.getOptionalBoolean("permission.enabled") ?? false;
-    this.authEnabled =
-      options.config.getOptionalBoolean("openchoreo.features.auth.enabled") ??
-      true;
-  }
-
-  async authorize(request: {
-    permission: { name: string };
-    resourceRef?: string;
-  }) {
-    if (!this.enabled) return { result: AuthorizeResult.ALLOW };
-
-    const permissionApiUrl = await this.discovery.getBaseUrl("permission");
-    const { token: backstageToken } = await this.identityApi.getCredentials();
-
-    let idpToken: string | undefined;
-    if (this.authEnabled) {
-      try {
-        idpToken = await this.oauthApi.getAccessToken();
-      } catch {
-        // No IDP token — proceed with just the Backstage token.
-      }
-    }
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-    if (backstageToken) headers.Authorization = `Bearer ${backstageToken}`;
-    if (idpToken) headers[OPENCHOREO_TOKEN_HEADER] = idpToken;
-
-    const response = await fetch(`${permissionApiUrl}/authorize`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        items: [{ id: crypto.randomUUID(), ...request }],
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Permission request failed: ${response.statusText}`);
-    }
-
-    const data = await response.json();
-    return data.items[0];
-  }
-}
-```
-
-Register against `permissionApiRef` in `apis.ts`:
-
-```ts title="packages/app/src/apis.ts"
-import { permissionApiRef } from "@backstage/plugin-permission-react";
-import { OpenChoreoPermissionApi } from "./apis/OpenChoreoPermissionApi";
-
-export const apis: AnyApiFactory[] = [
-  // ... existing factories, including the fetchApiRef one from 4.3.3 ...
-  createApiFactory({
-    api: permissionApiRef,
-    deps: {
-      configApi: configApiRef,
-      discoveryApi: discoveryApiRef,
-      identityApi: identityApiRef,
-      oauthApi: openChoreoAuthApiRef,
-    },
-    factory: ({ configApi, discoveryApi, identityApi, oauthApi }) =>
-      new OpenChoreoPermissionApi({
-        config: configApi,
-        discovery: discoveryApi,
-        identity: identityApi,
-        oauthApi,
-      }),
-  }),
-];
-```
-
-This factory short-circuits to ALLOW when `permission.enabled: false`, so installing it before you turn on the permission framework is safe.
-
-#### 4.3.5 Add the entity-page routes {#core-routes}
-
-In `packages/app/src/components/catalog/EntityPage.tsx`, import the Core tab components and add them to the relevant entity layouts:
-
-```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
-import {
-  Environments,
-  CellDiagram,
-  ResourceDefinitionTab,
-} from '@openchoreo/backstage-plugin';
-
-// In your componentEntityPage / defaultEntityPage <EntityLayout> blocks:
-<EntityLayout.Route path="/definition" title="Definition">
-  <ResourceDefinitionTab />
-</EntityLayout.Route>
-<EntityLayout.Route path="/environments" title="Deploy">
-  <Environments />
-</EntityLayout.Route>
-
-// In your systemPage <EntityLayout> block:
-<EntityLayout.Route path="/definition" title="Definition">
-  <ResourceDefinitionTab />
-</EntityLayout.Route>
-<EntityLayout.Route path="/cell" title="Cell">
-  <CellDiagram />
-</EntityLayout.Route>
-
-// In your domainPage <EntityLayout> block:
-<EntityLayout.Route path="/definition" title="Definition">
-  <ResourceDefinitionTab />
-</EntityLayout.Route>
-```
-
-OpenChoreo synced components have type strings like `deployment/web-application` and `deployment/service`. The default `componentPage` `EntitySwitch` only routes `service`/`website` to the page that includes Environments — add the Environments route to `defaultEntityPage` too if you want it on every component kind.
+If you need to override where a tab appears or hide one for a specific kind, see [Entity views — customizing under NFS](./entity-views.mdx#nfs-customization).
 
 ### 4.4 Configure `app-config` {#configure-app-config}
 
@@ -670,91 +630,53 @@ Expected:
 2. After ~30s: `Successfully processed N entities (X domains, Y systems, Z components, ...)`.
 3. Browser → `http://localhost:3000` → sign-in page shows "Sign in using OpenChoreo." Click through and land in the catalog.
 4. `http://localhost:3000/catalog?filters[kind]=domain` → see your OpenChoreo namespaces.
-5. Click into any project (`kind=system`) → **Cell** and **Definition** tabs are present and render real data.
-6. Click into any component → **Deploy** and **Definition** tabs are present and render real data.
+5. Click into any project (`kind=system`) → **CELL DIAGRAM** and **DEFINITION** tabs are present and render real data.
+6. Click into any component → **DEPLOY** and **DEFINITION** tabs are present and render real data.
 
-If you get a 401 on tab data fetches, you skipped 4.3.3 (`OpenChoreoFetchApi`). If you get "No permissions" on Deploy, you skipped 4.3.4 (`OpenChoreoPermissionApi`). See [Troubleshooting](./troubleshooting.mdx) for the full failure-mode index.
+If you get a 401 on tab data fetches, your `customAppModule`'s `ApiBlueprint` for `fetchApiRef` isn't being registered — check that `customAppModule` is in the `features: [...]` array in `App.tsx`. If you get "No permissions" on Deploy, same check for the `permissionApiRef` `ApiBlueprint`. See [Troubleshooting](./troubleshooting.mdx) for the full failure-mode index.
 
 ---
 
 ## 5. Add Observability tabs (optional)
 
-Adds **Logs, Metrics, Alerts** to Component pages and **Logs, Traces, Incidents, RCA Reports, Cost Analysis** to System pages. Built on top of Core.
+Adds **Logs, Events, Metrics, Alerts, Wirelogs** to Component pages and **Logs, Traces, Incidents, RCA Reports, Cost Analysis** to System pages. Built on top of Core.
 
 **Prerequisites:** Section 4 (Core) complete and verified.
 
 ### 5.1 Install packages
 
 ```bash
-yarn workspace app add @openchoreo/backstage-plugin-openchoreo-observability@^1.1.0
-yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-observability-backend@^1.1.0
+yarn workspace app add @openchoreo/backstage-plugin-openchoreo-observability@^1.2.0
+yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-observability-backend@^1.2.0
 ```
 
 ### 5.2 Wire the backend
 
-Append to `packages/backend/src/index.ts` (after the Core wiring):
+Append to `packages/backend/src/index.ts`:
 
 ```ts
-backend.add(
-  import("@openchoreo/backstage-plugin-openchoreo-observability-backend"),
-);
+backend.add(import('@openchoreo/backstage-plugin-openchoreo-observability-backend'));
 ```
 
 ### 5.3 Wire the frontend
 
-Register the plugin (append to the `plugins: [...]` array you set up in [4.3.1](#register-plugin)):
+Append the observability Alpha feature to `createApp({ features: [...] })`:
 
 ```tsx title="packages/app/src/App.tsx"
-import { openchoreoObservabilityPlugin } from '@openchoreo/backstage-plugin-openchoreo-observability';
+import openchoreoObservabilityPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-observability/alpha';
 
-plugins: [
-  choreoPlugin,
-  openchoreoObservabilityPlugin, // <-- add
-],
+export default createApp({
+  features: [
+    catalogPlugin,
+    openchoreoPluginAlpha,
+    openchoreoObservabilityPluginAlpha, // <-- add
+    navModule,
+    customAppModule,
+  ],
+});
 ```
 
-Add the observability routes to `packages/app/src/components/catalog/EntityPage.tsx`:
-
-```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
-import {
-  ObservabilityMetrics,
-  ObservabilityAlerts,
-  ObservabilityRuntimeLogs,
-  ObservabilityProjectRuntimeLogs,
-  ObservabilityTraces,
-  ObservabilityProjectIncidents,
-  ObservabilityRCA,
-  ObservabilityCostAnalysis,
-} from '@openchoreo/backstage-plugin-openchoreo-observability';
-
-// Component pages (componentEntityPage / defaultEntityPage):
-<EntityLayout.Route path="/runtime-logs" title="Logs">
-  <ObservabilityRuntimeLogs />
-</EntityLayout.Route>
-<EntityLayout.Route path="/metrics" title="Metrics">
-  <ObservabilityMetrics />
-</EntityLayout.Route>
-<EntityLayout.Route path="/alerts" title="Alerts">
-  <ObservabilityAlerts />
-</EntityLayout.Route>
-
-// System page (systemPage):
-<EntityLayout.Route path="/logs" title="Logs">
-  <ObservabilityProjectRuntimeLogs />
-</EntityLayout.Route>
-<EntityLayout.Route path="/traces" title="Traces">
-  <ObservabilityTraces />
-</EntityLayout.Route>
-<EntityLayout.Route path="/incidents" title="Incidents">
-  <ObservabilityProjectIncidents />
-</EntityLayout.Route>
-<EntityLayout.Route path="/rca-reports" title="RCA Reports">
-  <ObservabilityRCA />
-</EntityLayout.Route>
-<EntityLayout.Route path="/cost-analysis" title="Cost Analysis">
-  <ObservabilityCostAnalysis />
-</EntityLayout.Route>
-```
+**No `EntityPage.tsx` edits.** Every observability tab auto-mounts on the correct entity kind.
 
 ### 5.4 Configure
 
@@ -769,7 +691,7 @@ openchoreo:
 
 ### 5.5 Verify
 
-Restart `yarn start`. Open any Component → the **Logs**, **Metrics**, **Alerts** tabs appear. Open any System → **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
+Restart `yarn start`. Open any Component → the **LOGS**, **EVENTS**, **METRICS**, **ALERTS**, **WIRELOGS** tabs appear. Open any System → **LOGS**, **TRACES**, **INCIDENTS**, **RCA REPORTS**, **COST ANALYSIS** tabs appear. If a tab renders an empty state, the backend reached OpenChoreo but no data is available yet for that scope. If a tab errors, see [Troubleshooting](./troubleshooting.mdx).
 
 ---
 
@@ -782,8 +704,8 @@ Adds a **Build** tab to Component pages, showing workflow runs and a parameter-f
 ### 6.1 Install packages
 
 ```bash
-yarn workspace app add @openchoreo/backstage-plugin-openchoreo-ci@^1.1.0
-yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-ci-backend@^1.1.0
+yarn workspace app add @openchoreo/backstage-plugin-openchoreo-ci@^1.2.0
+yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-ci-backend@^1.2.0
 ```
 
 ### 6.2 Wire the backend
@@ -791,31 +713,25 @@ yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-ci-backend@^1
 Append to `packages/backend/src/index.ts`:
 
 ```ts
-backend.add(import("@openchoreo/backstage-plugin-openchoreo-ci-backend"));
+backend.add(import('@openchoreo/backstage-plugin-openchoreo-ci-backend'));
 ```
 
 ### 6.3 Wire the frontend
 
-Register the plugin (append to the `plugins: [...]` array):
+Append the CI Alpha feature to `createApp({ features: [...] })`:
 
 ```tsx title="packages/app/src/App.tsx"
-import { openchoreoCiPlugin } from '@openchoreo/backstage-plugin-openchoreo-ci';
+import openchoreoCiPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-ci/alpha';
 
-plugins: [
-  choreoPlugin,
-  openchoreoCiPlugin, // <-- add
-],
-```
-
-Add the Build route to `EntityPage.tsx`:
-
-```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
-import { Workflows } from "@openchoreo/backstage-plugin-openchoreo-ci";
-
-// In your componentEntityPage / defaultEntityPage:
-<EntityLayout.Route path="/workflows" title="Build">
-  <Workflows />
-</EntityLayout.Route>;
+export default createApp({
+  features: [
+    catalogPlugin,
+    openchoreoPluginAlpha,
+    openchoreoCiPluginAlpha, // <-- add
+    navModule,
+    customAppModule,
+  ],
+});
 ```
 
 ### 6.4 Configure
@@ -831,21 +747,21 @@ openchoreo:
 
 ### 6.5 Verify
 
-Restart `yarn start`. Open any Component → the **Build** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
+Restart `yarn start`. Open any Component → the **BUILD** tab appears. It lists past workflow runs and (depending on permissions) offers a "Trigger build" form.
 
 ---
 
 ## 7. Add standalone Workflows page (optional)
 
-Adds an org-level Workflows page for generic (non-component-scoped) workflow templates and runs. Built on top of Core.
+Adds an org-level `/workflows` page for generic (non-component-scoped) workflow templates and runs, plus a **Runs** tab on `Workflow` and `ClusterWorkflow` entities. Built on top of Core.
 
 **Prerequisites:** Section 4 (Core) complete and verified.
 
 ### 7.1 Install packages
 
 ```bash
-yarn workspace app add @openchoreo/backstage-plugin-openchoreo-workflows@^1.1.0
-yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-workflows-backend@^1.1.0
+yarn workspace app add @openchoreo/backstage-plugin-openchoreo-workflows@^1.2.0
+yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-workflows-backend@^1.2.0
 ```
 
 ### 7.2 Wire the backend
@@ -853,45 +769,30 @@ yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-workflows-bac
 Append to `packages/backend/src/index.ts`:
 
 ```ts
-backend.add(
-  import("@openchoreo/backstage-plugin-openchoreo-workflows-backend"),
-);
+backend.add(import('@openchoreo/backstage-plugin-openchoreo-workflows-backend'));
 ```
 
 ### 7.3 Wire the frontend
 
-Register the plugin:
+Append the workflows Alpha feature:
 
 ```tsx title="packages/app/src/App.tsx"
-import { openchoreoWorkflowsPlugin } from '@openchoreo/backstage-plugin-openchoreo-workflows';
+import openchoreoWorkflowsPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-workflows/alpha';
 
-plugins: [
-  choreoPlugin,
-  openchoreoWorkflowsPlugin, // <-- add
-],
+export default createApp({
+  features: [
+    catalogPlugin,
+    openchoreoPluginAlpha,
+    openchoreoWorkflowsPluginAlpha, // <-- add
+    navModule,
+    customAppModule,
+  ],
+});
 ```
 
-Mount the standalone Workflows page in your app's `FlatRoutes`. The plugin exports `GenericWorkflowsPage` — a routable extension whose API factories are registered through `openchoreoWorkflowsPlugin`:
+The plugin contributes the standalone `/workflows` page as a `PageBlueprint` — no `<Route>` mount needed.
 
-```tsx title="packages/app/src/App.tsx"
-import { Route } from "react-router-dom";
-import { GenericWorkflowsPage } from "@openchoreo/backstage-plugin-openchoreo-workflows";
-
-const routes = (
-  <FlatRoutes>
-    {/* ... your existing routes ... */}
-    <Route path="/workflows" element={<GenericWorkflowsPage />} />
-  </FlatRoutes>
-);
-```
-
-Optionally add a sidebar entry in `packages/app/src/components/Root/Root.tsx` so users can navigate to it:
-
-```tsx title="packages/app/src/components/Root/Root.tsx"
-import PlayCircleOutlineIcon from "@material-ui/icons/PlayCircleOutline";
-
-<SidebarItem icon={PlayCircleOutlineIcon} to="workflows" text="Workflows" />;
-```
+Optionally add a sidebar entry in `packages/app/src/modules/nav/Sidebar.tsx` so users can navigate to it.
 
 ### 7.4 Verify
 
@@ -899,62 +800,122 @@ Restart `yarn start`. Navigate to `http://localhost:3000/workflows` → see the 
 
 ---
 
-## 8. Remove the notifications plugin (if present)
+## 8. Troubleshooting
 
-The default `@backstage/create-app` template wires `@backstage/plugin-notifications` into both the sidebar (`NotificationsSidebarItem`) and routes (`<NotificationsPage />`). The version of that plugin published when this guide was tested expects `toastApiRef` and several components (`Tag`, `Dialog`, `DialogHeader`, ...) from `@backstage/ui` / `@backstage/frontend-plugin-api` that are **not present** in the 1.43.3 release line we pin. The sidebar item crashes the whole app shell with `Cannot read properties of undefined (reading 'id')`.
-
-Delete the import and JSX usage from `packages/app/src/components/Root/Root.tsx`:
-
-```tsx
-// Remove:
-// import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
-// <NotificationsSidebarItem />
-```
-
-…and from `packages/app/src/App.tsx`:
-
-```tsx
-// Remove:
-// import { NotificationsPage } from '@backstage/plugin-notifications';
-// <Route path="/notifications" element={<NotificationsPage />} />
-```
-
-You can leave the `@backstage/plugin-notifications` package installed; it just shouldn't be referenced from the rendered tree.
-
-### Backend cleanup
-
-The `create-app --legacy` scaffold also registers four backend modules in `packages/backend/src/index.ts` that are not pinned by the [compatibility matrix](./compatibility-matrix.mdx). They drift to versions outside the 1.43.3 release line and crash the backend at startup with `TypeError: Cannot read properties of undefined (reading 'id')` (see [Troubleshooting → Backend module startup fails](./troubleshooting.mdx#backend-module-startup-fails-with-cannot-read-properties-of-undefined-reading-id)).
-
-Remove their `backend.add(...)` lines from `packages/backend/src/index.ts`:
-
-```ts
-// Remove:
-// backend.add(import('@backstage/plugin-scaffolder-backend-module-notifications'));
-// backend.add(import('@backstage/plugin-notifications-backend'));
-// backend.add(import('@backstage/plugin-signals-backend'));
-// backend.add(import('@backstage/plugin-mcp-actions-backend'));
-```
-
-Then drop the packages from `packages/backend/package.json`:
-
-```bash
-yarn workspace backend remove \
-  @backstage/plugin-scaffolder-backend-module-notifications \
-  @backstage/plugin-notifications-backend \
-  @backstage/plugin-signals-backend \
-  @backstage/plugin-mcp-actions-backend
-```
-
-The signals backend was paired with a `<SignalsDisplay />` component in `packages/app/src/App.tsx`. Remove that too so the frontend doesn't reference a backend that no longer exists:
-
-```tsx
-// Remove from packages/app/src/App.tsx:
-// import { SignalsDisplay } from '@backstage/plugin-signals';
-// <SignalsDisplay />
-```
+If anything misbehaves at any step, see [Troubleshooting](./troubleshooting.mdx) for the full failure-mode index, indexed by exact error message.
 
 ---
 
-## Troubleshooting
+## 9. Legacy frontend system (fallback) {#9-legacy-frontend-system-fallback}
 
-If anything misbehaves at any step, see [Troubleshooting](./troubleshooting.mdx) for the full failure-mode index, indexed by exact error message.
+If your Backstage host is scaffolded with `--legacy` (or you have heavy `EntityPage.tsx` customization you want to keep), follow the legacy wiring below instead of Sections 4.3 through 7. Sections 1–3 and 4.1–4.2 (prereqs, resolutions, GitHub Packages auth, package install, backend wiring) are identical.
+
+The legacy install registers each plugin's default export via `createApp({ apis, plugins, bindRoutes })` and manually mounts every entity tab into `components/catalog/EntityPage.tsx`.
+
+:::warning Choose one path
+
+Do NOT mix the two. If you import `openchoreoPluginAlpha` from `/alpha` *and* also mount `<Environments />` in `EntityPage.tsx`, you will see duplicate tabs (or the wrong tab will win depending on extension load order).
+
+:::
+
+### 9.1 Wire the frontend (legacy)
+
+In `packages/app/src/App.tsx`:
+
+```tsx title="packages/app/src/App.tsx (legacy host)"
+import { choreoPlugin } from '@openchoreo/backstage-plugin';
+
+const app = createApp({
+  apis,
+  plugins: [choreoPlugin], // <-- add; opt-in sections will append more
+  bindRoutes({ bind }) { ... },
+});
+```
+
+Wire OpenChoreo sign-in by creating `packages/app/src/apis/authRefs.ts`:
+
+```ts title="packages/app/src/apis/authRefs.ts"
+import {
+  ApiRef,
+  BackstageIdentityApi,
+  createApiRef,
+  OAuthApi,
+  ProfileInfoApi,
+  SessionApi,
+} from '@backstage/core-plugin-api';
+
+export const openChoreoAuthApiRef: ApiRef<
+  OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
+> = createApiRef({
+  id: 'auth.openchoreo-auth',
+});
+```
+
+Register the OAuth2 factory in `packages/app/src/apis.ts`:
+
+```tsx title="packages/app/src/apis.ts"
+import { OAuth2 } from '@backstage/core-app-api';
+import { openChoreoAuthApiRef } from './apis/authRefs';
+
+export const apis: AnyApiFactory[] = [
+  // ... your existing factories ...
+  createApiFactory({
+    api: openChoreoAuthApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      oauthRequestApi: oauthRequestApiRef,
+      configApi: configApiRef,
+    },
+    factory: ({ discoveryApi, oauthRequestApi, configApi }) =>
+      OAuth2.create({
+        discoveryApi,
+        oauthRequestApi,
+        configApi,
+        provider: {
+          id: 'openchoreo-auth',
+          title: 'OpenChoreo',
+          icon: () => null,
+        },
+        environment: configApi.getOptionalString('auth.environment'),
+        defaultScopes: ['openid', 'profile', 'email'],
+      }),
+  }),
+];
+```
+
+The `OpenChoreoFetchApi` and `OpenChoreoPermissionApi` classes from [Section 4.3.2](#custom-app-module) above are registered as legacy `createApiFactory` entries in `apis.ts` (same shape as upstream `apiFactories`). Pass `components: { SignInPage: DynamicSignInPage }` to `createApp` for the sign-in slot.
+
+### 9.2 Mount entity tabs
+
+Add the Core tab components to `packages/app/src/components/catalog/EntityPage.tsx`:
+
+```tsx title="packages/app/src/components/catalog/EntityPage.tsx"
+import {
+  Environments,
+  CellDiagram,
+  ResourceDefinitionTab,
+} from '@openchoreo/backstage-plugin';
+
+// componentEntityPage / defaultEntityPage:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+<EntityLayout.Route path="/environments" title="Deploy">
+  <Environments />
+</EntityLayout.Route>
+
+// systemPage:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+<EntityLayout.Route path="/cell" title="Cell">
+  <CellDiagram />
+</EntityLayout.Route>
+
+// domainPage:
+<EntityLayout.Route path="/definition" title="Definition">
+  <ResourceDefinitionTab />
+</EntityLayout.Route>
+```
+
+For the legacy opt-in tab packs (Observability / CI / Workflows), see [Entity views — Legacy wiring example](./entity-views.mdx#legacy-wiring). The wiring is the same as the 1.1.x install guide — `plugins: [..., openchoreoObservabilityPlugin]` plus the per-tab `<EntityLayout.Route>` blocks.

--- a/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/installing-into-existing-backstage.mdx
@@ -82,8 +82,8 @@ GitHub Packages requires authentication even for `read:packages`-only operations
 nodeLinker: node-modules
 npmMinimalAgeGate: 3d
 npmPreapprovedPackages:
-  - '@backstage/*'
-  - '@openchoreo/*'
+  - "@backstage/*"
+  - "@openchoreo/*"
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs
 
@@ -154,14 +154,14 @@ The NFS scaffold's `packages/backend/src/index.ts` already wires `scaffolder`, `
 Edit `packages/backend/src/index.ts`:
 
 ```ts title="packages/backend/src/index.ts"
-import { createBackend } from '@backstage/backend-defaults';
-import { rootHttpRouterServiceFactory } from '@backstage/backend-defaults/rootHttpRouter';
+import { createBackend } from "@backstage/backend-defaults";
+import { rootHttpRouterServiceFactory } from "@backstage/backend-defaults/rootHttpRouter";
 import {
   immediateCatalogServiceFactory,
   annotationStoreFactory,
-} from '@openchoreo/backstage-plugin-catalog-backend-module';
-import { createIdpTokenHeaderMiddleware } from '@openchoreo/openchoreo-auth';
-import { OpenChoreoAuthModule } from '@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth';
+} from "@openchoreo/backstage-plugin-catalog-backend-module";
+import { createIdpTokenHeaderMiddleware } from "@openchoreo/openchoreo-auth";
+import { OpenChoreoAuthModule } from "@openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth";
 
 const backend = createBackend();
 
@@ -199,14 +199,14 @@ backend.add(OpenChoreoAuthModule);
 // falls back to ALLOW for everything else, so it is composable with
 // other host-app policies.
 backend.add(
-  import('@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy'),
+  import("@openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy"),
 );
 
 // IMPORTANT: register catalog-backend-module BEFORE openchoreo-backend.
 // openchoreo-backend depends on the AnnotationStore initialized by the catalog module.
-backend.add(import('@openchoreo/backstage-plugin-catalog-backend-module'));
-backend.add(import('@openchoreo/backstage-plugin-backend'));
-backend.add(import('@openchoreo/backstage-plugin-scaffolder-backend-module'));
+backend.add(import("@openchoreo/backstage-plugin-catalog-backend-module"));
+backend.add(import("@openchoreo/backstage-plugin-backend"));
+backend.add(import("@openchoreo/backstage-plugin-scaffolder-backend-module"));
 
 backend.start();
 ```
@@ -222,9 +222,9 @@ Three sub-steps, all in `packages/app/src/`. Compared to the legacy install, **y
 A fresh NFS scaffold's `packages/app/src/App.tsx` is roughly:
 
 ```tsx title="packages/app/src/App.tsx"
-import { createApp } from '@backstage/frontend-defaults';
-import catalogPlugin from '@backstage/plugin-catalog/alpha';
-import { navModule } from './modules/nav';
+import { createApp } from "@backstage/frontend-defaults";
+import catalogPlugin from "@backstage/plugin-catalog/alpha";
+import { navModule } from "./modules/nav";
 
 export default createApp({
   features: [catalogPlugin, navModule],
@@ -234,11 +234,11 @@ export default createApp({
 Add the OpenChoreo plugin to the `features` array:
 
 ```tsx title="packages/app/src/App.tsx"
-import { createApp } from '@backstage/frontend-defaults';
-import catalogPlugin from '@backstage/plugin-catalog/alpha';
-import openchoreoPluginAlpha from '@openchoreo/backstage-plugin/alpha';
-import { navModule } from './modules/nav';
-import { customAppModule } from './customAppModule';
+import { createApp } from "@backstage/frontend-defaults";
+import catalogPlugin from "@backstage/plugin-catalog/alpha";
+import openchoreoPluginAlpha from "@openchoreo/backstage-plugin/alpha";
+import { navModule } from "./modules/nav";
+import { customAppModule } from "./customAppModule";
 
 export default createApp({
   features: [
@@ -272,11 +272,11 @@ import {
   identityApiRef,
   oauthRequestApiRef,
   useApi,
-} from '@backstage/frontend-plugin-api';
-import { SignInPageBlueprint } from '@backstage/plugin-app-react';
-import { permissionApiRef } from '@backstage/plugin-permission-react';
-import { SignInPage } from '@backstage/core-components';
-import { OAuth2 } from '@backstage/core-app-api';
+} from "@backstage/frontend-plugin-api";
+import { SignInPageBlueprint } from "@backstage/plugin-app-react";
+import { permissionApiRef } from "@backstage/plugin-permission-react";
+import { SignInPage } from "@backstage/core-components";
+import { OAuth2 } from "@backstage/core-app-api";
 import {
   ApiRef,
   BackstageIdentityApi,
@@ -284,19 +284,19 @@ import {
   OAuthApi,
   ProfileInfoApi,
   SessionApi,
-} from '@backstage/core-plugin-api';
-import { AuthorizeResult } from '@backstage/plugin-permission-common';
-import type { Config } from '@backstage/config';
-import type { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
-import type { FetchApi } from '@backstage/frontend-plugin-api';
+} from "@backstage/core-plugin-api";
+import { AuthorizeResult } from "@backstage/plugin-permission-common";
+import type { Config } from "@backstage/config";
+import type { DiscoveryApi, IdentityApi } from "@backstage/core-plugin-api";
+import type { FetchApi } from "@backstage/frontend-plugin-api";
 
-const OPENCHOREO_TOKEN_HEADER = 'x-openchoreo-token';
-const DIRECT_MODE_HEADER = 'x-openchoreo-direct';
+const OPENCHOREO_TOKEN_HEADER = "x-openchoreo-token";
+const DIRECT_MODE_HEADER = "x-openchoreo-direct";
 
 export const openChoreoAuthApiRef: ApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 > = createApiRef({
-  id: 'auth.openchoreo-auth',
+  id: "auth.openchoreo-auth",
 });
 
 class OpenChoreoFetchApi implements FetchApi {
@@ -308,7 +308,7 @@ class OpenChoreoFetchApi implements FetchApi {
     configApi: Config,
   ) {
     this.authEnabled =
-      configApi.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
+      configApi.getOptionalBoolean("openchoreo.features.auth.enabled") ?? true;
     this.fetch = this.fetch.bind(this);
   }
 
@@ -321,7 +321,7 @@ class OpenChoreoFetchApi implements FetchApi {
       if (this.authEnabled) {
         try {
           const idpToken = await this.oauthApi.getAccessToken();
-          if (idpToken) headers.set('Authorization', `Bearer ${idpToken}`);
+          if (idpToken) headers.set("Authorization", `Bearer ${idpToken}`);
         } catch {
           // No IDP token — proceed unauthenticated.
         }
@@ -329,7 +329,7 @@ class OpenChoreoFetchApi implements FetchApi {
     } else {
       const { token: backstageToken } = await this.identityApi.getCredentials();
       if (backstageToken)
-        headers.set('Authorization', `Bearer ${backstageToken}`);
+        headers.set("Authorization", `Bearer ${backstageToken}`);
 
       if (this.authEnabled) {
         try {
@@ -362,9 +362,9 @@ class OpenChoreoPermissionApi {
     this.identityApi = options.identity;
     this.oauthApi = options.oauthApi;
     this.enabled =
-      options.config.getOptionalBoolean('permission.enabled') ?? false;
+      options.config.getOptionalBoolean("permission.enabled") ?? false;
     this.authEnabled =
-      options.config.getOptionalBoolean('openchoreo.features.auth.enabled') ??
+      options.config.getOptionalBoolean("openchoreo.features.auth.enabled") ??
       true;
   }
 
@@ -374,7 +374,7 @@ class OpenChoreoPermissionApi {
   }) {
     if (!this.enabled) return { result: AuthorizeResult.ALLOW };
 
-    const permissionApiUrl = await this.discovery.getBaseUrl('permission');
+    const permissionApiUrl = await this.discovery.getBaseUrl("permission");
     const { token: backstageToken } = await this.identityApi.getCredentials();
 
     let idpToken: string | undefined;
@@ -387,13 +387,13 @@ class OpenChoreoPermissionApi {
     }
 
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     };
     if (backstageToken) headers.Authorization = `Bearer ${backstageToken}`;
     if (idpToken) headers[OPENCHOREO_TOKEN_HEADER] = idpToken;
 
     const response = await fetch(`${permissionApiUrl}/authorize`, {
-      method: 'POST',
+      method: "POST",
       headers,
       body: JSON.stringify({
         items: [{ id: crypto.randomUUID(), ...request }],
@@ -412,19 +412,19 @@ class OpenChoreoPermissionApi {
 function DynamicSignInPage(props: any) {
   const configApi = useApi(configApiRef);
   const authEnabled =
-    configApi.getOptionalBoolean('openchoreo.features.auth.enabled') ?? true;
+    configApi.getOptionalBoolean("openchoreo.features.auth.enabled") ?? true;
 
   if (!authEnabled) {
-    return <SignInPage {...props} auto providers={['guest']} />;
+    return <SignInPage {...props} auto providers={["guest"]} />;
   }
 
   return (
     <SignInPage
       {...props}
       provider={{
-        id: 'openchoreo-auth',
-        title: 'OpenChoreo',
-        message: 'Sign in using OpenChoreo',
+        id: "openchoreo-auth",
+        title: "OpenChoreo",
+        message: "Sign in using OpenChoreo",
         apiRef: openChoreoAuthApiRef,
       }}
     />
@@ -432,7 +432,7 @@ function DynamicSignInPage(props: any) {
 }
 
 export const customAppModule = createFrontendModule({
-  pluginId: 'app',
+  pluginId: "app",
   extensions: [
     SignInPageBlueprint.make({
       params: {
@@ -440,8 +440,8 @@ export const customAppModule = createFrontendModule({
       },
     }),
     ApiBlueprint.make({
-      name: 'openchoreo-auth',
-      params: defineParams =>
+      name: "openchoreo-auth",
+      params: (defineParams) =>
         defineParams({
           api: openChoreoAuthApiRef,
           deps: {
@@ -455,18 +455,18 @@ export const customAppModule = createFrontendModule({
               oauthRequestApi,
               configApi,
               provider: {
-                id: 'openchoreo-auth',
-                title: 'OpenChoreo',
+                id: "openchoreo-auth",
+                title: "OpenChoreo",
                 icon: () => null,
               },
-              environment: configApi.getOptionalString('auth.environment'),
-              defaultScopes: ['openid', 'profile', 'email'],
+              environment: configApi.getOptionalString("auth.environment"),
+              defaultScopes: ["openid", "profile", "email"],
             }),
         }),
     }),
     ApiBlueprint.make({
-      name: 'fetch-api',
-      params: defineParams =>
+      name: "fetch-api",
+      params: (defineParams) =>
         defineParams({
           api: fetchApiRef,
           deps: {
@@ -479,8 +479,8 @@ export const customAppModule = createFrontendModule({
         }),
     }),
     ApiBlueprint.make({
-      name: 'permission-api',
-      params: defineParams =>
+      name: "permission-api",
+      params: (defineParams) =>
         defineParams({
           api: permissionApiRef,
           deps: {
@@ -655,7 +655,9 @@ yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-observability
 Append to `packages/backend/src/index.ts`:
 
 ```ts
-backend.add(import('@openchoreo/backstage-plugin-openchoreo-observability-backend'));
+backend.add(
+  import("@openchoreo/backstage-plugin-openchoreo-observability-backend"),
+);
 ```
 
 ### 5.3 Wire the frontend
@@ -663,7 +665,7 @@ backend.add(import('@openchoreo/backstage-plugin-openchoreo-observability-backen
 Append the observability Alpha feature to `createApp({ features: [...] })`:
 
 ```tsx title="packages/app/src/App.tsx"
-import openchoreoObservabilityPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-observability/alpha';
+import openchoreoObservabilityPluginAlpha from "@openchoreo/backstage-plugin-openchoreo-observability/alpha";
 
 export default createApp({
   features: [
@@ -713,7 +715,7 @@ yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-ci-backend@^1
 Append to `packages/backend/src/index.ts`:
 
 ```ts
-backend.add(import('@openchoreo/backstage-plugin-openchoreo-ci-backend'));
+backend.add(import("@openchoreo/backstage-plugin-openchoreo-ci-backend"));
 ```
 
 ### 6.3 Wire the frontend
@@ -721,7 +723,7 @@ backend.add(import('@openchoreo/backstage-plugin-openchoreo-ci-backend'));
 Append the CI Alpha feature to `createApp({ features: [...] })`:
 
 ```tsx title="packages/app/src/App.tsx"
-import openchoreoCiPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-ci/alpha';
+import openchoreoCiPluginAlpha from "@openchoreo/backstage-plugin-openchoreo-ci/alpha";
 
 export default createApp({
   features: [
@@ -769,7 +771,9 @@ yarn workspace backend add @openchoreo/backstage-plugin-openchoreo-workflows-bac
 Append to `packages/backend/src/index.ts`:
 
 ```ts
-backend.add(import('@openchoreo/backstage-plugin-openchoreo-workflows-backend'));
+backend.add(
+  import("@openchoreo/backstage-plugin-openchoreo-workflows-backend"),
+);
 ```
 
 ### 7.3 Wire the frontend
@@ -777,7 +781,7 @@ backend.add(import('@openchoreo/backstage-plugin-openchoreo-workflows-backend'))
 Append the workflows Alpha feature:
 
 ```tsx title="packages/app/src/App.tsx"
-import openchoreoWorkflowsPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-workflows/alpha';
+import openchoreoWorkflowsPluginAlpha from "@openchoreo/backstage-plugin-openchoreo-workflows/alpha";
 
 export default createApp({
   features: [
@@ -814,7 +818,7 @@ The legacy install registers each plugin's default export via `createApp({ apis,
 
 :::warning Choose one path
 
-Do NOT mix the two. If you import `openchoreoPluginAlpha` from `/alpha` *and* also mount `<Environments />` in `EntityPage.tsx`, you will see duplicate tabs (or the wrong tab will win depending on extension load order).
+Do NOT mix the two. If you import `openchoreoPluginAlpha` from `/alpha` _and_ also mount `<Environments />` in `EntityPage.tsx`, you will see duplicate tabs (or the wrong tab will win depending on extension load order).
 
 :::
 
@@ -842,20 +846,20 @@ import {
   OAuthApi,
   ProfileInfoApi,
   SessionApi,
-} from '@backstage/core-plugin-api';
+} from "@backstage/core-plugin-api";
 
 export const openChoreoAuthApiRef: ApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 > = createApiRef({
-  id: 'auth.openchoreo-auth',
+  id: "auth.openchoreo-auth",
 });
 ```
 
 Register the OAuth2 factory in `packages/app/src/apis.ts`:
 
 ```tsx title="packages/app/src/apis.ts"
-import { OAuth2 } from '@backstage/core-app-api';
-import { openChoreoAuthApiRef } from './apis/authRefs';
+import { OAuth2 } from "@backstage/core-app-api";
+import { openChoreoAuthApiRef } from "./apis/authRefs";
 
 export const apis: AnyApiFactory[] = [
   // ... your existing factories ...
@@ -872,12 +876,12 @@ export const apis: AnyApiFactory[] = [
         oauthRequestApi,
         configApi,
         provider: {
-          id: 'openchoreo-auth',
-          title: 'OpenChoreo',
+          id: "openchoreo-auth",
+          title: "OpenChoreo",
           icon: () => null,
         },
-        environment: configApi.getOptionalString('auth.environment'),
-        defaultScopes: ['openid', 'profile', 'email'],
+        environment: configApi.getOptionalString("auth.environment"),
+        defaultScopes: ["openid", "profile", "email"],
       }),
   }),
 ];

--- a/docs/platform-engineer-guide/backstage-plugins/migration-1.1-to-1.2.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/migration-1.1-to-1.2.mdx
@@ -102,8 +102,8 @@ NFS gives you simpler wiring (no `EntityPage.tsx` mounts, no per-tab imports) an
 
    ```yaml
    npmPreapprovedPackages:
-     - '@backstage/*'
-     - '@openchoreo/*'
+     - "@backstage/*"
+     - "@openchoreo/*"
    ```
 
 ## Step 4 — Verify

--- a/docs/platform-engineer-guide/backstage-plugins/migration-1.1-to-1.2.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/migration-1.1-to-1.2.mdx
@@ -1,0 +1,138 @@
+---
+title: Migrating from 1.1.x to 1.2.x
+description: Upgrade an existing OpenChoreo Backstage host from the 1.1.x plugin line to 1.2.x.
+sidebar_position: 2
+---
+
+# Migrating from 1.1.x to 1.2.x
+
+The 1.2.x line of `@openchoreo/backstage-plugin*` brings two coordinated changes for adopters who installed the plugins into their own Backstage host:
+
+1. **Backstage `1.51.0`** is the new minimum. 1.1.x targeted `1.43.3`; every transitive `@backstage/*` peer-dep range moves to the 1.51 line, and `@backstage/cli` minimum becomes `^0.36.2`.
+2. **New Frontend System (NFS) install path** — each plugin now ships an `/alpha` entry point that exports a `createFrontendPlugin` instance. Adopters can drop `--legacy` from `@backstage/create-app`, install via `createApp({ features: [...] })`, and get every OpenChoreo entity tab and overview card mounted automatically — no `EntityPage.tsx` edits.
+
+The default (legacy) plugin exports keep working unchanged. Existing 1.1.x adopters on the legacy frontend system can take just the Backstage bump and keep their `EntityPage.tsx`; opting into NFS is recommended but not required.
+
+:::tip Tracking the upcoming 1.2.0 release
+
+The upgrade commands on this page reference `@openchoreo/<pkg>@^1.2.0`, which will be the GA dist-tag of the 1.2.0 release. While `1.2.0` is still under active development, swap `@^1.2.0` for `@next` in every command below to bump to the latest prerelease today. Once `1.2.0` GA is announced, switch back to `@^1.2.0` to pin to the stable release.
+
+:::
+
+## Step 1 — Bump Backstage to 1.51
+
+In your workspace root, run:
+
+```bash
+yarn backstage-cli versions:bump --release 1.51.0
+```
+
+This rewrites every `@backstage/*` caret range in your `package.json` files to the 1.51 line. Then replace the heavy `resolutions` block (carried over from the 1.1.x install guide) with the much smaller 1.2.x block. In your root `package.json`:
+
+```json title="package.json"
+{
+  "resolutions": {
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "@mui/material": "^5.18.0"
+  }
+}
+```
+
+The `@mui/material` pin is new — it fixes a `material-ui-popup-state` transitive resolution issue that surfaces with the newer scaffold. Without it Rspack fails to compile with `Module not found: Can't resolve '@mui/material/version'`.
+
+Then:
+
+```bash
+rm -rf node_modules yarn.lock
+yarn install
+```
+
+If anything in `@backstage/*` peer-deps fails to resolve after this, fall back to the [compatibility matrix](./compatibility-matrix.mdx) for the exact pinned set.
+
+## Step 2 — Bump OpenChoreo plugins to 1.2.0
+
+```bash
+yarn workspace app upgrade \
+  @openchoreo/backstage-design-system@^1.2.0 \
+  @openchoreo/backstage-plugin-common@^1.2.0 \
+  @openchoreo/backstage-plugin-react@^1.2.0 \
+  @openchoreo/backstage-plugin@^1.2.0 \
+  @openchoreo/backstage-plugin-openchoreo-ci@^1.2.0 \
+  @openchoreo/backstage-plugin-openchoreo-observability@^1.2.0 \
+  @openchoreo/backstage-plugin-openchoreo-workflows@^1.2.0
+
+yarn workspace backend upgrade \
+  @openchoreo/openchoreo-client-node@^1.2.0 \
+  @openchoreo/openchoreo-auth@^1.2.0 \
+  @openchoreo/backstage-plugin-common@^1.2.0 \
+  @openchoreo/backstage-plugin-catalog-backend-module@^1.2.0 \
+  @openchoreo/backstage-plugin-permission-backend-module-openchoreo-policy@^1.2.0 \
+  @openchoreo/backstage-plugin-scaffolder-backend-module@^1.2.0 \
+  @openchoreo/backstage-plugin-backend@^1.2.0 \
+  @openchoreo/backstage-plugin-auth-backend-module-openchoreo-auth@^1.2.0 \
+  @openchoreo/backstage-plugin-openchoreo-ci-backend@^1.2.0 \
+  @openchoreo/backstage-plugin-openchoreo-observability-backend@^1.2.0 \
+  @openchoreo/backstage-plugin-openchoreo-workflows-backend@^1.2.0
+```
+
+(Drop the optional packs you don't have installed.)
+
+## Step 3 — Choose an install path
+
+### Option A: Stay on the legacy frontend system
+
+If you have heavy `EntityPage.tsx` customization you want to keep, or you're not ready to move to NFS, you're effectively done. The default plugin exports from `@openchoreo/*@^1.2.0` are API-compatible with `1.1.x` — same `createPlugin` instances, same component exports (`Environments`, `CellDiagram`, `ResourceDefinitionTab`, `Workflows`, `ObservabilityRuntimeLogs`, etc.). Your existing `App.tsx` `plugins: [...]` array and `EntityPage.tsx` mounts continue to work.
+
+Restart `yarn start` and verify the catalog still syncs and the entity tabs still render.
+
+### Option B: Switch to NFS (recommended)
+
+NFS gives you simpler wiring (no `EntityPage.tsx` mounts, no per-tab imports) and is the path the install guide will continue to maintain. To switch:
+
+1. **Re-scaffold or migrate `App.tsx`.** The legacy `App.tsx` builds `createApp({ apis, plugins, bindRoutes })` and wraps `<FlatRoutes>` in `<AppRouter>`. NFS uses `createApp({ features: [...] })` with feature contributions handling routing. Easiest path: scaffold a fresh `npx @backstage/create-app@latest` host alongside your existing one, port your `app-config.yaml`, then follow [install guide Section 4](./installing-into-existing-backstage.mdx#core) to wire OpenChoreo features into the new host. Use the legacy host as a reference for any custom routes / sidebar items you need to recreate as NFS modules.
+
+2. **Move `apis.ts` factories into a `customAppModule`.** Each `createApiFactory({ api, deps, factory })` becomes an `ApiBlueprint.make({ params: defineParams => defineParams({ api, deps, factory }) })` inside a `createFrontendModule({ pluginId: 'app', extensions: [...] })`. The shape is in [install guide Section 4.3.2](./installing-into-existing-backstage.mdx#custom-app-module).
+
+3. **Delete the per-tab `<EntityLayout.Route>` mounts from `EntityPage.tsx`.** Once `openchoreoPluginAlpha` (and the opt-in packs' Alpha features) are in `createApp({ features: [...] })`, every OpenChoreo tab auto-mounts via `EntityContentBlueprint`. Leaving the legacy mounts in produces duplicate tabs.
+
+4. **Drop the legacy `<Route>` for `/workflows`** if you mounted `GenericWorkflowsPage` by hand — under NFS, `openchoreoWorkflowsPluginAlpha` contributes `/workflows` as a `PageBlueprint`.
+
+5. **Update `.yarnrc.yml`** to add `@openchoreo/*` to `npmPreapprovedPackages` so newly published prereleases install immediately instead of being blocked by the 3-day age gate:
+
+   ```yaml
+   npmPreapprovedPackages:
+     - '@backstage/*'
+     - '@openchoreo/*'
+   ```
+
+## Step 4 — Verify
+
+```bash
+yarn start
+```
+
+1. Backend logs show `Plugin initialization complete` for `openchoreo`, `catalog`, `permission`, `auth`. No `MODULE_NOT_FOUND` or `serviceRef{alpha.core.metrics}` errors.
+2. After ~30s: `Successfully processed N entities (X domains, Y systems, Z components, ...)`.
+3. Browser → catalog renders, sign-in works, you can click into a Component and see the **DEPLOY** tab render real deployment data.
+4. Browser DevTools console: no "extension not discovered" or "missing api factory" warnings at boot. Under NFS, the `Source` tab of every loaded extension should be `loaded`.
+
+If you see duplicated tabs (e.g. two `DEPLOY` tabs), you're on the NFS path but left legacy `EntityPage.tsx` mounts in place — see [Troubleshooting → NFS: duplicate Core tab](./troubleshooting.mdx#nfs-duplicate-core-tab-two-deploy-tabs-etc).
+
+## What did NOT change between 1.1.x and 1.2.x
+
+- The package set — same names, same default exports. Adopters on Option A above keep their `import { Environments } from '@openchoreo/backstage-plugin'` lines unchanged.
+- Backend wiring shape — `index.ts` keeps the same `immediateCatalogServiceFactory`, `annotationStoreFactory`, `createIdpTokenHeaderMiddleware`, `OpenChoreoAuthModule`, permission policy, and catalog/scaffolder modules. Only the `@backstage/*` versions move.
+- `app-config.yaml` shape — `openchoreo.baseUrl`, `openchoreo.features.*`, `openchoreo.auth.*`, the `permission.enabled` flag, and the catalog rules are all unchanged.
+- `OpenChoreoFetchApi` and `OpenChoreoPermissionApi` — still the same classes; 1.2.x does not ship them. Adopters keep them in `apis/` (legacy) or move them into the `customAppModule` (NFS).
+- Catalog sync behavior — same `schedule.frequency` / `schedule.timeout` integers, same entity-kind mapping, same client-credentials auth flow.
+
+## What did change
+
+- **Backstage minimum** — 1.43.3 → 1.51.0.
+- **`@backstage/cli` minimum** — 0.34.3 → 0.36.2.
+- **Yarn scaffold version** — `create-app@latest` now produces Yarn 4.13.x with `npmMinimalAgeGate: 3d`. The install guide adds `@openchoreo/*` to `npmPreapprovedPackages`.
+- **NFS install path added** — see install guide [Section 4 — Core](./installing-into-existing-backstage.mdx#core).
+- **Tab catalog additions** — `Component → EVENTS` and `Component → WIRELOGS` are new tabs in the observability pack. They auto-mount under NFS; for legacy hosts add the corresponding `<EntityLayout.Route>` mounts (see [entity-views legacy wiring](./entity-views.mdx#legacy-wiring)).
+- **Workflows `/alpha` contributes a `/workflows` page** — under NFS the standalone Workflows page mounts via `PageBlueprint`; no manual `<Route path="/workflows">` mount needed.
+- **Notifications-removal cleanup is no longer required** — the 1.43.3-era `@backstage/plugin-notifications` crash that the 1.1.x install guide Section 8 worked around is fixed in the 1.51 line. If you removed those packages on the old install you can re-add them; if you left them you're fine.

--- a/docs/platform-engineer-guide/backstage-plugins/overview.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/overview.mdx
@@ -26,11 +26,11 @@ This is an alternative to forking the [`openchoreo/backstage-plugins`](https://g
 
 **Optional tab packs** — install only the ones you want:
 
-| Pack                                                    | Adds                                                                                                                                                       |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pack                                                    | Adds                                                                                                                                                               |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `@openchoreo/backstage-plugin-openchoreo-observability` | System tabs: **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis**. Component tabs: **Logs**, **Events**, **Metrics**, **Alerts**, **Wirelogs**. |
-| `@openchoreo/backstage-plugin-openchoreo-ci`            | Component tab: **Build** (workflow runs + trigger form).                                                                                                   |
-| `@openchoreo/backstage-plugin-openchoreo-workflows`     | Standalone `/workflows` page + **Runs** tab on Workflow/ClusterWorkflow entities.                                                                          |
+| `@openchoreo/backstage-plugin-openchoreo-ci`            | Component tab: **Build** (workflow runs + trigger form).                                                                                                           |
+| `@openchoreo/backstage-plugin-openchoreo-workflows`     | Standalone `/workflows` page + **Runs** tab on Workflow/ClusterWorkflow entities.                                                                                  |
 
 See the [compatibility matrix](./compatibility-matrix.mdx) for the full list of packages.
 

--- a/docs/platform-engineer-guide/backstage-plugins/overview.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/overview.mdx
@@ -26,11 +26,11 @@ This is an alternative to forking the [`openchoreo/backstage-plugins`](https://g
 
 **Optional tab packs** — install only the ones you want:
 
-| Pack                                                    | Adds                                                                                                                                     |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `@openchoreo/backstage-plugin-openchoreo-observability` | System tabs: **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis**. Component tabs: **Logs**, **Metrics**, **Alerts**. |
-| `@openchoreo/backstage-plugin-openchoreo-ci`            | Component tab: **Build** (workflow runs + trigger form).                                                                                 |
-| `@openchoreo/backstage-plugin-openchoreo-workflows`     | Standalone org-level Workflows page.                                                                                                     |
+| Pack                                                    | Adds                                                                                                                                                       |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@openchoreo/backstage-plugin-openchoreo-observability` | System tabs: **Logs**, **Traces**, **Incidents**, **RCA Reports**, **Cost Analysis**. Component tabs: **Logs**, **Events**, **Metrics**, **Alerts**, **Wirelogs**. |
+| `@openchoreo/backstage-plugin-openchoreo-ci`            | Component tab: **Build** (workflow runs + trigger form).                                                                                                   |
+| `@openchoreo/backstage-plugin-openchoreo-workflows`     | Standalone `/workflows` page + **Runs** tab on Workflow/ClusterWorkflow entities.                                                                          |
 
 See the [compatibility matrix](./compatibility-matrix.mdx) for the full list of packages.
 
@@ -46,6 +46,15 @@ If you need any of these today, fork the upstream repo or file an issue at [open
 ## Compatibility
 
 OpenChoreo plugins target a specific Backstage release line. See the [compatibility matrix](./compatibility-matrix.mdx) for the tested combinations. Installing into a Backstage app on a different release line may surface dependency-resolution issues; the [troubleshooting](./troubleshooting.mdx) guide lists the common ones and how to pin around them.
+
+## Install paths
+
+There are two ways to install OpenChoreo plugins:
+
+- **New Frontend System (NFS)** — the default for hosts scaffolded with `npx @backstage/create-app@latest`. Plugins are added to `createApp({ features: [...] })`, tabs and overview cards auto-mount, and you do not edit `EntityPage.tsx`. This is the recommended path.
+- **Legacy frontend system** — for hosts scaffolded with `--legacy` or with heavy `EntityPage.tsx` customization. See [Section 9 of the install guide](./installing-into-existing-backstage.mdx#9-legacy-frontend-system-fallback) for the legacy wiring.
+
+If you are upgrading from a plugin version `^1.1.x` install, see the [1.1.x to 1.2.x migration guide](./migration-1.1-to-1.2.mdx).
 
 ## Where to start
 

--- a/docs/platform-engineer-guide/backstage-plugins/permission-policy.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/permission-policy.mdx
@@ -66,7 +66,7 @@ backend.add(
 );
 ```
 
-You also need the frontend OIDC sign-in provider so the policy receives the user's IDP token. That wiring is part of [Core install § 4.3.2](./installing-into-existing-backstage.mdx#wire-signin) — `OpenChoreoAuthModule` on the backend, the `OAuth2` factory and `DynamicSignInPage` on the frontend. Plus the [`OpenChoreoPermissionApi`](./installing-into-existing-backstage.mdx#permission-api) override, without which the IDP token doesn't reach the authorize call at all.
+You also need the frontend OIDC sign-in provider so the policy receives the user's IDP token. That wiring is part of [Core install Section 4.3.2](./installing-into-existing-backstage.mdx#custom-app-module) — `OpenChoreoAuthModule` on the backend, the `OAuth2` factory and `DynamicSignInPage` on the frontend, plus the `OpenChoreoPermissionApi` `ApiBlueprint` override, without which the IDP token doesn't reach the authorize call at all.
 
 ## Composability semantics
 

--- a/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
@@ -8,6 +8,79 @@ sidebar_position: 6
 
 Issues you will most likely run into when installing the OpenChoreo plugins into an existing Backstage app, drawn from observed failures.
 
+## NFS: tab missing on entity page
+
+**Symptom:** you installed an opt-in pack (e.g. `@openchoreo/backstage-plugin-openchoreo-observability`) and the tab does not appear on the entity page after restart.
+
+**Cause:** the plugin's `Alpha` feature is not in `createApp({ features: [...] })`.
+
+**Fix:** add the import and append to the features array in `packages/app/src/App.tsx`:
+
+```tsx
+import openchoreoObservabilityPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-observability/alpha';
+
+export default createApp({
+  features: [
+    catalogPlugin,
+    openchoreoPluginAlpha,
+    openchoreoObservabilityPluginAlpha, // <-- add
+    navModule,
+    customAppModule,
+  ],
+});
+```
+
+## NFS: 401 on tab data fetches / "No permissions" on Deploy
+
+**Cause:** the `OpenChoreoFetchApi` / `OpenChoreoPermissionApi` overrides aren't being registered. Either `customAppModule` is missing from `createApp({ features: [...] })`, or the `ApiBlueprint` extensions inside it didn't get loaded (look for an extension-disabled warning in the browser console).
+
+**Fix:** confirm `customAppModule` is the *last* entry in `features: [...]` (NFS resolves api factories last-write-wins, so overrides must come after the plugins they override), and that both `ApiBlueprint.make` calls inside the module use `params: defineParams => defineParams({...})` (not `params: { factory: ... }` — that's the wrong shape and silently drops the extension).
+
+## NFS: duplicate Core tab (two `DEPLOY` tabs, etc.)
+
+**Cause:** you imported `openchoreoPluginAlpha` from `/alpha` (which auto-mounts the tab via `EntityContentBlueprint`) **and** left a legacy `<EntityLayout.Route path="/environments" title="Deploy"><Environments /></EntityLayout.Route>` in `EntityPage.tsx`.
+
+**Fix:** pick one path. For NFS hosts, delete the legacy `<EntityLayout.Route>` mounts from `EntityPage.tsx` (or delete the file entirely if you have no other host-custom tabs). For legacy hosts, do NOT add the `/alpha` features — install the plugin via its default export only. See [install guide Section 9](./installing-into-existing-backstage.mdx#9-legacy-frontend-system-fallback).
+
+## Rspack fails: `Can't resolve '@mui/material/version'`
+
+```
+ERROR in ../../node_modules/material-ui-popup-state/HoverPopover.mjs 5:1-46
+  × Module not found: Can't resolve '@mui/material/version' in
+    '/.../node_modules/material-ui-popup-state'
+```
+
+**Cause:** `material-ui-popup-state` requires `@mui/material@>=5 <10`. Without a resolution, yarn satisfies it with a nested copy of `@mui/material@5.13.x` that predates the `/version` subpath.
+
+**Fix:** pin `@mui/material` in your workspace root `package.json`:
+
+```json
+{
+  "resolutions": {
+    "@mui/material": "^5.18.0"
+  }
+}
+```
+
+Then `rm -rf node_modules yarn.lock && yarn install`.
+
+## Yarn age gate blocks fresh `@openchoreo/*` releases
+
+```
+YN0090: @openchoreo/backstage-plugin@npm:1.2.0 is younger than the
+configured minimum age (3d)
+```
+
+**Cause:** the NFS `create-app` scaffold's `.yarnrc.yml` sets `npmMinimalAgeGate: 3d` to protect against supply-chain attacks. Fresh `@openchoreo/*` prereleases sometimes land within that window.
+
+**Fix:** add `@openchoreo/*` to the pre-approved list in `.yarnrc.yml`:
+
+```yaml
+npmPreapprovedPackages:
+  - '@backstage/*'
+  - '@openchoreo/*'
+```
+
 ## Missing `alpha.core.metrics` service ref
 
 ```
@@ -181,7 +254,7 @@ Uncaught TypeError: Cannot read properties of undefined (reading 'id')
 
 **Cause:** the create-app template installs `@backstage/plugin-notifications`, which in versions newer than the 1.43.3 release line expects exports (`toastApiRef`, `Tag`, `Dialog`, `DialogHeader`, ...) that the pinned `@backstage/ui` and `@backstage/frontend-plugin-api` do not provide.
 
-**Fix:** remove `NotificationsSidebarItem` from `packages/app/src/components/Root/Root.tsx` and `<NotificationsPage />` from `packages/app/src/App.tsx`. See the [installation guide](./installing-into-existing-backstage.mdx#8-remove-the-notifications-plugin-if-present) for details.
+**Fix (legacy 1.43-era hosts only):** remove `NotificationsSidebarItem` from `packages/app/src/components/Root/Root.tsx` and `<NotificationsPage />` from `packages/app/src/App.tsx`. The 1.51 NFS scaffold does not exhibit this crash — if you are on `^1.2.x` of the OpenChoreo plugins against Backstage 1.51, you can leave the notifications wiring in place.
 
 ## `choreoPlugin` API factories not registered on entity tabs
 
@@ -235,13 +308,13 @@ HTTP 401: Unauthorized
 
 **Cause:** you're signed in to Backstage but the OpenChoreo backend modules (`-observability-backend`, `-ci-backend`, `-workflows-backend`) reject your requests because they can't find the IDP token. Backstage's default `fetchApi` only injects the Backstage identity token in `Authorization`; it has no concept of the `x-openchoreo-token` header the backend modules read.
 
-**Fix:** install the custom `OpenChoreoFetchApi` and register it against `fetchApiRef`. See [Override `fetchApi`](./installing-into-existing-backstage.mdx#fetch-api). The same fix is needed for permission requests — see [Override `permissionApi`](./installing-into-existing-backstage.mdx#permission-api).
+**Fix:** install the custom `OpenChoreoFetchApi` and register it against `fetchApiRef` via an `ApiBlueprint` extension in your `customAppModule`. See [install guide Section 4.3.2](./installing-into-existing-backstage.mdx#custom-app-module). The same fix is needed for permission requests — `OpenChoreoPermissionApi` against `permissionApiRef`, also covered in the same section.
 
 ## "No permissions to view this environment" on Deploy / Logs / Metrics tabs
 
 **Cause:** one of two things, in order of likelihood:
 
-1. **`OpenChoreoPermissionApi` not registered** in `packages/app/src/apis.ts`. The default `PermissionClient` bypasses `fetchApi` entirely and never gets the IDP token, so every authorize call fails. Fix: [Override `permissionApi`](./installing-into-existing-backstage.mdx#permission-api).
+1. **`OpenChoreoPermissionApi` not registered.** The default `PermissionClient` bypasses `fetchApi` entirely and never gets the IDP token, so every authorize call fails. Fix: register `OpenChoreoPermissionApi` against `permissionApiRef` — via the `customAppModule` `ApiBlueprint` extension under NFS (see [install guide Section 4.3.2](./installing-into-existing-backstage.mdx#custom-app-module)), or via `createApiFactory` in `apis.ts` on the legacy frontend.
 2. **Your user genuinely has no capabilities** in OpenChoreo. The IDP token is valid but the user's entitlements from ThunderID have not been mapped to a role in OpenChoreo that grants `release-binding:read` / `environment:read`. Confirm with `LOG_LEVEL=debug yarn start`, hit a Deploy tab, and grep backend logs for `[AUTHZ] Parsed capabilities` — that dumps what the OpenChoreo authz service returned. If the expected capabilities aren't there, fix the user's role bindings on the OpenChoreo control plane, not in Backstage.
 
 ## `JWKSNoMatchingKey` warnings in permission backend logs

--- a/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
+++ b/docs/platform-engineer-guide/backstage-plugins/troubleshooting.mdx
@@ -17,7 +17,7 @@ Issues you will most likely run into when installing the OpenChoreo plugins into
 **Fix:** add the import and append to the features array in `packages/app/src/App.tsx`:
 
 ```tsx
-import openchoreoObservabilityPluginAlpha from '@openchoreo/backstage-plugin-openchoreo-observability/alpha';
+import openchoreoObservabilityPluginAlpha from "@openchoreo/backstage-plugin-openchoreo-observability/alpha";
 
 export default createApp({
   features: [
@@ -34,7 +34,7 @@ export default createApp({
 
 **Cause:** the `OpenChoreoFetchApi` / `OpenChoreoPermissionApi` overrides aren't being registered. Either `customAppModule` is missing from `createApp({ features: [...] })`, or the `ApiBlueprint` extensions inside it didn't get loaded (look for an extension-disabled warning in the browser console).
 
-**Fix:** confirm `customAppModule` is the *last* entry in `features: [...]` (NFS resolves api factories last-write-wins, so overrides must come after the plugins they override), and that both `ApiBlueprint.make` calls inside the module use `params: defineParams => defineParams({...})` (not `params: { factory: ... }` — that's the wrong shape and silently drops the extension).
+**Fix:** confirm `customAppModule` is the _last_ entry in `features: [...]` (NFS resolves api factories last-write-wins, so overrides must come after the plugins they override), and that both `ApiBlueprint.make` calls inside the module use `params: defineParams => defineParams({...})` (not `params: { factory: ... }` — that's the wrong shape and silently drops the extension).
 
 ## NFS: duplicate Core tab (two `DEPLOY` tabs, etc.)
 
@@ -77,8 +77,8 @@ configured minimum age (3d)
 
 ```yaml
 npmPreapprovedPackages:
-  - '@backstage/*'
-  - '@openchoreo/*'
+  - "@backstage/*"
+  - "@openchoreo/*"
 ```
 
 ## Missing `alpha.core.metrics` service ref

--- a/docs/platform-engineer-guide/backstage-scaffolder-templates.mdx
+++ b/docs/platform-engineer-guide/backstage-scaffolder-templates.mdx
@@ -151,7 +151,7 @@ export const apis: AnyApiFactory[] = [
 ];
 ```
 
-The `openChoreoAuthApiRef` import is the same one wired up in [section 4.3.2 of the install guide](./backstage-plugins/installing-into-existing-backstage.mdx#wire-signin).
+The `openChoreoAuthApiRef` import is the same one wired up in [section 4.3.2 of the install guide](./backstage-plugins/installing-into-existing-backstage.mdx#custom-app-module).
 
 </TabItem>
 </Tabs>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -105,6 +105,7 @@ const sidebars: SidebarsConfig = {
             id: "platform-engineer-guide/backstage-plugins/overview",
           },
           items: [
+            "platform-engineer-guide/backstage-plugins/migration-1.1-to-1.2",
             "platform-engineer-guide/backstage-plugins/installing-into-existing-backstage",
             "platform-engineer-guide/backstage-plugins/catalog-sync",
             "platform-engineer-guide/backstage-plugins/entity-views",


### PR DESCRIPTION
  NFS-primary install (createApp({ features }) + customAppModule ApiBlueprints,
  no EntityPage.tsx edits) with legacy fallback in Section 9. Add 1.1.x to 1.2.x
  migration page, refresh compatibility matrix to 1.51.0, document new Events/
  Wirelogs tabs and auto-mounted EntityCard contributions. Versions reference
  1.2.0 GA with @next tip while it's still in development. Validated end-to-end
  against a fresh NFS scaffold via local tarballs

Demo Backstage Host configured following the updated docs

https://github.com/user-attachments/assets/95dfb835-7d0d-485d-baf5-d90ef04ce57e


