### PR TITLE
fix: set stroke colour of ticks in AgentSetupBuilder to white

### DIFF
--- a/src/components/AgentSetupBuilder/index.tsx
+++ b/src/components/AgentSetupBuilder/index.tsx
@@ -135,7 +135,7 @@ export default function AgentSetupBuilder({ currentVersion, fixedEnv }: Props) {
                 <span className={`${styles.planeCheck} ${isOn ? styles.planeCheckOn : ""}`}>
                   {isOn && (
                     <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
-                      <path d="M1 4L3.5 6.5L9 1" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M1 4L3.5 6.5L9 1" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
                     </svg>
                   )}
                 </span>


### PR DESCRIPTION
## Purpose
Change the tick colour used in the agent setup builder window to white so it is properly visible when using the light theme

Following screenshot shows how the agent setup builder window looks with this change.
<img width="1029" height="499" alt="Screenshot 2026-06-24 at 11 51 25" src="https://github.com/user-attachments/assets/e45d33e6-ec53-429a-9754-dd7dc3ebac59" />


## Related Issues
https://github.com/openchoreo/openchoreo/issues/3971

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
