### PR TITLE
fix: render plane checkbox background in production by bumping .planeCheckOn specificity

### DIFF
--- a/src/components/AgentSetupBuilder/index.tsx
+++ b/src/components/AgentSetupBuilder/index.tsx
@@ -135,7 +135,7 @@ export default function AgentSetupBuilder({ currentVersion, fixedEnv }: Props) {
                 <span className={`${styles.planeCheck} ${isOn ? styles.planeCheckOn : ""}`}>
                   {isOn && (
                     <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
-                      <path d="M1 4L3.5 6.5L9 1" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M1 4L3.5 6.5L9 1" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
                     </svg>
                   )}
                 </span>

--- a/src/components/AgentSetupBuilder/styles.module.css
+++ b/src/components/AgentSetupBuilder/styles.module.css
@@ -116,7 +116,7 @@
   transition: border-color 0.12s, background 0.12s;
 }
 
-.planeCheckOn {
+.planeCheck.planeCheckOn {
   border-color: var(--ifm-color-primary);
   background: var(--ifm-color-primary);
   color: #fff;


### PR DESCRIPTION
## Purpose

<img width="1029" height="499" alt="Screenshot 2026-06-24 at 11 51 25" src="https://github.com/user-attachments/assets/2153b081-e28c-43b9-8891-971f6aa49d25" />

The plane checkboxes in AgentSetupBuilder showed a white tick on a blue background under `npm run start`, but on the with `npm run build` + `npm run serve`, the blue background was missing, leaving an invisible white tick.

The checkbox span always has two equal-specificity classes:
- `.planeCheck` (where background is transparent)
- `.planeCheckOn` (where background is blue)

When the specificity is the same, source order decides the winner. Running locally (style-loader) keeps source order, so `.planeCheckOn` is applied. In production, cssnano's `mergeRules` merges `.planeCheckOn` with other rules sharing the same declaration block, so the transparent base rule is applied.

To fix this, this PR raises specificity by chaining it as  .planeCheck.planeCheckOn
Also reverts the change from https://github.com/openchoreo/openchoreo.github.io/pull/735

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3971

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
