### PR TITLE
docs: add an install picker to the getting-started guides

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -6,43 +6,21 @@ sidebar_position: 1
 
 import CodeBlock from "@theme/CodeBlock";
 import Link from "@docusaurus/Link";
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 import { versions, defaultCredentials } from "../../_constants.mdx";
-import AgentSetupBuilder from "@site/src/components/AgentSetupBuilder";
-import AgentCallout from "@site/src/components/AgentCallout";
+import { SetupSwitch, SetupOption } from "@site/src/components/SetupSwitch";
 
 # Run OpenChoreo on K3d Locally
 
-This guide walks you through setting up OpenChoreo on your machine with k3d. You will install each plane one at a time, and after each one you will do something real with it: log in, deploy a service, or trigger a build.
+This guide runs all four OpenChoreo planes on your machine, in a single k3d cluster.
 
 OpenChoreo has four planes:
 
 - **Control Plane** runs the API, console, identity provider, and controllers.
 - **Data Plane** runs your workloads and routes traffic to them.
 - **Workflow Plane** builds container images from source using Argo Workflows.
-- **Observability Plane** collects logs and metrics from all other planes.
+- **Observability Plane** collects logs and metrics from the other planes.
 
-By the end you will have all four running in a single k3d cluster.
-
-**What you will get:**
-
-- A working OpenChoreo installation on localhost
-- A deployed web app you can open in your browser
-- A source-to-image build pipeline
-- Log collection and querying
-
-<AgentCallout>
-
-Install the skill, pick your planes, and paste the prompt into your agent (Claude Code, Codex, Cursor, or any coding agent).
-
-```bash
-npx skills add openchoreo/skills --skill openchoreo-setup
-```
-
-<AgentSetupBuilder fixedEnv="k3d" currentVersion={versions.helmChart} />
-
-</AgentCallout>
+By the end you'll have a working installation on localhost: a web app you can open in your browser, a source-to-image build pipeline, and log collection.
 
 ## Prerequisites
 
@@ -77,6 +55,28 @@ colima start --vm-type=vz --vz-rosetta --cpu 4 --memory 8
 
 :::
 
+## Install
+
+Pick how you want to install it:
+
+<SetupSwitch>
+
+<SetupOption title="Run one command" desc="One script creates the cluster and installs every plane. The fastest way to a running setup." noToc>
+
+Run the following command. `--with-build` adds the workflow plane and `--with-observability` adds the observability plane. Drop either flag to skip that plane.
+
+<CodeBlock language="bash" className="wrap-code">
+  {`curl -fsSL https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/k3d-install.sh | bash -s -- --version ${versions.dockerTag} --with-build --with-observability`}
+</CodeBlock>
+
+The script creates the k3d cluster and installs all four planes. Once it finishes, try it out below.
+
+</SetupOption>
+
+<SetupOption title="Guided install" desc="Install each plane yourself, step by step, and learn what every piece does and how it fits together.">
+
+Install OpenChoreo by hand, one plane at a time. Work through each step in order.
+
 ## Step 1: Create the Cluster
 
 :::note[Colima users]
@@ -92,26 +92,6 @@ This creates a cluster named `openchoreo`. Your kubectl context is now `k3d-open
 ## Step 2: Install Prerequisites
 
 These are third-party components that OpenChoreo depends on. None of them are OpenChoreo-specific, they are standard Kubernetes building blocks.
-
-<Tabs>
-<TabItem value="quick" label="Quick Setup" default>
-
-This runs all the prerequisite commands from the Step-by-Step tab sequentially in a single script. If you want to understand what each component does and why it is needed, switch to the Step-by-Step tab instead.
-
-The script installs the following components:
-
-- **Gateway API CRDs** — Kubernetes-native ingress and routing definitions
-- **cert-manager** — Automated TLS certificate management
-- **External Secrets Operator** — Syncs secrets from external providers into Kubernetes
-- **kgateway** — Gateway API implementation that handles traffic routing
-- **OpenBao** — Secret backend (open-source Vault fork) with a `ClusterSecretStore`
-
-<CodeBlock language="bash">
-  {`curl -fsSL https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/k3d-prerequisites.sh | OPENCHOREO_REF=${versions.githubRef} bash`}
-</CodeBlock>
-
-</TabItem>
-<TabItem value="step-by-step" label="Step-by-Step">
 
 #### Gateway API CRDs
 
@@ -226,9 +206,6 @@ Pods inside the cluster need to resolve `*.openchoreo.localhost` hostnames to re
 <CodeBlock language="bash">
   {`kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/common/coredns-custom.yaml`}
 </CodeBlock>
-
-</TabItem>
-</Tabs>
 
 ## Step 3: Setup Control Plane
 
@@ -760,21 +737,6 @@ docker exec k3d-openchoreo-server-0 sh -c \
 
 A functional observability stack consists of the observability plane core services, logs module, traces module, and metrics module.
 
-<Tabs>
-<TabItem value="quick" label="Quick Install" default>
-
-This runs all the install commands from the Step-by-Step tab sequentially in a single script.
-If you want to understand what each command does and why it is needed, switch to the Step-by-Step tab instead.
-
-Run the following script:
-
-<CodeBlock language="bash">
-  {`curl -fsSL https://raw.githubusercontent.com/openchoreo/openchoreo/${versions.githubRef}/install/k3d/k3d-observability-plane.sh | OPENCHOREO_REF=${versions.githubRef} OPENCHOREO_OP_VERSION=${versions.helmChart} bash`}
-</CodeBlock>
-
-</TabItem>
-<TabItem value="step-by-step" label="Step-by-Step">
-
 #### Install the observability plane core
 
 <CodeBlock language="bash">
@@ -870,9 +832,6 @@ pipelineExporters:
 EOF
 ```
 
-</TabItem>
-</Tabs>
-
 ### Register the Observability Plane
 
 ```bash
@@ -909,7 +868,11 @@ kubectl patch clusterworkflowplane default --type merge \
   -p '{"spec":{"observabilityPlaneRef":{"kind":"ClusterObservabilityPlane","name":"default"}}}'
 ```
 
-## Step 8: Try it Out
+</SetupOption>
+
+</SetupSwitch>
+
+## Try it Out
 
 ### Log in to OpenChoreo
 

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -8,41 +8,22 @@ import CodeBlock from "@theme/CodeBlock";
 import Link from "@docusaurus/Link";
 import { versions, defaultCredentials } from "../../_constants.mdx";
 import AgentSetupBuilder from "@site/src/components/AgentSetupBuilder";
-import AgentCallout from "@site/src/components/AgentCallout";
+import { SetupSwitch, SetupOption } from "@site/src/components/SetupSwitch";
 
 # Run OpenChoreo in Your Environment
 
-This guide walks you through setting up OpenChoreo on any Kubernetes cluster (k3s, GKE, EKS, DOKS, AKS, or self-managed). You will install each plane one at a time, and after each one you will do something real with it: log in, deploy a service, or trigger a build.
+This guide runs OpenChoreo on any Kubernetes cluster (k3s, GKE, EKS, DOKS, AKS, or self-managed), using a **single-cluster topology** with all planes in one cluster. For split-cluster setups, follow [Multi-Cluster Connectivity](../../platform-engineer-guide/multi-cluster-connectivity.mdx).
 
-It uses a **single-cluster topology** (all planes in one cluster). For split-cluster setups, follow [Multi-Cluster Connectivity](../../platform-engineer-guide/multi-cluster-connectivity.mdx).
-
-All gateways are configured with HTTPS using self-signed certificates by default. You can replace them with certificates from a real CA later.
+Gateways use HTTPS with self-signed certificates by default; you can swap in certificates from a real CA later.
 
 OpenChoreo has four planes:
 
 - **Control Plane** runs the API, console, identity provider, and controllers.
 - **Data Plane** runs your workloads and routes traffic to them.
 - **Workflow Plane** builds container images from source using Argo Workflows.
-- **Observability Plane** collects logs and metrics from all other planes.
+- **Observability Plane** collects logs and metrics from the other planes.
 
-**What you will get:**
-
-- OpenChoreo running on your Kubernetes cluster with HTTPS
-- A reachable console URL over your cluster LoadBalancer
-- A deployed web app you can open in your browser
-- Optional source-to-image build pipeline and log collection
-
-<AgentCallout>
-
-Install the skill, pick your environment and planes, and paste the prompt into your agent (Claude Code, Codex, Cursor, or any coding agent).
-
-```bash
-npx skills add openchoreo/skills --skill openchoreo-setup
-```
-
-<AgentSetupBuilder currentVersion={versions.helmChart} />
-
-</AgentCallout>
+By the end you'll have OpenChoreo running on your cluster over HTTPS, reachable at a console URL through your LoadBalancer, with a web app deployed and, optionally, a source-to-image build pipeline and log collection.
 
 ## Prerequisites
 
@@ -80,6 +61,16 @@ Verify the node kernel and CRI runtime reported by Kubernetes:
 kubectl get nodes \
   -o custom-columns=NAME:.metadata.name,KERNEL:.status.nodeInfo.kernelVersion,RUNTIME:.status.nodeInfo.containerRuntimeVersion,KUBELET:.status.nodeInfo.kubeletVersion
 ```
+
+## Install
+
+Pick how you want to install it:
+
+<SetupSwitch>
+
+<SetupOption title="Guided install" desc="Install each plane yourself, step by step, and learn what every piece does and how it fits together.">
+
+Install OpenChoreo by hand, one plane at a time. Work through each step in order.
 
 ## Step 1: Install Prerequisites
 
@@ -1247,6 +1238,24 @@ kubectl delete namespace \
   external-secrets \
   cert-manager 2>/dev/null
 ```
+
+</SetupOption>
+
+<SetupOption title="Install with your agent (experimental)" desc="Install the skill and paste one prompt into Claude Code, Codex, Cursor, or any coding agent." interactive noToc>
+
+Install the `openchoreo-setup` skill.
+
+```bash
+npx skills add openchoreo/skills --skill openchoreo-setup -g
+```
+
+Then pick your environment and planes, and copy the prompt into your agent.
+
+<AgentSetupBuilder currentVersion={versions.helmChart} />
+
+</SetupOption>
+
+</SetupSwitch>
 
 ## Next Steps
 

--- a/plugins/docusaurus-plugin-markdown-export/mdxProcessor.js
+++ b/plugins/docusaurus-plugin-markdown-export/mdxProcessor.js
@@ -60,6 +60,10 @@ async function processMarkdownFile(content, constants, sourceDir, linkContext) {
   const { frontmatter, body } = extractFrontmatter(result);
   result = body;
 
+  // Step 2.5: Drop the interactive agent callout and unwrap the install picker,
+  // leaving a clean manual guide (and, on the k3d page, the one-command script).
+  result = processInstallComponents(result);
+
   // Step 3: Process CodeBlock components
   result = processCodeBlocks(result, constants);
 
@@ -116,6 +120,20 @@ function extractFrontmatter(content) {
 
   const body = content.slice(frontmatterMatch[0].length);
   return { frontmatter, body };
+}
+
+function processInstallComponents(content) {
+  let result = content;
+  // Drop interactive agent panels (prompt builder, older callout) entirely.
+  result = result.replace(/<SetupOption\b[^>]*\binteractive\b[^>]*>[\s\S]*?<\/SetupOption>/g, '');
+  result = result.replace(/<AgentCallout\b[^>]*>[\s\S]*?<\/AgentCallout>/g, '');
+  result = result.replace(/<AgentSetupBuilder\b[^>]*\/>/g, '');
+  // Unwrap the picker containers, keeping the remaining panels' markdown so the
+  // exported guide reads as plain markdown.
+  result = result.replace(/<\/?SetupSwitch>/g, '');
+  result = result.replace(/<SetupOption\b[^>]*>/g, '');
+  result = result.replace(/<\/SetupOption>/g, '');
+  return result;
 }
 
 function removeImports(content) {

--- a/src/components/AgentCallout/index.tsx
+++ b/src/components/AgentCallout/index.tsx
@@ -3,9 +3,10 @@ import styles from "./styles.module.css";
 
 interface Props {
   children: React.ReactNode;
+  label?: string;
 }
 
-export default function AgentCallout({ children }: Props) {
+export default function AgentCallout({ children, label }: Props) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -16,7 +17,7 @@ export default function AgentCallout({ children }: Props) {
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
       >
-        <span>✦&nbsp; Have your agent set this up for you</span>
+        <span>✦&nbsp; {label ?? "Have your agent set this up for you"}</span>
         <span className={`${styles.chevron} ${open ? styles.chevronOpen : ""}`}>›</span>
       </button>
       {open && <div className={styles.content}>{children}</div>}

--- a/src/components/AgentCallout/styles.module.css
+++ b/src/components/AgentCallout/styles.module.css
@@ -47,3 +47,13 @@
 .content {
   margin-top: 0.75rem;
 }
+
+.content :global([class*="codeBlockContainer"]) {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  box-shadow: none;
+}
+
+.content :global(.prism-code) {
+  background: var(--ifm-background-surface-color);
+}

--- a/src/components/AgentSetupBuilder/index.tsx
+++ b/src/components/AgentSetupBuilder/index.tsx
@@ -13,21 +13,21 @@ type Env =
 type Topology = "single" | "multi";
 
 const ENVS: { id: Env; label: string }[] = [
+  { id: "self-managed", label: "Self-managed" },
   { id: "k3d", label: "Local k3d" },
   { id: "rancher-desktop", label: "Rancher Desktop" },
   { id: "gke", label: "GKE" },
   { id: "eks", label: "EKS" },
   { id: "aks", label: "AKS" },
-  { id: "self-managed", label: "Self-managed" },
 ];
 
-const ENV_PROMPT: Record<Env, string> = {
-  "k3d": "Install OpenChoreo locally on k3d.",
-  "rancher-desktop": "Install OpenChoreo on Rancher Desktop.",
-  "gke": "Install OpenChoreo on GKE.",
-  "eks": "Install OpenChoreo on EKS.",
-  "aks": "Install OpenChoreo on AKS.",
-  "self-managed": "Install OpenChoreo on my Kubernetes cluster.",
+const ENV_TARGET: Record<Env, string> = {
+  "k3d": "a local k3d cluster",
+  "rancher-desktop": "Rancher Desktop",
+  "gke": "GKE",
+  "eks": "EKS",
+  "aks": "AKS",
+  "self-managed": "my Kubernetes environment",
 };
 
 const PLANES = [
@@ -44,20 +44,20 @@ function resolveVersion(helmChart: string): string {
 
 function buildPrompt(env: Env, topology: Topology, workflow: boolean, obs: boolean, version: string): string {
   const topologyClause = topology === "single"
-    ? "Everything on a single cluster."
-    : "Use a multi-cluster topology.";
+    ? "on a single cluster"
+    : "across a multi-cluster topology";
 
   let planes: string;
   if (workflow && obs) {
-    planes = "Install all four planes.";
+    planes = "all four planes (control, data, workflow, and observability)";
   } else if (workflow && !obs) {
-    planes = "Install the control, data, and workflow planes. Skip the observability plane.";
+    planes = "the control, data, and workflow planes (skip the observability plane)";
   } else if (!workflow && obs) {
-    planes = "Install the control, data, and observability planes. Skip the workflow plane.";
+    planes = "the control, data, and observability planes (skip the workflow plane)";
   } else {
-    planes = "Install only the control and data planes.";
+    planes = "just the control and data planes";
   }
-  return `${ENV_PROMPT[env]} ${topologyClause} Use version ${version}. ${planes}`;
+  return `Install OpenChoreo on ${ENV_TARGET[env]} ${topologyClause} at version ${version}, with ${planes}. Use the /openchoreo-setup skill. When it's done, summarize what was installed.`;
 }
 
 interface Props {
@@ -69,7 +69,7 @@ export default function AgentSetupBuilder({ currentVersion, fixedEnv }: Props) {
   const version = currentVersion ? resolveVersion(currentVersion) : "next";
   const visibleEnvs = fixedEnv ? ENVS : ENVS.filter((e) => e.id !== "k3d");
 
-  const [env, setEnv] = useState<Env>(fixedEnv ?? "rancher-desktop");
+  const [env, setEnv] = useState<Env>(fixedEnv ?? "self-managed");
   const [topology, setTopology] = useState<Topology>("single");
   const [workflow, setWorkflow] = useState(true);
   const [obs, setObs] = useState(true);
@@ -139,9 +139,11 @@ export default function AgentSetupBuilder({ currentVersion, fixedEnv }: Props) {
                     </svg>
                   )}
                 </span>
-                <span className={styles.planeName}>{p.label}</span>
+                <span className={styles.planeName}>
+                  {p.label}
+                  {p.required && <span className={styles.planeReqInline}> (required)</span>}
+                </span>
                 <span className={styles.planeDesc}>{p.desc}</span>
-                {p.required && <span className={styles.planeReqBadge}>required</span>}
               </button>
             );
           })}

--- a/src/components/AgentSetupBuilder/styles.module.css
+++ b/src/components/AgentSetupBuilder/styles.module.css
@@ -1,7 +1,7 @@
 .builder {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
   margin-top: 0.75rem;
 }
 
@@ -64,7 +64,7 @@
 .planesGrid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.4rem;
+  gap: 0.55rem;
 }
 
 @media (max-width: 480px) {
@@ -75,11 +75,11 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
-  padding: 0.5rem 0.5rem 0.5rem 2rem;
+  gap: 0.2rem;
+  padding: 0.7rem 0.75rem 0.7rem 2.1rem;
   border-radius: 8px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
   cursor: pointer;
   text-align: left;
   transition: border-color 0.12s, background 0.12s, opacity 0.12s;
@@ -87,14 +87,13 @@
 
 .planeCardRequired {
   cursor: default;
-  opacity: 0.55;
 }
 
 .planeCard:not(.planeCardRequired):hover {
   border-color: var(--ifm-color-primary);
 }
 
-.planeCardOn:not(.planeCardRequired) {
+.planeCardOn {
   border-color: var(--ifm-color-primary);
   background: rgba(43, 140, 247, 0.08);
 }
@@ -133,10 +132,9 @@
   color: var(--ifm-color-emphasis-600);
 }
 
-.planeReqBadge {
-  font-size: 0.65rem;
-  color: var(--ifm-color-emphasis-500);
-  font-style: italic;
+.planeReqInline {
+  font-weight: 400;
+  color: var(--ifm-color-emphasis-600);
 }
 
 .builder :global(.prism-code) {

--- a/src/components/SetupSwitch/index.tsx
+++ b/src/components/SetupSwitch/index.tsx
@@ -1,0 +1,100 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import styles from "./styles.module.css";
+
+// A two-way picker for the install guides. Each SetupOption is a panel with a
+// title/description shown in the band. Both panels render on the server so
+// crawlers and the markdown export see them; after hydration only the selected
+// one shows. Options flagged noToc hide the page table of contents while active
+// (they don't own the page's headings).
+
+const Ctx = createContext<{ sel: number; setSel: (i: number) => void; mounted: boolean }>({
+  sel: 0,
+  setSel: () => {},
+  mounted: false,
+});
+
+interface OptionProps {
+  title: string;
+  desc: string;
+  noToc?: boolean;
+  // Marks an interactive panel dropped from the markdown export; no runtime effect.
+  interactive?: boolean;
+  children: React.ReactNode;
+}
+
+export function SetupOption(_props: OptionProps) {
+  // Rendered by SetupSwitch via cloneElement, which injects the index.
+  const { sel, setSel, mounted } = useContext(Ctx);
+  const index = (_props as OptionProps & { _index?: number })._index ?? 0;
+  const ref = useRef<HTMLDivElement>(null);
+  const pendingId = useRef<string | null>(null);
+
+  // A deep link or TOC click to a heading in this panel reveals it. Wait for
+  // hydration: before mount the panel isn't hidden yet, so the guard can't tell.
+  useEffect(() => {
+    if (!mounted) return;
+    const reveal = () => {
+      const id = decodeURIComponent(window.location.hash.slice(1));
+      if (!id || !ref.current) return;
+      const target = document.getElementById(id);
+      if (target && ref.current.hidden && ref.current.contains(target)) {
+        pendingId.current = id;
+        setSel(index);
+      }
+    };
+    reveal();
+    window.addEventListener("hashchange", reveal);
+    return () => window.removeEventListener("hashchange", reveal);
+  }, [setSel, mounted, index]);
+
+  useEffect(() => {
+    if (sel === index && pendingId.current) {
+      const target = document.getElementById(pendingId.current);
+      pendingId.current = null;
+      if (target) target.scrollIntoView();
+    }
+  }, [sel, index]);
+
+  return (
+    <div ref={ref} hidden={mounted && sel !== index}>
+      {_props.children}
+    </div>
+  );
+}
+
+export function SetupSwitch({ children }: { children: React.ReactNode }) {
+  const options = React.Children.toArray(children).filter(React.isValidElement) as React.ReactElement<OptionProps>[];
+  const [sel, setSel] = useState(0);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const root = document.documentElement;
+    if (options[sel]?.props.noToc) root.setAttribute("data-setup-pane", "notoc");
+    else root.removeAttribute("data-setup-pane");
+    return () => root.removeAttribute("data-setup-pane");
+  }, [sel, mounted, options]);
+
+  return (
+    <Ctx.Provider value={{ sel, setSel, mounted }}>
+      <div className={styles.band} role="tablist">
+        {options.map((opt, i) => (
+          <button
+            key={i}
+            type="button"
+            className={styles.half}
+            role="tab"
+            aria-selected={sel === i}
+            onClick={() => setSel(i)}
+          >
+            <span className={styles.title}>{opt.props.title}</span>
+            <span className={styles.desc}>{opt.props.desc}</span>
+          </button>
+        ))}
+      </div>
+      {options.map((opt, i) => React.cloneElement(opt as React.ReactElement<OptionProps & { _index: number }>, { _index: i, key: i }))}
+    </Ctx.Provider>
+  );
+}

--- a/src/components/SetupSwitch/styles.module.css
+++ b/src/components/SetupSwitch/styles.module.css
@@ -1,0 +1,43 @@
+.band {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  overflow: hidden;
+  margin: 1.25rem 0 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .band { grid-template-columns: 1fr; }
+}
+
+.half {
+  padding: 1.1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: var(--ifm-background-surface-color);
+  cursor: pointer;
+  text-align: left;
+  border: none;
+  font: inherit;
+  color: inherit;
+  transition: background 0.12s;
+}
+
+.half:first-child { border-right: 1px solid var(--ifm-color-emphasis-200); }
+
+@media (max-width: 600px) {
+  .half:first-child { border-right: none; border-bottom: 1px solid var(--ifm-color-emphasis-200); }
+}
+
+.half:not([aria-selected="true"]):hover { background: var(--ifm-color-emphasis-100); }
+
+.half[aria-selected="true"] {
+  background: rgba(43, 140, 247, 0.10);
+}
+
+.half[aria-selected="true"] .title { color: var(--ifm-color-primary); }
+
+.title { font-weight: 700; }
+.desc { color: var(--ifm-color-emphasis-700); font-size: 0.86rem; }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -330,3 +330,18 @@ html:not([data-theme='dark']) .DocSearch-Sidepanel-Prompt--submit {
 html:not([data-theme='dark']) .DocSearch-Sidepanel-Prompt--stop {
   background-color: #fff;
 }
+
+/* Install pages: hide the page TOC while the "agent" setup pane is active,
+   since every TOC entry belongs to the (hidden) manual guide. The TOC column
+   width is kept, so toggling panes does not reflow the content. */
+html[data-setup-pane='notoc'] .theme-doc-toc-desktop,
+html[data-setup-pane='notoc'] .theme-doc-toc-mobile {
+  display: none;
+}
+
+/* Wrap long single-line commands instead of scrolling horizontally */
+.wrap-code pre,
+.wrap-code code {
+  white-space: pre-wrap !important;
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
## What

Replaces the collapsible agent callout at the top of both install guides with a
shared two-way picker (`SetupSwitch`).

- **Run Locally on K3d** — **Run one command** (a single install script that
  creates the cluster and installs every plane, via `install/k3d/k3d-install.sh`)
  or **Guided install** (the full step-by-step guide).
- **Run in Your Environment** — **Guided install**, or **Install with your agent
  (experimental)** as the second option (install the skill, paste one prompt).

https://github.com/user-attachments/assets/a737a22c-51b5-4163-ac9d-3ff2f75ab0b9

## Behaviour

- Both panels render before hydration, so crawlers and the exported `.md` (and
  `llms.txt`) see them. The export drops the interactive agent panel and unwraps
  the picker containers, leaving clean markdown.
- Prerequisites sit above the picker (shared) and trailing sections follow below
  it, so either path flows in without a jump link. A deep link or table-of-contents
  click to a heading in a hidden panel reveals it; the table of contents is hidden
  while a panel without page headings is active.
- The k3d single-cluster **Cleanup** is shared below the picker (both k3d paths are
  single-cluster). On the your-environment page Cleanup lives inside the guided
  panel only, since the agent path may install multi-cluster.
- The agent prompt builder produces a fuller, more direct prompt that asks for a
  summary once done, and defaults to a self-managed environment.

## Notes

- `next` docs only; versioned docs are unchanged.
- The k3d one-command path uses `install/k3d/k3d-install.sh` (openchoreo/openchoreo#4096); this docs change should land after that merges.
