### PR TITLE
feat(blog): show all posts in the blog sidebar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -161,6 +161,8 @@ const config: Config = {
             type: ['rss', 'atom'],
             xslt: true,
           },
+          blogSidebarTitle: 'All posts',
+          blogSidebarCount: 'ALL',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:


### PR DESCRIPTION
## Purpose
Add all blog posts listing to the sidebar.
<img width="512" height="763" alt="image" src="https://github.com/user-attachments/assets/9ef776cf-d5bf-4910-a87c-ad2bc4fa7ca6" />


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
