### PR TITLE
docs: track the visible panel in the install-guide table of contents

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -61,7 +61,7 @@ Pick how you want to install it:
 
 <SetupSwitch>
 
-<SetupOption title="Run one command" desc="One script creates the cluster and installs every plane. The fastest way to a running setup." noToc>
+<SetupOption title="Run one command" desc="One script creates the cluster and installs every plane. The fastest way to a running setup.">
 
 Run the following command. `--with-build` adds the workflow plane and `--with-observability` adds the observability plane. Drop either flag to skip that plane.
 

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -1241,7 +1241,7 @@ kubectl delete namespace \
 
 </SetupOption>
 
-<SetupOption title="Install with your agent (experimental)" desc="Install the skill and paste one prompt into Claude Code, Codex, Cursor, or any coding agent." interactive noToc>
+<SetupOption title="Install with your agent (experimental)" desc="Install the skill and paste one prompt into Claude Code, Codex, Cursor, or any coding agent." interactive>
 
 Install the `openchoreo-setup` skill.
 

--- a/src/components/AgentSetupBuilder/index.tsx
+++ b/src/components/AgentSetupBuilder/index.tsx
@@ -126,13 +126,13 @@ export default function AgentSetupBuilder({ currentVersion, fixedEnv }: Props) {
                 key={p.id}
                 type="button"
                 disabled={p.required}
-                className={`${styles.planeCard} ${isOn ? styles.planeCardOn : ""} ${p.required ? styles.planeCardRequired : ""}`}
+                className={`${styles.planeCard} ${isOn && !p.required ? styles.planeCardOn : ""} ${p.required ? styles.planeCardRequired : ""}`}
                 onClick={() => {
                   if (p.id === "workflow") setWorkflow((v) => !v);
                   if (p.id === "observability") setObs((v) => !v);
                 }}
               >
-                <span className={`${styles.planeCheck} ${isOn ? styles.planeCheckOn : ""}`}>
+                <span className={`${styles.planeCheck} ${p.required ? styles.planeCheckRequired : isOn ? styles.planeCheckOn : ""}`}>
                   {isOn && (
                     <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
                       <path d="M1 4L3.5 6.5L9 1" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/components/AgentSetupBuilder/styles.module.css
+++ b/src/components/AgentSetupBuilder/styles.module.css
@@ -121,6 +121,12 @@
   color: #fff;
 }
 
+.planeCheck.planeCheckRequired {
+  border-color: var(--ifm-color-emphasis-400);
+  background: var(--ifm-color-emphasis-400);
+  color: #fff;
+}
+
 .planeName {
   font-size: 0.78rem;
   font-weight: 600;

--- a/src/components/SetupSwitch/index.tsx
+++ b/src/components/SetupSwitch/index.tsx
@@ -4,8 +4,8 @@ import styles from "./styles.module.css";
 // A two-way picker for the install guides. Each SetupOption is a panel with a
 // title/description shown in the band. Both panels render on the server so
 // crawlers and the markdown export see them; after hydration only the selected
-// one shows. Options flagged noToc hide the page table of contents while active
-// (they don't own the page's headings).
+// one shows. The page table of contents is filtered to the headings that are
+// currently visible, so it tracks the active panel and the shared sections.
 
 const Ctx = createContext<{ sel: number; setSel: (i: number) => void; mounted: boolean }>({
   sel: 0,
@@ -16,7 +16,6 @@ const Ctx = createContext<{ sel: number; setSel: (i: number) => void; mounted: b
 interface OptionProps {
   title: string;
   desc: string;
-  noToc?: boolean;
   // Marks an interactive panel dropped from the markdown export; no runtime effect.
   interactive?: boolean;
   children: React.ReactNode;
@@ -56,7 +55,7 @@ export function SetupOption(_props: OptionProps) {
   }, [sel, index]);
 
   return (
-    <div ref={ref} hidden={mounted && sel !== index}>
+    <div ref={ref} data-setup-panel hidden={mounted && sel !== index}>
       {_props.children}
     </div>
   );
@@ -69,13 +68,26 @@ export function SetupSwitch({ children }: { children: React.ReactNode }) {
 
   useEffect(() => setMounted(true), []);
 
+  // Keep the page table of contents in sync with what's visible: hide the
+  // entries whose target heading sits inside a hidden panel, so the nav reflects
+  // the active panel plus the shared sections instead of vanishing.
   useEffect(() => {
     if (!mounted) return;
-    const root = document.documentElement;
-    if (options[sel]?.props.noToc) root.setAttribute("data-setup-pane", "notoc");
-    else root.removeAttribute("data-setup-pane");
-    return () => root.removeAttribute("data-setup-pane");
-  }, [sel, mounted, options]);
+    const hidden = new Set<string>();
+    document.querySelectorAll<HTMLElement>("[data-setup-panel]").forEach((panel) => {
+      if (panel.hidden) {
+        panel.querySelectorAll<HTMLElement>("h1[id],h2[id],h3[id],h4[id],h5[id],h6[id]").forEach((h) => hidden.add(h.id));
+      }
+    });
+    const links = document.querySelectorAll<HTMLAnchorElement>(
+      ".table-of-contents a[href^='#'], .theme-doc-toc-mobile a[href^='#']"
+    );
+    links.forEach((a) => {
+      const id = decodeURIComponent((a.getAttribute("href") || "").slice(1));
+      const li = a.closest("li");
+      if (li) li.style.display = hidden.has(id) ? "none" : "";
+    });
+  }, [sel, mounted]);
 
   return (
     <Ctx.Provider value={{ sel, setSel, mounted }}>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -334,11 +334,6 @@ html:not([data-theme='dark']) .DocSearch-Sidepanel-Prompt--stop {
 /* Install pages: hide the page TOC while the "agent" setup pane is active,
    since every TOC entry belongs to the (hidden) manual guide. The TOC column
    width is kept, so toggling panes does not reflow the content. */
-html[data-setup-pane='notoc'] .theme-doc-toc-desktop,
-html[data-setup-pane='notoc'] .theme-doc-toc-mobile {
-  display: none;
-}
-
 /* Wrap long single-line commands instead of scrolling horizontally */
 .wrap-code pre,
 .wrap-code code {


### PR DESCRIPTION
Follow-up to #743 (merged), refining the getting-started install picker.

## What

- **Table of contents tracks the visible panel.** Previously, selecting a
  non-guided panel (Run one command / Install with your agent) hid the entire
  right-hand table of contents, leaving an empty rail even though the shared
  sections below the picker are still on screen. Now the TOC filters to the
  headings that are actually visible, so it shows the active panel's headings
  plus the shared sections (Try it Out / Cleanup / Next Steps).
- **Required planes read as fixed.** In the agent prompt builder, the
  always-installed Control Plane and Data Plane now show a greyed tick with no
  selected-card highlight, so they look fixed rather than like a toggle.

`next` docs only; versioned docs are unchanged.
