### PR TITLE
docs: add Google Cloud Logging logs module to marketplace

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -481,6 +481,25 @@
     "released": true
   },
   {
+    "id": "logs-gcp-cloudlogging",
+    "group": "module",
+    "name": "Logs - Google Cloud Logging",
+    "description": "The Observability Logs Module for Google Cloud Logging queries OpenChoreo application logs from Cloud Logging, populated by the GKE managed logging agent, and exposes them through the OpenChoreo Portal, CLI, and MCP servers, with support for log-based alerts via Cloud Monitoring alert policies.",
+    "category": "Observability",
+    "tags": [
+      "logs",
+      "observability",
+      "gcp",
+      "cloudlogging",
+      "gke"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/observability-logs-gcp-cloudlogging",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "metrics-cloudwatch",
     "group": "module",
     "name": "Metrics - AWS CloudWatch",


### PR DESCRIPTION
## Purpose

Adds the **Logs - Google Cloud Logging** observability module to the ecosystem/marketplace catalog (`src/data/marketplace-plugins.json`), so it appears alongside its siblings (AWS CloudWatch, Azure Log Analytics). The module lives in [community-modules/observability-logs-gcp-cloudlogging](https://github.com/openchoreo/community-modules/tree/main/observability-logs-gcp-cloudlogging) and is now merged.

The entry queries application logs from Google Cloud Logging (populated by the GKE managed logging agent) and supports log-based alerts via Cloud Monitoring alert policies, matching the schema and phrasing of the existing logs entries.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)