### PR TITLE
docs: bump opensearch tracing module to 0.5.0 in getting-started guides

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -766,7 +766,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2 \
+  --version 0.5.0 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```

--- a/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
+++ b/docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh
@@ -29,7 +29,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2 \
+  --version 0.5.0 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -993,7 +993,7 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.2 \
+  --version 0.5.0 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
 ```

--- a/docs/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx
+++ b/docs/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx
@@ -332,6 +332,22 @@ The data, workflow, and observability planes have no backward-incompatible chang
 
 If you use the community observability modules (logs, traces, metrics), upgrade each to the version compatible with v1.2; see the [release notes](https://github.com/openchoreo/openchoreo/releases) for the module versions and any module-specific steps.
 
+:::warning Traces OpenSearch module is a breaking upgrade on v1.2
+Upgrade the `observability-tracing-opensearch` module from v0.4.x to **v0.5.0** when you move to v1.2. v0.5.0 changes the span-details response: `attributes` and `resourceAttributes` are returned as a native key/value map instead of an array of `{key, value}` objects. The v1.2 Observer expects the map form, so leaving the module on v0.4.x breaks span-details retrieval.
+
+```bash
+helm upgrade --install observability-traces-opensearch \
+  oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
+  --create-namespace \
+  --namespace openchoreo-observability-plane \
+  --version 0.5.0 \
+  --reset-then-reuse-values \
+  --set openSearch.enabled=false \
+  --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials"
+```
+
+:::
+
 ## Verifying and rolling back
 
 Verify the control-plane migration with the checks in [step 7](#step-7-post-upgrade-verification), and verify the remaining planes as described in the [standard process](./overview.mdx#verify).


### PR DESCRIPTION
## Purpose
Update the docs to use the `observability-tracing-opensearch` 0.5.0 module. The
0.5.0 adapter returns span-details attributes as a native key/value map (instead
of an array of `{key, value}` objects), matching the format the v1.2 Observer
expects.

- Getting-started install steps — bump the tracing module `--version` from `0.4.2`
  to `0.5.0`:
  - `docs/getting-started/try-it-out/on-k3d-locally.mdx`
  - `docs/getting-started/try-it-out/on-k3d-locally/k3d-observability-plane.sh`
  - `docs/getting-started/try-it-out/on-your-environment.mdx`
- v1.1 → v1.2 upgrade guide — add a warning + helm command for the traces module
  0.4.x → 0.5.0 upgrade, noting the breaking span-details attributes format change:
  - `docs/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx`

## Related Issues
> N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)