### PR TITLE
fix: pin observability logs opensearch module to v0.4.1

### DIFF
--- a/docs/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
+++ b/docs/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
@@ -28,14 +28,14 @@ kubectl patch deployment observer -n openchoreo-observability-plane \
 
 If you use the default logs, metrics, and traces modules at the versions from the OpenChoreo v1.0.0 documentation, upgrade them to the versions compatible with v1.1 as well.
 
-- Observability Logs OpenSearch module: v0.3.11 -> v0.5.3
+- Observability Logs OpenSearch module: v0.3.11 -> v0.4.1
 
 ```bash
 helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.5.3 \
+  --version 0.4.1 \
   --reset-then-reuse-values \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials"


### PR DESCRIPTION
## Purpose

The v1.0 to v1.1 upgrade guide listed the Observability Logs OpenSearch module target version as `v0.5.3`. This PR corrects it to `v0.4.1`, the version compatible with v1.1 (matching the traces module's `v0.4.x` line documented in the same section).

## Approach

- Update the Observability Logs OpenSearch module version from `v0.5.3` to `v0.4.1` in the upgrade note and the `helm upgrade` command's `--version` flag.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)