### PR TITLE
docs: note that the gpt-5.6 series is unsupported by the agents

### DIFF
--- a/versioned_docs/version-v1.2.0-rc.1/ai/finops-agent.mdx
+++ b/versioned_docs/version-v1.2.0-rc.1/ai/finops-agent.mdx
@@ -83,6 +83,8 @@ Enable the FinOps Agent and configure the LLM model. The `--reuse-values` flag p
 
 :::note Supported Models
 The FinOps Agent currently supports the [OpenAI](https://platform.openai.com/) GPT model series (e.g., `gpt-5.4`, `gpt-5.2-pro`, `gpt-5` etc.). Support for additional model providers is coming soon.
+
+The `gpt-5.6` series is not supported at the moment. Support is coming soon.
 :::
 
 If the observability plane and control plane are in separate clusters, also set `finOpsAgent.openchoreoApiUrl` to the control plane API URL (defaults to `http://api.openchoreo.localhost:8080`).

--- a/versioned_docs/version-v1.2.0-rc.1/ai/portal-assistant.mdx
+++ b/versioned_docs/version-v1.2.0-rc.1/ai/portal-assistant.mdx
@@ -95,7 +95,9 @@ Any `provider:model` string accepted by LangChain's `init_chat_model` works. Com
 - `openai:gpt-5` — base model, good default for development.
 - `openai:gpt-5.2-pro` — better tool-use reasoning, recommended for production.
 - `openai:gpt-5.4` — latest, highest-quality option.
-  :::
+
+The `gpt-5.6` series is not supported at the moment. Support is coming soon.
+:::
 
 If your Observer or SRE Agent live outside the cluster, also point the Portal Assistant at them:
 

--- a/versioned_docs/version-v1.2.0-rc.1/ai/sre-agent.mdx
+++ b/versioned_docs/version-v1.2.0-rc.1/ai/sre-agent.mdx
@@ -82,6 +82,8 @@ Enable the SRE Agent and configure the LLM model. The `--reuse-values` flag pres
 
 :::note Supported Models
 The SRE Agent currently supports the [OpenAI](https://platform.openai.com/) GPT model series (e.g., `gpt-5.4`, `gpt-5.2-pro`, `gpt-5` etc.). Support for additional model providers is coming soon.
+
+The `gpt-5.6` series is not supported at the moment. Support is coming soon.
 :::
 
 If the observability plane and control plane are in separate clusters, also set `rca.openchoreoApiUrl` to the control plane API URL (defaults to `http://api.openchoreo.localhost:8080`).


### PR DESCRIPTION
## Purpose
OpenAI rejects function tools for gpt-5.6 models on /v1/chat/completions, which all three agents use, so the whole series fails at request time. Adds a note to the supported-models section on each agent page. Models up to gpt-5.5 are unaffected.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
