### PR TITLE
docs(ecosystem): add metrics module for google cloud monitoring

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -537,6 +537,25 @@
     "released": true
   },
   {
+    "id": "metrics-gcp-cloudmonitoring",
+    "group": "module",
+    "name": "Metrics - Google Cloud Monitoring",
+    "description": "The Observability Metrics Module for Google Cloud Monitoring queries OpenChoreo container CPU and memory metrics from the GKE system metrics in Cloud Monitoring, and exposes them through the OpenChoreo Portal, CLI, and MCP servers, with support for metric-based alerts via Cloud Monitoring alert policies.",
+    "category": "Observability",
+    "tags": [
+      "metrics",
+      "observability",
+      "gcp",
+      "cloudmonitoring",
+      "gke"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/observability-metrics-gcp-cloudmonitoring",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "tracing-xray",
     "group": "module",
     "name": "Tracing - AWS X-Ray",


### PR DESCRIPTION
## Purpose

Add the **Metrics - Google Cloud Monitoring** community module to the ecosystem page. The module queries OpenChoreo container CPU/memory metrics from GKE system metrics in Cloud Monitoring and supports metric-based alerts via Cloud Monitoring alert policies.

Module PR: openchoreo/community-modules#277 — this entry should merge alongside/after it.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)