### PR TITLE
docs: add Events - OpenTelemetry Collector module to ecosystem

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -593,6 +593,26 @@
     "released": true
   },
   {
+    "id": "events-otel-collector",
+    "group": "module",
+    "name": "Events - OpenTelemetry Collector",
+    "description": "The Observability Events Module deploys a specialized OpenTelemetry Collector distribution that gathers Kubernetes events cluster-wide and enriches them with object metadata such as labels, annotations, and owner references before forwarding them to a backend of your choice, including OpenSearch, CloudWatch Logs, and any OTLP-compatible destination.",
+    "category": "Observability",
+    "tags": [
+      "events",
+      "observability",
+      "opentelemetry",
+      "otel",
+      "kubernetes",
+      "otlp"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/observability-events-otel-collector",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "networking-cilium",
     "group": "module",
     "name": "Networking - Cilium",


### PR DESCRIPTION
## Purpose
This pull request adds a new observability plugin to the ecosystem. The new plugin, "Events - OpenTelemetry Collector," enables cluster-wide collection and enrichment of Kubernetes events, forwarding them to various backends.

Module Reference: https://github.com/openchoreo/community-modules/tree/main/observability-events-otel-collector

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
