### PR TITLE
docs: fix wording issues in namespace management guide

### DIFF
--- a/docs/platform-engineer-guide/namespace-management.mdx
+++ b/docs/platform-engineer-guide/namespace-management.mdx
@@ -1,6 +1,6 @@
 ---
 title: Control Plane Namespace Management
-description: Platform engineer guide to create and setup OpenChoreo Control Plane Namespaces
+description: Platform engineer guide to create and set up OpenChoreo Control Plane Namespaces
 ---
 
 import CodeBlock from "@theme/CodeBlock";

--- a/docs/platform-engineer-guide/namespace-management.mdx
+++ b/docs/platform-engineer-guide/namespace-management.mdx
@@ -1,6 +1,6 @@
 ---
-title: Controlplane Namespace Management
-description: Platform engineer guide to create and setup OpenChoreo Controlplane Namespaces
+title: Control Plane Namespace Management
+description: Platform engineer guide to create and setup OpenChoreo Control Plane Namespaces
 ---
 
 import CodeBlock from "@theme/CodeBlock";
@@ -8,11 +8,11 @@ import { versions } from "../_constants.mdx";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# Controlplane Namespace Management
+# Control Plane Namespace Management
 
-You can create multiple namespaces in OpenChoreo controlplane to group resources and keep them isolated in the controlplane cluster.
+You can create multiple namespaces in OpenChoreo Control Plane to group resources and keep them isolated in the Control Plane cluster.
 
-After creating a new namespace in OpenChoreo controlplane, cluster-scoped default resources (ClusterComponentType, ClusterTrait, ClusterWorkflow, ClusterDataPlane, ClusterWorkflowPlane) are automatically visible without any additional setup. You only need to create namespace-scoped Environments, a DeploymentPipeline, and a Project.
+After creating a new namespace in OpenChoreo Control Plane, cluster-scoped default resources (ClusterComponentType, ClusterTrait, ClusterWorkflow, ClusterDataPlane, ClusterWorkflowPlane) are automatically visible without any additional setup. You only need to create namespace-scoped Environments, a DeploymentPipeline, and a Project.
 
 If you need physical isolation, you can create namespace-scoped variants (ComponentType, Trait, DataPlane, etc.) that override the cluster-scoped defaults within that namespace.
 


### PR DESCRIPTION
## Summary
- Fixes a typo where "Controlplane" (one word) was used in the title, description, heading, and body text of the namespace management guide, instead of "Control Plane" as used consistently (300+ times) elsewhere in the docs.

## Test plan
- [x] Verified no other prose instances of "Controlplane" remain in this file
- [x] Confirmed sidebar label pulls from the doc's title/frontmatter, so no other file needed updating