### PR TITLE
docs: update changelog for release 1.0.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ description: Release history for OpenChoreo
 | v1.1.2      | 2026-07-08 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v112) |
 | v1.1.1      | 2026-05-29 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v111) |
 | v1.1.0      | 2026-05-18 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v110)         |
+| v1.0.3      | 2026-07-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v103) |
 | v1.0.2      | 2026-07-08 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v102) |
 | v1.0.1      | 2026-05-07 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v101) |
 | v1.0.0      | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)         |

--- a/docs/releases/release-and-support-process.md
+++ b/docs/releases/release-and-support-process.md
@@ -31,7 +31,7 @@ Community support is provided for the latest three minor release lines. Publish 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
 | v1.1          | 2026-May-18 | v1.1.3       | Actively Supported | TBD                     | TBD         |
-| v1.0          | 2026-Mar-23 | v1.0.2       | Actively Supported | TBD                     | TBD         |
+| v1.0          | 2026-Mar-23 | v1.0.3       | Actively Supported | TBD                     | TBD         |
 
 # Planned Future Minor Releases
 

--- a/versioned_docs/version-v1.0.x/_constants.mdx
+++ b/versioned_docs/version-v1.0.x/_constants.mdx
@@ -1,9 +1,9 @@
 [//] # (This file stores the constants used across the documentation.)
 
 export const versions = {
-  dockerTag: "v1.0.2",
+  dockerTag: "v1.0.3",
   githubRef: "release-v1.0", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
-  helmChart: "1.0.2",
+  helmChart: "1.0.3",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };
 

--- a/versioned_docs/version-v1.0.x/changelog.md
+++ b/versioned_docs/version-v1.0.x/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version          | Date       | Changelog                                                                                           |
 | ---------------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| v1.0.3           | 2026-07-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v103)                  |
 | v1.0.2           | 2026-07-08 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v102)                  |
 | v1.0.1           | 2026-05-07 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v101)                  |
 | v1.0.0           | 2026-03-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v100)                  |


### PR DESCRIPTION
## Purpose
Update changelog for release 1.0.3.

## Approach
- Added `v1.0.3` row to `docs/changelog.md` and `versioned_docs/version-v1.0.x/changelog.md`
- Bumped "Latest patch" for the v1.0 line to `v1.0.3` in `docs/releases/release-and-support-process.md`
- Bumped `dockerTag`/`helmChart` to `1.0.3` in `versioned_docs/version-v1.0.x/_constants.mdx`

Did not touch the `docusaurus.config.ts` announcement bar since it tracks the overall latest release (currently v1.1.x), not this patch line.