### PR TITLE
docs: add KubeCon Japan 2026 blog post

### DIFF
--- a/blog/2026-07-23-openchoreo-at-kubecon-japan-2026.mdx
+++ b/blog/2026-07-23-openchoreo-at-kubecon-japan-2026.mdx
@@ -3,7 +3,7 @@ slug: openchoreo-at-kubecon-japan-2026
 title: OpenChoreo at KubeCon Japan 2026
 authors: [tishan]
 tags: [OpenChoreo, "2026", community, CNCF, KubeCon]
-description: OpenChoreo is heading to KubeCon + CloudNativeCon Japan 2026 — come find us in Tokyo.
+description: OpenChoreo is heading to KubeCon + CloudNativeCon Japan 2026 — come find us in Yokohama.
 category: announcements
 image: ./assets/previews/openchoreo-at-kubecon-japan-2026-preview.png
 ---

--- a/blog/2026-07-23-openchoreo-at-kubecon-japan-2026.mdx
+++ b/blog/2026-07-23-openchoreo-at-kubecon-japan-2026.mdx
@@ -1,0 +1,36 @@
+---
+slug: openchoreo-at-kubecon-japan-2026
+title: OpenChoreo at KubeCon Japan 2026
+authors: [tishan]
+tags: [OpenChoreo, "2026", community, CNCF, KubeCon]
+description: OpenChoreo is heading to KubeCon + CloudNativeCon Japan 2026 — come find us in Tokyo.
+category: announcements
+image: ./assets/previews/openchoreo-at-kubecon-japan-2026-preview.png
+---
+![OpenChoreo at KubeCon Japan 2026](./assets/previews/openchoreo-at-kubecon-japan-2026-preview.png)
+<p></p>
+こんにちは (Konnichiwa)! I wanted to share a quick update on [OpenChoreo](https://openchoreo.dev/?utm_source=mp&utm_medium=link&utm_campaign=blog_link_global_openchoreo_kubeconjapan_072326) at KubeCon + CloudNativeCon Japan 2026, which is just next week. Fresh off our first KubeCon in Amsterdam, we're excited to bring OpenChoreo to the community in Japan as a CNCF Sandbox project. If you're heading to Japan, we'd love to meet you.
+
+Here are some opportunities for you to connect with us in Japan.
+{/* truncate */}
+
+## Find us at the Project Pavilion
+**Wed, July 29, 2026 — 10:45–14:45 · Table T-3**
+
+Come visit us at Table T-3 in the [Project Pavilion](https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/features-add-ons/project-engagement/). Whether you're a platform engineer exploring developer platform options for Kubernetes, an architect thinking about the right level of abstraction for your teams, or just curious about what OpenChoreo does, stop by and say hi (or お立ち寄りください!).
+
+We'll be showing how OpenChoreo brings together development abstractions, a programmable control plane, GitOps, observability, and AI-native capabilities into a single, cohesive platform on Kubernetes.
+
+### What we'll be showing
+This trip we're demoing the latest in OpenChoreo v1.2.0, including our already loved typed **ComponentType** and **Trait** developer abstractions and the self-service **Resource** model that lets developers depend on databases, queues, and caches declaratively.
+
+The headline for v1.2.0 is the new **Project Release Lifecycle**: shared, project-scoped infrastructure — namespaces, NetworkPolicies, ResourceQuotas, and RBAC — is now captured as versioned, immutable snapshots you can promote across environments, bringing the same GitOps discipline you already get for components to the platform layer underneath them.
+
+We'll also be showing off the developer experience improvements landing alongside it — an interactive **shell into running components** and AI-assisted **debugging** from the Backstage portal, a redesigned flow to **browse and compare releases**, and **API Try Out** for OpenAPI and GraphQL endpoints. If you've been following along, we'd love to hear how these map to the problems you're solving on your own platforms.
+
+## Come say hi
+This is our first KubeCon in Japan, and we're looking forward to meeting the community face-to-face. If developer platforms for Kubernetes are a problem space you care about, find me at the conference or come by the booth. We'd love to hear what you're building.
+
+Stay tuned for some exciting news about OpenChoreo during KubeCon week.
+
+Yokohama でお会いしましょう — see you in Yokohama! 🇯🇵

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -22,3 +22,9 @@ lakmal:
   url: https://github.com/lakwarus
   image_url: https://github.com/lakwarus.png
   page: true
+tishan:
+  name: Tishan Dahanayakage
+  title: OpenChoreo Maintainer @ WSO2
+  url: https://github.com/tishan89
+  image_url: https://github.com/tishan89.png
+  page: true


### PR DESCRIPTION
## Summary
- Add blog post announcing OpenChoreo at KubeCon Japan 2026
- Add preview image and author entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)