### PR TITLE
fix: remove unmaintained banner and add noIndex for v1.1.x

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -131,6 +131,8 @@ const config: Config = {
             },
             'v1.1.x': {
               label: 'v1.1.x',
+              banner: 'none',
+              noIndex: true,
             },
             'v1.0.x': {
               label: 'v1.0.x',


### PR DESCRIPTION
v1.1.x stopped being lastVersion once v1.2.x went GA, so Docusaurus started defaulting it to the 'unmaintained' banner even though it is still Actively Supported. Set banner: 'none' to match v1.0.x, and add noIndex: true per the same non-latest-version SEO policy.
