### PR TITLE
docs: add workflow template update steps to upgrade guides

### DIFF
--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -724,6 +724,10 @@ kubectl get secret cluster-gateway-ca -n openchoreo-control-plane \
 
 Build pipelines are defined as ClusterWorkflowTemplates. Each build workflow (docker, react, etc.) is composed from smaller shared templates, so you can swap out individual pieces without touching the rest.
 
+:::tip Upgrading an existing installation?
+Re-apply these templates on every upgrade — they're not part of any Helm chart, so a chart upgrade alone leaves them pinned to the old release's images. See [Update workflow templates](../../platform-engineer-guide/upgrades/overview.mdx#update-workflow-templates) in the upgrade guide.
+:::
+
 Start with the **checkout step**. This controls how source code is cloned. If your repos live behind a corporate proxy or need a custom auth flow, this is the template you would edit.
 
 <CodeBlock language="bash">

--- a/docs/platform-engineer-guide/upgrades/overview.mdx
+++ b/docs/platform-engineer-guide/upgrades/overview.mdx
@@ -12,7 +12,7 @@ This section covers how to upgrade an OpenChoreo installation to a newer version
 
 **Upgrade one minor version at a time.** OpenChoreo supports upgrading only from one minor version to the immediately following minor version. To move across several minors, step through each one in order.
 
-- Patch releases within the same minor (for example `v1.1.0` to `v1.1.2`) are always safe and need no special procedure.
+- Patch releases within the same minor (for example `v1.1.0` to `v1.1.2`) need no special CRD or Helm procedure, but you must still [update the workflow templates](#update-workflow-templates) on every upgrade — their image tags can change between patches too.
 - Minor upgrades (for example `v1.1` to `v1.2`) may introduce breaking changes and have a dedicated guide below.
 - To go from `v1.0` to `v1.2`, first upgrade `v1.0` to `v1.1`, then `v1.1` to `v1.2`. Do not skip the intermediate minor.
 
@@ -32,7 +32,7 @@ Skipping a minor version is not supported and may leave CRDs, controllers, and s
 
 ## Standard upgrade process
 
-Unless the target version's guide says otherwise, every upgrade follows the same shape: for each plane you run, apply the target version's CRDs, then run `helm upgrade`. Upgrade the planes in order — **control plane first**, then data, workflow, and observability.
+Unless the target version's guide says otherwise, every upgrade follows the same shape: for each plane you run, apply the target version's CRDs, then run `helm upgrade`. Upgrade the planes in order — **control plane first**, then data, workflow, and observability. Once the workflow plane is upgraded, also update the build workflow templates — they are applied independently of any chart.
 
 Replace `<version>` below with the target chart version (each per-version guide states it).
 
@@ -70,6 +70,29 @@ Plain `--reuse-values` reuses **all** values from the last release, including th
 :::
 
 On multi-cluster installations, run each plane's upgrade against its own cluster with `--kube-context` (Helm) and `--context` (kubectl), applying that plane's CRDs to the same cluster first.
+
+### Update workflow templates
+
+The build `ClusterWorkflowTemplate`s — `checkout-source`, the build coordinators (`docker`, `react`, `ballerina-buildpack`, `google-cloud-buildpacks`), `publish-image`, and `generate-workload` — are **not** shipped by any Helm chart. They're applied separately from `samples/getting-started/workflow-templates/`, as described in [Install Workflow Templates](../../getting-started/try-it-out/on-your-environment.mdx#install-workflow-templates), so upgrading the workflow plane chart alone leaves them pinned to the previous release's images (for example `ghcr.io/openchoreo/openchoreo-cli` or `ghcr.io/openchoreo/podman-runner`). Re-apply them on **every** upgrade, including patch releases — template content can change without a chart version bump.
+
+Replace `<github-ref>` below with the target release (for example `release-v1.2`, matching the chart version you upgraded to):
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates/checkout-source.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates/publish-image.yaml
+
+curl -fsSL https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates/generate-workload.yaml \
+  | sed "s#https://host.k3d.internal:8080/oauth2/token#https://thunder.${CP_BASE_DOMAIN}/oauth2/token#g" \
+  | sed "s#http://host.k3d.internal:8080#https://api.${CP_BASE_DOMAIN}#g" \
+  | kubectl apply -f -
+```
+
+`CP_BASE_DOMAIN` is the same control-plane base domain you set at install time (see [Install Workflow Templates](../../getting-started/try-it-out/on-your-environment.mdx#install-workflow-templates)).
+
+:::note Customized a template?
+If you replaced a stock template — for example pointed `publish-image` at your own registry (see [Container Registry Configuration](../container-registry-configuration.mdx)) — don't overwrite it with the command above. Instead, diff the new stock template against the previous release's version to find just the image-tag bump, and apply that change to your customized copy.
+:::
 
 ### Verify
 

--- a/docs/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
+++ b/docs/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Upgrading from v1.0 to v1.1
 
-There are no backward-incompatible CRD or API changes in v1.1. Follow the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply each plane's updated CRDs, then `helm upgrade` the control, data, workflow, and observability planes in order — using chart version `1.1.x`.
+There are no backward-incompatible CRD or API changes in v1.1. Follow the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply each plane's updated CRDs, `helm upgrade` the control, data, workflow, and observability planes in order, and update the workflow templates — using chart version `1.1.x`.
 
 The notes below cover the version-specific steps that apply only when upgrading **from v1.0**.
 

--- a/docs/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx
+++ b/docs/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx
@@ -385,7 +385,7 @@ After step 6, roll back with `helm rollback` and re-apply the relaxed `Project` 
 
 ## Upgrading the other planes
 
-The data, workflow, and observability planes have no backward-incompatible changes in v1.2. Upgrade each plane you run with the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply the plane's updated CRDs, then `helm upgrade` with `--version 1.2.0 --reset-then-reuse-values` — after the control plane is on v1.2.
+The data, workflow, and observability planes have no backward-incompatible changes in v1.2. Upgrade each plane you run with the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply the plane's updated CRDs, then `helm upgrade` with `--version 1.2.0 --reset-then-reuse-values` — after the control plane is on v1.2. After the workflow plane is upgraded, also [update the workflow templates](./overview.mdx#update-workflow-templates) — they're applied separately from `samples/getting-started/workflow-templates/` and are not part of the chart.
 
 Make sure the [Gateway API and kgateway](#gateway-api-and-kgateway) prerequisites are done for each plane you upgrade. The observability plane renders a `TLSRoute` and needs the `v1alpha2` re-serve; the data plane does not, and its Gateway API upgrade is conditional on the API gateway module (see that section).
 

--- a/docs/platform-engineer-guide/upgrades/v1.2-to-v1.3.mdx
+++ b/docs/platform-engineer-guide/upgrades/v1.2-to-v1.3.mdx
@@ -11,4 +11,4 @@ sidebar_position: 2
 There are no backward-incompatible changes to call out for this upgrade yet.
 Follow the [standard upgrade process](./overview.mdx): apply each plane's updated
 CRDs, then `helm upgrade` the control, data, workflow, and observability planes
-in order.
+in order, then update the workflow templates.

--- a/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-your-environment.mdx
@@ -724,6 +724,10 @@ kubectl get secret cluster-gateway-ca -n openchoreo-control-plane \
 
 Build pipelines are defined as ClusterWorkflowTemplates. Each build workflow (docker, react, etc.) is composed from smaller shared templates, so you can swap out individual pieces without touching the rest.
 
+:::tip Upgrading an existing installation?
+Re-apply these templates on every upgrade — they're not part of any Helm chart, so a chart upgrade alone leaves them pinned to the old release's images. See [Update workflow templates](../../platform-engineer-guide/upgrades/overview.mdx#update-workflow-templates) in the upgrade guide.
+:::
+
 Start with the **checkout step**. This controls how source code is cloned. If your repos live behind a corporate proxy or need a custom auth flow, this is the template you would edit.
 
 <CodeBlock language="bash">

--- a/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/overview.mdx
+++ b/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/overview.mdx
@@ -12,7 +12,7 @@ This section covers how to upgrade an OpenChoreo installation to a newer version
 
 **Upgrade one minor version at a time.** OpenChoreo supports upgrading only from one minor version to the immediately following minor version. To move across several minors, step through each one in order.
 
-- Patch releases within the same minor (for example `v1.1.0` to `v1.1.2`) are always safe and need no special procedure.
+- Patch releases within the same minor (for example `v1.1.0` to `v1.1.2`) need no special CRD or Helm procedure, but you must still [update the workflow templates](#update-workflow-templates) on every upgrade — their image tags can change between patches too.
 - Minor upgrades (for example `v1.1` to `v1.2`) may introduce breaking changes and have a dedicated guide below.
 - To go from `v1.0` to `v1.2`, first upgrade `v1.0` to `v1.1`, then `v1.1` to `v1.2`. Do not skip the intermediate minor.
 
@@ -32,7 +32,7 @@ Skipping a minor version is not supported and may leave CRDs, controllers, and s
 
 ## Standard upgrade process
 
-Unless the target version's guide says otherwise, every upgrade follows the same shape: for each plane you run, apply the target version's CRDs, then run `helm upgrade`. Upgrade the planes in order — **control plane first**, then data, workflow, and observability.
+Unless the target version's guide says otherwise, every upgrade follows the same shape: for each plane you run, apply the target version's CRDs, then run `helm upgrade`. Upgrade the planes in order — **control plane first**, then data, workflow, and observability. Once the workflow plane is upgraded, also update the build workflow templates — they are applied independently of any chart.
 
 Replace `<version>` below with the target chart version (each per-version guide states it).
 
@@ -70,6 +70,29 @@ Plain `--reuse-values` reuses **all** values from the last release, including th
 :::
 
 On multi-cluster installations, run each plane's upgrade against its own cluster with `--kube-context` (Helm) and `--context` (kubectl), applying that plane's CRDs to the same cluster first.
+
+### Update workflow templates
+
+The build `ClusterWorkflowTemplate`s — `checkout-source`, the build coordinators (`docker`, `react`, `ballerina-buildpack`, `google-cloud-buildpacks`), `publish-image`, and `generate-workload` — are **not** shipped by any Helm chart. They're applied separately from `samples/getting-started/workflow-templates/`, as described in [Install Workflow Templates](../../getting-started/try-it-out/on-your-environment.mdx#install-workflow-templates), so upgrading the workflow plane chart alone leaves them pinned to the previous release's images (for example `ghcr.io/openchoreo/openchoreo-cli` or `ghcr.io/openchoreo/podman-runner`). Re-apply them on **every** upgrade, including patch releases — template content can change without a chart version bump.
+
+Replace `<github-ref>` below with the target release (for example `release-v1.2`, matching the chart version you upgraded to):
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates/checkout-source.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates.yaml
+kubectl apply -f https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates/publish-image.yaml
+
+curl -fsSL https://raw.githubusercontent.com/openchoreo/openchoreo/<github-ref>/samples/getting-started/workflow-templates/generate-workload.yaml \
+  | sed "s#https://host.k3d.internal:8080/oauth2/token#https://thunder.${CP_BASE_DOMAIN}/oauth2/token#g" \
+  | sed "s#http://host.k3d.internal:8080#https://api.${CP_BASE_DOMAIN}#g" \
+  | kubectl apply -f -
+```
+
+`CP_BASE_DOMAIN` is the same control-plane base domain you set at install time (see [Install Workflow Templates](../../getting-started/try-it-out/on-your-environment.mdx#install-workflow-templates)).
+
+:::note Customized a template?
+If you replaced a stock template — for example pointed `publish-image` at your own registry (see [Container Registry Configuration](../container-registry-configuration.mdx)) — don't overwrite it with the command above. Instead, diff the new stock template against the previous release's version to find just the image-tag bump, and apply that change to your customized copy.
+:::
 
 ### Verify
 

--- a/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
+++ b/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Upgrading from v1.0 to v1.1
 
-There are no backward-incompatible CRD or API changes in v1.1. Follow the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply each plane's updated CRDs, then `helm upgrade` the control, data, workflow, and observability planes in order — using chart version `1.1.x`.
+There are no backward-incompatible CRD or API changes in v1.1. Follow the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply each plane's updated CRDs, `helm upgrade` the control, data, workflow, and observability planes in order, and update the workflow templates — using chart version `1.1.x`.
 
 The notes below cover the version-specific steps that apply only when upgrading **from v1.0**.
 

--- a/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx
+++ b/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/v1.1-to-v1.2.mdx
@@ -385,7 +385,7 @@ After step 6, roll back with `helm rollback` and re-apply the relaxed `Project` 
 
 ## Upgrading the other planes
 
-The data, workflow, and observability planes have no backward-incompatible changes in v1.2. Upgrade each plane you run with the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply the plane's updated CRDs, then `helm upgrade` with `--version 1.2.0 --reset-then-reuse-values` — after the control plane is on v1.2.
+The data, workflow, and observability planes have no backward-incompatible changes in v1.2. Upgrade each plane you run with the [standard upgrade process](./overview.mdx#standard-upgrade-process) — apply the plane's updated CRDs, then `helm upgrade` with `--version 1.2.0 --reset-then-reuse-values` — after the control plane is on v1.2. After the workflow plane is upgraded, also [update the workflow templates](./overview.mdx#update-workflow-templates) — they're applied separately from `samples/getting-started/workflow-templates/` and are not part of the chart.
 
 Make sure the [Gateway API and kgateway](#gateway-api-and-kgateway) prerequisites are done for each plane you upgrade. The observability plane renders a `TLSRoute` and needs the `v1alpha2` re-serve; the data plane does not, and its Gateway API upgrade is conditional on the API gateway module (see that section).
 


### PR DESCRIPTION
## Purpose
The current upgrade documentation leaves build `ClusterWorkflowTemplates` untouched, causing a silent version skew where the platform upgrades but build templates remain pinned to older images. 

This PR resolves that by adding explicit manual update instructions (`kubectl apply` commands mirroring the installation guide) to `docs/overview.mdx` and the transition summaries. It also adds an admonition advising operators to use `diff` for custom templates instead of blindly overwriting them. These fixes have been applied to the unreleased docs and backported to `versioned_docs/version-v1.2.x/`.

*(Note to maintainers: I held off on backporting to `v1.1.x` because it uses the older `upgrades.mdx` format, but let me know if you would like me to adapt the fix for that version as well!)*

## Related Issues
Fixes openchoreo/openchoreo#3659

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)