### PR TITLE
docs: add Google Cloud Trace tracing module to marketplace

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -593,6 +593,25 @@
     "released": true
   },
   {
+    "id": "tracing-gcp-cloudtrace",
+    "group": "module",
+    "name": "Tracing - Google Cloud Trace",
+    "description": "The Observability Tracing Module for Google Cloud Trace queries OpenChoreo application traces from Cloud Trace, ingested via the OpenTelemetry Collector on GKE, and exposes them through the OpenChoreo Portal, CLI, and MCP servers, with support for scope-based trace querying.",
+    "category": "Observability",
+    "tags": [
+      "tracing",
+      "observability",
+      "gcp",
+      "cloudtrace",
+      "gke"
+    ],
+    "logoUrl": "",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://github.com/openchoreo/community-modules/tree/main/observability-tracing-gcp-cloudtrace",
+    "default": false,
+    "released": true
+  },
+  {
     "id": "events-otel-collector",
     "group": "module",
     "name": "Events - OpenTelemetry Collector",


### PR DESCRIPTION
## Purpose

Adds the **Tracing - Google Cloud Trace** observability module to the marketplace catalog (\`src/data/marketplace-plugins.json\`).

This lists the new module introduced in [openchoreo/community-modules#326](https://github.com/openchoreo/community-modules/pull/326), completing the GCP observability family alongside the existing Cloud Logging (logs) and metrics adapters.

## Module details

- **Name:** Tracing - Google Cloud Trace
- **Category:** Observability
- **Source:** https://github.com/openchoreo/community-modules/tree/main/observability-tracing-gcp-cloudtrace

The module queries OpenChoreo application traces from Cloud Trace (ingested via the OpenTelemetry Collector on GKE) and exposes them through the OpenChoreo Portal, CLI, and MCP servers, with support for scope-based trace querying.