### PR TITLE
feat: use clean path-based URLs for ecosystem items

### DIFF
--- a/blog/2026-05-19-v1.1-release-blog.mdx
+++ b/blog/2026-05-19-v1.1-release-blog.mdx
@@ -73,7 +73,7 @@ Once installed and configured, the optional Cilium ecosystem module enables seve
 
 3. OpenChoreo controllers will switch to Cilium Network Policies for logical project isolation across environments and namespaces created in data planes configured with Cilium
 
-[Install the Cilium module from the ecosystem →](https://openchoreo.dev/ecosystem/item/?id=networking-cilium) 
+[Install the Cilium module from the ecosystem →](https://openchoreo.dev/ecosystem/item/networking-cilium) 
 
 ### Agentic skills for platform engineers and developers with MCP toolset improvements
 
@@ -157,11 +157,11 @@ Once installed, teams can define budget thresholds for components. When actual c
   fillContainer={true}
 />
 
-This agent is based on the existing [Prometheus metrics module](https://openchoreo.dev/ecosystem/item/?id=metrics-prometheus) and [OpenCost](https://opencost.io/), an open-source project for real-time cloud infrastructure and container cost measurement.
+This agent is based on the existing [Prometheus metrics module](https://openchoreo.dev/ecosystem/item/metrics-prometheus) and [OpenCost](https://opencost.io/), an open-source project for real-time cloud infrastructure and container cost measurement.
 
 This release sets the foundation for agentic FinOps in OpenChoreo, and future releases will bring more ease-of-life improvements, such as component- and project-level cost dashboards and analytics to the developer portal.
 
-[Install the FinOps agent from the ecosystem →](https://openchoreo.dev/ecosystem/item/?id=finops-opencost)
+[Install the FinOps agent from the ecosystem →](https://openchoreo.dev/ecosystem/item/finops-opencost)
 
 
 ### Manage secrets in external secret stores directly via the OpenChoreo UI and CLI
@@ -215,7 +215,7 @@ This module provides reusable component Traits that enable:
 * MCP federation for AI agent communication  
 * Standardized AI gateway integration patterns
 
-[Install the agentgateway module from the ecosystem →](https://openchoreo.dev/ecosystem/item/?id=agentgateway)
+[Install the agentgateway module from the ecosystem →](https://openchoreo.dev/ecosystem/item/agentgateway)
 
  
 
@@ -229,7 +229,7 @@ Supported capabilities include:
 * Kernel-level sandbox isolation using Kata Containers or gVisor (if your hardware supports it)  
 * Pre-warmed sandbox pools for faster agent startup times
 
-[Set up agent sandboxing from the ecosystem →](https://openchoreo.dev/ecosystem/item/?id=agent-sandbox)
+[Set up agent sandboxing from the ecosystem →](https://openchoreo.dev/ecosystem/item/agent-sandbox)
 
 
 

--- a/docs/ai/mcp-servers.mdx
+++ b/docs/ai/mcp-servers.mdx
@@ -305,8 +305,8 @@ Access tokens expire (default: 1 hour). When your token expires, re-run the `cur
 :::tip To get the most out of MCP, pair it with skills
 MCP gives your agent the **capabilities** to talk to OpenChoreo. **Skills** teach it how to use them well, so it gets it right first try instead of you correcting it along the way. You can stay in your agentic environment instead of jumping to the UI or CLI. To get started, install one (or both) of the skills below:
 
-- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
-- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
+- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
+- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
 
 Browse [our ecosystem](https://openchoreo.dev/ecosystem/?group=skill) for all available skills.
 :::

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -64,6 +64,7 @@ const config: Config = {
     './plugins/docusaurus-plugin-markdown-export',
     './plugins/docusaurus-plugin-llms-txt',
     './plugins/docusaurus-plugin-docs-scripts',
+    './plugins/docusaurus-plugin-ecosystem-items',
     [
       '@docusaurus/plugin-client-redirects',
       {

--- a/plugins/docusaurus-plugin-ecosystem-items/index.js
+++ b/plugins/docusaurus-plugin-ecosystem-items/index.js
@@ -18,8 +18,11 @@ module.exports = function pluginEcosystemItems(context) {
       try {
         entries = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
       } catch (e) {
-        console.warn(`[ecosystem-items] could not read ${jsonPath}: ${e.message}`);
-        return;
+        throw new Error(`[ecosystem-items] could not read ${jsonPath}: ${e.message}`);
+      }
+
+      if (!Array.isArray(entries)) {
+        throw new Error(`[ecosystem-items] expected ${jsonPath} to contain an array`);
       }
 
       await Promise.all(

--- a/plugins/docusaurus-plugin-ecosystem-items/index.js
+++ b/plugins/docusaurus-plugin-ecosystem-items/index.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+// Registers one static route per ecosystem/marketplace entry (e.g.
+// /ecosystem/item/skill-openchoreo-platform-engineer/) so items get clean,
+// shareable, crawlable URLs instead of /ecosystem/item/?id=<id>. All routes
+// render the same page component, which reads the id from the URL path
+// (falling back to the legacy ?id= query param for old links).
+module.exports = function pluginEcosystemItems(context) {
+  const { siteDir } = context;
+
+  return {
+    name: 'docusaurus-plugin-ecosystem-items',
+
+    async contentLoaded({ actions }) {
+      const jsonPath = path.join(siteDir, 'src', 'data', 'marketplace-plugins.json');
+      let entries;
+      try {
+        entries = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+      } catch (e) {
+        console.warn(`[ecosystem-items] could not read ${jsonPath}: ${e.message}`);
+        return;
+      }
+
+      await Promise.all(
+        entries.map((entry) =>
+          actions.addRoute({
+            path: `/ecosystem/item/${entry.id}`,
+            component: '@site/src/pages/ecosystem/item.tsx',
+            exact: true,
+          }),
+        ),
+      );
+    },
+  };
+};

--- a/src/components/PluginCard/PluginCard.tsx
+++ b/src/components/PluginCard/PluginCard.tsx
@@ -80,7 +80,7 @@ export const PluginCard: React.FC<PluginCardProps> = ({ plugin }) => {
           <span className={styles.comingSoon}>Coming Soon</span>
         ) : (
           <Link
-            to={`/ecosystem/item/?id=${plugin.id}`}
+            to={`/ecosystem/item/${plugin.id}`}
             aria-label={`View ${plugin.name}`}
             className={styles.viewButton}
           >

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import { useLocation } from '@docusaurus/router';
+import { useHistory, useLocation } from '@docusaurus/router';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -390,12 +390,23 @@ function createMdComponents(rawBaseUrl: string) {
 
 export default function EcosystemItem(): ReactNode {
   const location = useLocation();
+  const history = useHistory();
   const id = useMemo(() => {
     const queryId = new URLSearchParams(location.search).get('id');
     if (queryId) return queryId;
     const pathMatch = location.pathname.match(/\/ecosystem\/item\/([^/]+)\/?$/);
     return pathMatch ? decodeURIComponent(pathMatch[1]) : null;
   }, [location.pathname, location.search]);
+
+  // Legacy /ecosystem/item/?id=<id> links: swap in the clean path-based URL
+  // once mounted, without a full reload, so old links converge on it.
+  useEffect(() => {
+    const queryId = new URLSearchParams(location.search).get('id');
+    if (queryId) {
+      history.replace(`/ecosystem/item/${queryId}`);
+    }
+  }, [location.search, history]);
+
   const plugin = plugins.find((p) => p.id === id);
   const defaultLogo = useBaseUrl('/img/openchoreo-logo.svg');
   const [logoFailed, setLogoFailed] = useState(false);

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -390,10 +390,12 @@ function createMdComponents(rawBaseUrl: string) {
 
 export default function EcosystemItem(): ReactNode {
   const location = useLocation();
-  const id = useMemo(
-    () => new URLSearchParams(location.search).get('id'),
-    [location.search],
-  );
+  const id = useMemo(() => {
+    const queryId = new URLSearchParams(location.search).get('id');
+    if (queryId) return queryId;
+    const pathMatch = location.pathname.match(/\/ecosystem\/item\/([^/]+)\/?$/);
+    return pathMatch ? decodeURIComponent(pathMatch[1]) : null;
+  }, [location.pathname, location.search]);
   const plugin = plugins.find((p) => p.id === id);
   const defaultLogo = useBaseUrl('/img/openchoreo-logo.svg');
   const [logoFailed, setLogoFailed] = useState(false);

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -388,24 +388,36 @@ function createMdComponents(rawBaseUrl: string) {
   };
 }
 
+// Extracts the id segment from a clean /ecosystem/item/<id> pathname. Returns
+// null for the legacy /ecosystem/item/ (bare) route or a malformed segment.
+function matchPathId(pathname: string): string | null {
+  const pathMatch = pathname.match(/\/ecosystem\/item\/([^/]+)\/?$/);
+  if (!pathMatch) return null;
+  try {
+    return decodeURIComponent(pathMatch[1]);
+  } catch {
+    return null;
+  }
+}
+
 export default function EcosystemItem(): ReactNode {
   const location = useLocation();
   const history = useHistory();
   const id = useMemo(() => {
-    const queryId = new URLSearchParams(location.search).get('id');
-    if (queryId) return queryId;
-    const pathMatch = location.pathname.match(/\/ecosystem\/item\/([^/]+)\/?$/);
-    return pathMatch ? decodeURIComponent(pathMatch[1]) : null;
+    const pathId = matchPathId(location.pathname);
+    if (pathId) return pathId;
+    return new URLSearchParams(location.search).get('id');
   }, [location.pathname, location.search]);
 
   // Legacy /ecosystem/item/?id=<id> links: swap in the clean path-based URL
   // once mounted, without a full reload, so old links converge on it.
   useEffect(() => {
+    if (matchPathId(location.pathname)) return;
     const queryId = new URLSearchParams(location.search).get('id');
     if (queryId) {
       history.replace(`/ecosystem/item/${queryId}`);
     }
-  }, [location.search, history]);
+  }, [location.pathname, location.search, history]);
 
   const plugin = plugins.find((p) => p.id === id);
   const defaultLogo = useBaseUrl('/img/openchoreo-logo.svg');

--- a/versioned_docs/version-v1.1.x/ai/mcp-servers.mdx
+++ b/versioned_docs/version-v1.1.x/ai/mcp-servers.mdx
@@ -305,8 +305,8 @@ Access tokens expire (default: 1 hour). When your token expires, re-run the `cur
 :::tip To get the most out of MCP, pair it with skills
 MCP gives your agent the **capabilities** to talk to OpenChoreo. **Skills** teach it how to use them well, so it gets it right first try instead of you correcting it along the way. You can stay in your agentic environment instead of jumping to the UI or CLI. To get started, install one (or both) of the skills below:
 
-- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
-- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
+- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
+- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
 
 Browse [our ecosystem](https://openchoreo.dev/ecosystem/?group=skill) for all available skills.
 :::

--- a/versioned_docs/version-v1.2.x/ai/mcp-servers.mdx
+++ b/versioned_docs/version-v1.2.x/ai/mcp-servers.mdx
@@ -305,8 +305,8 @@ Access tokens expire (default: 1 hour). When your token expires, re-run the `cur
 :::tip To get the most out of MCP, pair it with skills
 MCP gives your agent the **capabilities** to talk to OpenChoreo. **Skills** teach it how to use them well, so it gets it right first try instead of you correcting it along the way. You can stay in your agentic environment instead of jumping to the UI or CLI. To get started, install one (or both) of the skills below:
 
-- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
-- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/?id=skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
+- **[`openchoreo-developer`](https://openchoreo.dev/ecosystem/item/skill-openchoreo-developer)**: daily developer tasks like deploying components, triggering builds, configuring workloads, promoting across environments, and troubleshooting.
+- **[`openchoreo-platform-engineer`](https://openchoreo.dev/ecosystem/item/skill-openchoreo-platform-engineer)**: daily platform engineering tasks like authoring ComponentTypes, Traits, and Workflows, setting up environments and pipelines, registering planes, and configuring identity and authorization.
 
 Browse [our ecosystem](https://openchoreo.dev/ecosystem/?group=skill) for all available skills.
 :::


### PR DESCRIPTION
## Summary
- Register a static route per marketplace entry (`/ecosystem/item/<id>/`) via a new `docusaurus-plugin-ecosystem-items` build-time plugin, instead of relying only on `/ecosystem/item/?id=<id>`, giving each ecosystem item a clean, shareable, crawlable URL.
- Update the ecosystem item page (`src/pages/ecosystem/item.tsx`) to read the id from the URL path, with the legacy `?id=` query param kept as a fallback so old links keep working.
- Update `PluginCard`'s "View" button to link to the new clean URL.
- Add a client-side redirect: visiting an old `?id=` link now swaps the browser URL to the new clean path (via `history.replace`) without a full reload, so old links converge on the new format going forward.
- Update all existing old-format links found in the repo to the new clean URL format.

## Test plan
- [x] `yarn build` completes cleanly (`onBrokenLinks`/`onDuplicateRoutes: 'throw'` both pass) and generates one static HTML file per ecosystem item with correct server-rendered title/content
- [x] `yarn typecheck` passes
- [x] `yarn format:check` passes