### PR TITLE
docs: align Kubernetes version requirements across doc versions

### DIFF
--- a/docs/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/docs/getting-started/try-it-out/on-k3d-locally.mdx
@@ -28,7 +28,7 @@ By the end you'll have a working installation on localhost: a web app you can op
 | -------------------------------------------------- | ---------------------- | ------------------------- |
 | [Docker](https://docs.docker.com/get-docker/)      | v26+ (8 GB RAM, 4 CPU) | Container runtime         |
 | [k3d](https://k3d.io/stable/#installation)         | v5.8+                  | Local Kubernetes clusters |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.33+                 | Kubernetes CLI            |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.34+                 | Kubernetes CLI            |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+                 | Package manager           |
 
 Verify everything is installed:

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -32,7 +32,7 @@ By the end you'll have OpenChoreo running on your cluster over HTTPS, reachable 
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.34+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.34+, LoadBalancer support, and a default StorageClass.
+Minimum supported Kubernetes version: 1.34+. The cluster also needs LoadBalancer support and a default StorageClass.
 
 Verify everything is installed:
 

--- a/docs/getting-started/try-it-out/on-your-environment.mdx
+++ b/docs/getting-started/try-it-out/on-your-environment.mdx
@@ -29,22 +29,10 @@ By the end you'll have OpenChoreo running on your cluster over HTTPS, reachable 
 
 | Tool                                               | Version | Purpose         |
 | -------------------------------------------------- | ------- | --------------- |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.33+  | Kubernetes CLI  |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.34+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.33+, LoadBalancer support, and a default StorageClass.
-
-:::warning User namespaces required
-OpenChoreo's default build workflows run Argo Workflow pods that opt in to Kubernetes [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. Use **Kubernetes 1.33 or newer**; Kubernetes 1.33 enables user namespaces by default when the node stack supports them.
-
-Every Linux node that can run Workflow Plane build pods must also provide:
-
-- **Linux kernel 6.3 or newer**
-- **containerd 2.0 or newer** or **CRI-O 1.25 or newer**
-- **runc 1.2 or newer** or **crun 1.9 or newer**
-
-See the [Kubernetes user namespaces guide](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) for details.
-:::
+Recommended cluster baseline: Kubernetes 1.34+, LoadBalancer support, and a default StorageClass.
 
 Verify everything is installed:
 

--- a/docs/platform-engineer-guide/deployment-topology.mdx
+++ b/docs/platform-engineer-guide/deployment-topology.mdx
@@ -16,7 +16,7 @@ Before deploying OpenChoreo to production, ensure your environment meets the fol
 
 | Requirement        | Specification                                                |
 | ------------------ | ------------------------------------------------------------ |
-| Kubernetes Version | 1.32 or later                                                |
+| Kubernetes Version | 1.34 or later                                                |
 | Node Count         | Minimum 3 nodes (for high availability)                      |
 | Node Resources     | 4 CPU cores, 8 GB RAM per node (minimum)                     |
 | RBAC               | Enabled                                                      |
@@ -33,7 +33,7 @@ Install the following tools on your workstation:
 
 | Tool                                                       | Version | Notes                                                         |
 | ---------------------------------------------------------- | ------- | ------------------------------------------------------------- |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/)         | 1.32+   | Kubernetes CLI                                                |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/)         | 1.34+   | Kubernetes CLI                                                |
 | [Helm](https://helm.sh/docs/intro/install/)                | 3.12+   | Package manager                                               |
 | [cert-manager](https://cert-manager.io/docs/installation/) | 1.12+   | Required on all clusters where OpenChoreo planes are deployed |
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -33,8 +33,8 @@ OpenChoreo focuses on:
 
 ### What are the prerequisites for OpenChoreo?
 
-- **Kubernetes Cluster**: Version 1.32 or later
-- **kubectl**: v1.32+ configured to access your cluster
+- **Kubernetes Cluster**: Version 1.34 or later
+- **kubectl**: v1.34+ configured to access your cluster
 - **Helm**: Version 3.x (for installation)
 - **Container Registry**: For storing application images (required for CI workflows)
 

--- a/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-k3d-locally.mdx
@@ -39,6 +39,10 @@ By the end you will have all four running in a single k3d cluster.
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+                 | Kubernetes CLI            |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+                 | Package manager           |
 
+:::note Kubernetes version in this setup
+The local k3d cluster created by the quick start runs Kubernetes 1.32. The default build workflows set `hostUsers: false`, but [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) only take effect on Kubernetes 1.33 or later, so the setting is ignored here. This setup is intended for local development.
+:::
+
 Verify everything is installed:
 
 ```bash

--- a/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-your-environment.mdx
@@ -37,7 +37,7 @@ OpenChoreo has four planes:
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.32+ (1.33+ for the default build workflows), LoadBalancer support, and a default StorageClass.
+Minimum supported Kubernetes version: 1.32+, or 1.33+ for the default build workflows. The cluster also needs LoadBalancer support and a default StorageClass.
 
 :::note Kubernetes version for the default build workflows
 The default build workflows rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. This takes effect only on Kubernetes 1.33 or later, so use 1.33 or later if you plan to run them. On earlier versions the setting is ignored.

--- a/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.0.x/getting-started/try-it-out/on-your-environment.mdx
@@ -37,7 +37,11 @@ OpenChoreo has four planes:
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.32+, LoadBalancer support, and a default StorageClass.
+Recommended cluster baseline: Kubernetes 1.32+ (1.33+ for the default build workflows), LoadBalancer support, and a default StorageClass.
+
+:::note Kubernetes version for the default build workflows
+The default build workflows rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. This takes effect only on Kubernetes 1.33 or later, so use 1.33 or later if you plan to run them. On earlier versions the setting is ignored.
+:::
 
 Verify everything is installed:
 

--- a/versioned_docs/version-v1.0.x/platform-engineer-guide/deployment-topology.mdx
+++ b/versioned_docs/version-v1.0.x/platform-engineer-guide/deployment-topology.mdx
@@ -16,7 +16,7 @@ Before deploying OpenChoreo to production, ensure your environment meets the fol
 
 | Requirement        | Specification                                                |
 | ------------------ | ------------------------------------------------------------ |
-| Kubernetes Version | 1.32 or later                                                |
+| Kubernetes Version | 1.32 or later (1.33 or later for the default build workflows) |
 | Node Count         | Minimum 3 nodes (for high availability)                      |
 | Node Resources     | 4 CPU cores, 8 GB RAM per node (minimum)                     |
 | RBAC               | Enabled                                                      |
@@ -25,6 +25,10 @@ Before deploying OpenChoreo to production, ensure your environment meets the fol
 
 :::note
 For development or testing, a single-node cluster with 8 GB RAM and 4 CPU cores is sufficient. Production deployments should use a multi-node cluster with appropriate resource allocation.
+:::
+
+:::note Kubernetes version for the default build workflows
+The default build workflows rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. This takes effect only on Kubernetes 1.33 or later, so use 1.33 or later if you plan to run them. On earlier versions the setting is ignored.
 :::
 
 ### Required Tools

--- a/versioned_docs/version-v1.0.x/reference/faq.md
+++ b/versioned_docs/version-v1.0.x/reference/faq.md
@@ -33,7 +33,7 @@ OpenChoreo focuses on:
 
 ### What are the prerequisites for OpenChoreo?
 
-- **Kubernetes Cluster**: Version 1.32 or later
+- **Kubernetes Cluster**: Version 1.32 or later. Use 1.33 or later if you plan to run the default build workflows, as these rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) that are ignored on earlier versions.
 - **kubectl**: v1.32+ configured to access your cluster
 - **Helm**: Version 3.x (for installation)
 - **Container Registry**: For storing application images (required for CI workflows)

--- a/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-k3d-locally.mdx
@@ -39,6 +39,10 @@ By the end you will have all four running in a single k3d cluster.
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+                 | Kubernetes CLI            |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+                 | Package manager           |
 
+:::note Kubernetes version in this setup
+The local k3d cluster created by the quick start runs Kubernetes 1.32. The default build workflows set `hostUsers: false`, but [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) only take effect on Kubernetes 1.33 or later, so the setting is ignored here. This setup is intended for local development.
+:::
+
 Verify everything is installed:
 
 ```bash

--- a/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-your-environment.mdx
@@ -37,7 +37,7 @@ OpenChoreo has four planes:
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.32+ (1.33+ for the default build workflows), LoadBalancer support, and a default StorageClass.
+Minimum supported Kubernetes version: 1.32+, or 1.33+ for the default build workflows. The cluster also needs LoadBalancer support and a default StorageClass.
 
 :::note Kubernetes version for the default build workflows
 The default build workflows rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. This takes effect only on Kubernetes 1.33 or later, so use 1.33 or later if you plan to run them. On earlier versions the setting is ignored.

--- a/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-your-environment.mdx
@@ -37,7 +37,11 @@ OpenChoreo has four planes:
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.32+, LoadBalancer support, and a default StorageClass.
+Recommended cluster baseline: Kubernetes 1.32+ (1.33+ for the default build workflows), LoadBalancer support, and a default StorageClass.
+
+:::note Kubernetes version for the default build workflows
+The default build workflows rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. This takes effect only on Kubernetes 1.33 or later, so use 1.33 or later if you plan to run them. On earlier versions the setting is ignored.
+:::
 
 Verify everything is installed:
 

--- a/versioned_docs/version-v1.1.x/platform-engineer-guide/deployment-topology.mdx
+++ b/versioned_docs/version-v1.1.x/platform-engineer-guide/deployment-topology.mdx
@@ -16,7 +16,7 @@ Before deploying OpenChoreo to production, ensure your environment meets the fol
 
 | Requirement        | Specification                                                |
 | ------------------ | ------------------------------------------------------------ |
-| Kubernetes Version | 1.32 or later                                                |
+| Kubernetes Version | 1.32 or later (1.33 or later for the default build workflows) |
 | Node Count         | Minimum 3 nodes (for high availability)                      |
 | Node Resources     | 4 CPU cores, 8 GB RAM per node (minimum)                     |
 | RBAC               | Enabled                                                      |
@@ -25,6 +25,10 @@ Before deploying OpenChoreo to production, ensure your environment meets the fol
 
 :::note
 For development or testing, a single-node cluster with 8 GB RAM and 4 CPU cores is sufficient. Production deployments should use a multi-node cluster with appropriate resource allocation.
+:::
+
+:::note Kubernetes version for the default build workflows
+The default build workflows rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. This takes effect only on Kubernetes 1.33 or later, so use 1.33 or later if you plan to run them. On earlier versions the setting is ignored.
 :::
 
 ### Required Tools

--- a/versioned_docs/version-v1.1.x/reference/faq.md
+++ b/versioned_docs/version-v1.1.x/reference/faq.md
@@ -33,7 +33,7 @@ OpenChoreo focuses on:
 
 ### What are the prerequisites for OpenChoreo?
 
-- **Kubernetes Cluster**: Version 1.32 or later
+- **Kubernetes Cluster**: Version 1.32 or later. Use 1.33 or later if you plan to run the default build workflows, as these rely on [Kubernetes user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) that are ignored on earlier versions.
 - **kubectl**: v1.32+ configured to access your cluster
 - **Helm**: Version 3.x (for installation)
 - **Container Registry**: For storing application images (required for CI workflows)

--- a/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-k3d-locally.mdx
@@ -28,7 +28,7 @@ By the end you'll have a working installation on localhost: a web app you can op
 | -------------------------------------------------- | ---------------------- | ------------------------- |
 | [Docker](https://docs.docker.com/get-docker/)      | v26+ (8 GB RAM, 4 CPU) | Container runtime         |
 | [k3d](https://k3d.io/stable/#installation)         | v5.8+                  | Local Kubernetes clusters |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.33+                 | Kubernetes CLI            |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.34+                 | Kubernetes CLI            |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+                 | Package manager           |
 
 Verify everything is installed:

--- a/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-your-environment.mdx
@@ -32,7 +32,7 @@ By the end you'll have OpenChoreo running on your cluster over HTTPS, reachable 
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.34+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.34+, LoadBalancer support, and a default StorageClass.
+Minimum supported Kubernetes version: 1.34+. The cluster also needs LoadBalancer support and a default StorageClass.
 
 Verify everything is installed:
 

--- a/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-your-environment.mdx
+++ b/versioned_docs/version-v1.2.x/getting-started/try-it-out/on-your-environment.mdx
@@ -29,22 +29,10 @@ By the end you'll have OpenChoreo running on your cluster over HTTPS, reachable 
 
 | Tool                                               | Version | Purpose         |
 | -------------------------------------------------- | ------- | --------------- |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.33+  | Kubernetes CLI  |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.34+  | Kubernetes CLI  |
 | [Helm](https://helm.sh/docs/intro/install/)        | v3.12+  | Package manager |
 
-Recommended cluster baseline: Kubernetes 1.33+, LoadBalancer support, and a default StorageClass.
-
-:::warning User namespaces required
-OpenChoreo's default build workflows run Argo Workflow pods that opt in to Kubernetes [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) by setting `hostUsers: false`. Use **Kubernetes 1.33 or newer**; Kubernetes 1.33 enables user namespaces by default when the node stack supports them.
-
-Every Linux node that can run Workflow Plane build pods must also provide:
-
-- **Linux kernel 6.3 or newer**
-- **containerd 2.0 or newer** or **CRI-O 1.25 or newer**
-- **runc 1.2 or newer** or **crun 1.9 or newer**
-
-See the [Kubernetes user namespaces guide](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/) for details.
-:::
+Recommended cluster baseline: Kubernetes 1.34+, LoadBalancer support, and a default StorageClass.
 
 Verify everything is installed:
 

--- a/versioned_docs/version-v1.2.x/platform-engineer-guide/deployment-topology.mdx
+++ b/versioned_docs/version-v1.2.x/platform-engineer-guide/deployment-topology.mdx
@@ -16,7 +16,7 @@ Before deploying OpenChoreo to production, ensure your environment meets the fol
 
 | Requirement        | Specification                                                |
 | ------------------ | ------------------------------------------------------------ |
-| Kubernetes Version | 1.32 or later                                                |
+| Kubernetes Version | 1.34 or later                                                |
 | Node Count         | Minimum 3 nodes (for high availability)                      |
 | Node Resources     | 4 CPU cores, 8 GB RAM per node (minimum)                     |
 | RBAC               | Enabled                                                      |
@@ -33,7 +33,7 @@ Install the following tools on your workstation:
 
 | Tool                                                       | Version | Notes                                                         |
 | ---------------------------------------------------------- | ------- | ------------------------------------------------------------- |
-| [kubectl](https://kubernetes.io/docs/tasks/tools/)         | 1.32+   | Kubernetes CLI                                                |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/)         | 1.34+   | Kubernetes CLI                                                |
 | [Helm](https://helm.sh/docs/intro/install/)                | 3.12+   | Package manager                                               |
 | [cert-manager](https://cert-manager.io/docs/installation/) | 1.12+   | Required on all clusters where OpenChoreo planes are deployed |
 

--- a/versioned_docs/version-v1.2.x/reference/faq.md
+++ b/versioned_docs/version-v1.2.x/reference/faq.md
@@ -33,8 +33,8 @@ OpenChoreo focuses on:
 
 ### What are the prerequisites for OpenChoreo?
 
-- **Kubernetes Cluster**: Version 1.32 or later
-- **kubectl**: v1.32+ configured to access your cluster
+- **Kubernetes Cluster**: Version 1.34 or later
+- **kubectl**: v1.34+ configured to access your cluster
 - **Helm**: Version 3.x (for installation)
 - **Container Registry**: For storing application images (required for CI workflows)
 


### PR DESCRIPTION
## Purpose

The platform engineer guide and FAQ stated Kubernetes 1.32 or later in every doc version, while the v1.2.x getting started page stated 1.33 or later. The kubectl version was also inconsistent across these pages, and the getting started pages described the cluster version as a recommended baseline rather than a requirement.

Kubernetes 1.32 and 1.33 have both reached end of life, so current and v1.2.x now state 1.34 or later.

**Changes**

- Current and v1.2.x state Kubernetes 1.34 or later, and kubectl v1.34+, across the deployment topology, FAQ, and getting started pages
- v1.0.x and v1.1.x keep their 1.32 baseline, with a note that the default build workflows need 1.33 or later, since those quick starts create a 1.32 cluster
- Getting started pages now say "Minimum supported Kubernetes version" instead of "Recommended cluster baseline", so all pages state the same requirement
- Removed the kernel, containerd, and runc version requirements. These are implied by the Kubernetes version and are not the only node level dependencies, so listing them is incomplete and hard to keep current.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
