### PR TITLE
fix(ecosystem): stop labelling the placeholder logo as the item's logo

### DIFF
--- a/src/components/PluginCard/PluginCard.tsx
+++ b/src/components/PluginCard/PluginCard.tsx
@@ -44,7 +44,8 @@ export const PluginCard: React.FC<PluginCardProps> = ({ plugin }) => {
   const groupClass = GROUP_CLASSES[plugin.group] ?? styles.groupModule;
   const defaultLogo = useBaseUrl("/img/openchoreo-logo.svg");
   const [logoFailed, setLogoFailed] = useState(false);
-  const logoSrc = plugin.logoUrl && !logoFailed ? plugin.logoUrl : defaultLogo;
+  const usingPlaceholderLogo = !plugin.logoUrl || logoFailed;
+  const logoSrc = usingPlaceholderLogo ? defaultLogo : plugin.logoUrl;
 
   return (
     <article className={styles.card}>
@@ -52,7 +53,8 @@ export const PluginCard: React.FC<PluginCardProps> = ({ plugin }) => {
         <div className={styles.logoWrap}>
           <img
             src={logoSrc}
-            alt={`${plugin.name} logo`}
+            alt={usingPlaceholderLogo ? "" : `${plugin.name} logo`}
+            aria-hidden={usingPlaceholderLogo || undefined}
             className={styles.logo}
             onError={() => setLogoFailed(true)}
           />

--- a/src/pages/ecosystem/item.tsx
+++ b/src/pages/ecosystem/item.tsx
@@ -522,7 +522,8 @@ export default function EcosystemItem(): ReactNode {
     return () => resizeObserver.disconnect();
   }, [parsed.sections.length, updateTabAffordances]);
 
-  const logoSrc = plugin?.logoUrl && !logoFailed ? plugin.logoUrl : defaultLogo;
+  const usingPlaceholderLogo = !plugin?.logoUrl || logoFailed;
+  const logoSrc = usingPlaceholderLogo ? defaultLogo : plugin.logoUrl;
   const groupLabel = plugin ? (GROUP_LABELS[plugin.group] ?? plugin.group) : '';
   const groupBadgeClass = plugin
     ? (GROUP_BADGE_CLASSES[plugin.group] ?? styles.groupModule)
@@ -616,7 +617,8 @@ export default function EcosystemItem(): ReactNode {
                 <div className={styles.logoWrap}>
                   <img
                     src={logoSrc}
-                    alt={`${plugin.name} logo`}
+                    alt={usingPlaceholderLogo ? '' : `${plugin.name} logo`}
+                    aria-hidden={usingPlaceholderLogo || undefined}
                     className={styles.logo}
                     onError={() => setLogoFailed(true)}
                   />


### PR DESCRIPTION
## Purpose
Stop labelling the placeholder logo as the item's logo
